### PR TITLE
feat(core): add get_cronjob tool; remove prompt from list_cronjobs

### DIFF
--- a/packages/core/src/cronjob-tools.ts
+++ b/packages/core/src/cronjob-tools.ts
@@ -325,7 +325,8 @@ export function listCronjobsTool(options: CronjobToolsOptions): AgentTool {
     description:
       'List all configured cronjobs with their schedules, status, and upcoming run times. ' +
       'Use this to answer questions like "which cronjobs are active?", "what runs tomorrow morning?", ' +
-      'or "show me all scheduled tasks". Optionally compute the next N run times for each cronjob.',
+      'or "show me all scheduled tasks". Optionally compute the next N run times for each cronjob. ' +
+      'To read the full prompt of a specific cronjob, use get_cronjob with its ID.',
     parameters: Type.Object({
       enabled_only: Type.Optional(
         Type.Boolean({
@@ -414,6 +415,64 @@ export function listCronjobsTool(options: CronjobToolsOptions): AgentTool {
 /**
  * Create the `create_reminder` agent tool — a convenient shortcut for injection-type cronjobs
  */
+export function getCronjobTool(options: CronjobToolsOptions): AgentTool {
+  return {
+    name: 'get_cronjob',
+    label: 'Get Cronjob',
+    description:
+      'Get the full configuration of a single cronjob by ID, including its complete prompt. ' +
+      'Use this when you need to read or verify the prompt of an existing cronjob.',
+    parameters: Type.Object({
+      id: Type.String({
+        description: 'The ID of the cronjob to retrieve.',
+      }),
+    }),
+    execute: async (_toolCallId, params) => {
+      const { id } = params as { id: string }
+
+      try {
+        const cj = options.scheduledTaskStore.getById(id)
+        if (!cj) {
+          return {
+            content: [{ type: 'text' as const, text: `No cronjob found with ID: ${id}` }],
+            details: { error: true },
+          }
+        }
+
+        const humanSchedule = cronToHumanReadable(cj.schedule)
+        const status = cj.enabled ? 'ENABLED' : 'DISABLED'
+        const actionLabel = cj.actionType === 'injection' ? 'injection' : 'task'
+        const lastRun = cj.lastRunAt
+          ? `${cj.lastRunStatus ?? 'unknown'} at ${cj.lastRunAt}`
+          : 'never'
+
+        const text = [
+          `[${status}] ${cj.name}`,
+          `ID: ${cj.id}`,
+          `Schedule: ${humanSchedule} (${cj.schedule})`,
+          `Action: ${actionLabel}`,
+          `Provider: ${cj.provider ?? 'default'}`,
+          `Last run: ${lastRun}`,
+          ``,
+          `Prompt:`,
+          cj.prompt,
+        ].join('\n')
+
+        return {
+          content: [{ type: 'text' as const, text }],
+          details: { cronjob: cj },
+        }
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: `Error retrieving cronjob: ${errorMsg}` }],
+          details: { error: true },
+        }
+      }
+    },
+  }
+}
+
 export function createReminderTool(options: CronjobToolsOptions): AgentTool {
   return {
     name: 'create_reminder',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -199,7 +199,7 @@ export { ScheduledTaskStore, initScheduledTasksTable } from './scheduled-task-st
 export type { ScheduledTask, ScheduledTaskActionType, CreateScheduledTaskInput, UpdateScheduledTaskInput } from './scheduled-task-store.js'
 export { TaskScheduler } from './task-scheduler.js'
 export type { TaskSchedulerOptions } from './task-scheduler.js'
-export { createCronjobTool, editCronjobTool, removeCronjobTool, listCronjobsTool, createReminderTool } from './cronjob-tools.js'
+export { createCronjobTool, editCronjobTool, removeCronjobTool, listCronjobsTool, getCronjobTool, createReminderTool } from './cronjob-tools.js'
 export type { CronjobToolsOptions } from './cronjob-tools.js'
 export {
   formatTaskTelegramMessage,

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -670,6 +670,7 @@ ${dailyContext}
       '- **edit_cronjob**: Edit an existing cronjob.',
       '- **remove_cronjob**: Remove a cronjob.',
       '- **list_cronjobs**: List all cronjobs.',
+      '- **get_cronjob**: Get the full configuration (including complete prompt) of a single cronjob by ID.',
       '- **create_reminder**: Create a one-time reminder delivered at a specific time.',
     )
 

--- a/packages/web-backend/src/server.ts
+++ b/packages/web-backend/src/server.ts
@@ -24,6 +24,7 @@ import {
   editCronjobTool,
   removeCronjobTool,
   listCronjobsTool,
+  getCronjobTool,
   createReminderTool,
   listTasksTool,
   loadProvidersDecrypted,
@@ -418,6 +419,7 @@ const agentTools = [
   editCronjobTool(cronjobToolsOptions),
   removeCronjobTool(cronjobToolsOptions),
   listCronjobsTool(cronjobToolsOptions),
+  getCronjobTool(cronjobToolsOptions),
   createReminderTool(cronjobToolsOptions),
   createReadChatHistoryTool({ db }),
 ]


### PR DESCRIPTION
## Problem

`list_cronjobs` returned the full prompt inline for every cronjob. With long prompts (e.g. a Twitter digest with 50+ lines) this bloats every overview call with hundreds of unnecessary tokens — even when the agent just wants to know what's scheduled.

## Solution

Remove the prompt from `list_cronjobs` output entirely and add a dedicated `get_cronjob` tool that returns the full config (including complete prompt) for a single cronjob by ID. Two-call pattern: list to find the ID, get to read the prompt when actually needed.

## Changes

- `list_cronjobs`: removes Prompt line; adds hint to use `get_cronjob`
- `get_cronjob`: new tool — returns name, schedule, action type, provider, last run status, and full prompt
- Registers `getCronjobTool` in `server.ts`
- Exports `getCronjobTool` from `core/index.ts`
- Adds `get_cronjob` to `available_tools` list in `assembleSystemPrompt()`