### PR TITLE
fix(core): improve session summary prompt for accurate daily activity log

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -804,16 +804,15 @@ export class AgentCore {
 
     try {
       const response = await completeSimple(this.model, {
-        systemPrompt: `Summarize this conversation for the agent's daily memory log.
+        systemPrompt: `You are writing a chronological activity log entry for this session. Your output will be stored in a daily file so the agent can recall what happened in past sessions (e.g. "yesterday at 14:30 we discussed X and you asked me to do Y").
 
 Rules:
-- Write 1–3 short bullet points (not paragraphs). Max 150 words total.
-- Focus on: decisions made, action items, key facts learned, and open questions.
-- Omit greetings, small talk, and anything the agent already knows from its core memory.
-- Use neutral, factual tone. No filler words.
-- If the transcript contains background-task updates or task results, treat them as part of the session and summarize their actual outcome.
-- If nothing noteworthy happened, write "No significant content."
-- Do NOT repeat the full conversation — extract only what matters for future sessions.`,
+- Write 2–5 sentences or bullet points. Max 200 words total.
+- Always describe what actually happened: topics discussed, questions answered, decisions made, tasks started or completed, PRs or files created, and anything left open.
+- If a background task completed or a task result was injected, mention its outcome (e.g. "PR #15 created for X", "wiki page updated").
+- Use neutral, factual tone. No filler words. No meta-commentary about the summary itself.
+- Do NOT filter for "memory-worthiness" — this is an activity log, not a memory promotion filter. Even a single answered question is worth one sentence.
+- Write "Empty session." ONLY if the transcript contains nothing but greetings or a bare connection with zero substantive content.`,
         messages: [{
           role: 'user' as const,
           content: conversationHistory,
@@ -830,7 +829,7 @@ Rules:
         .join('')
         .trim()
 
-      return summary || 'No significant content.'
+      return summary || 'Empty session.'
     } catch (err) {
       console.error('Failed to generate session summary:', err)
       return 'Session ended (summary generation failed).'


### PR DESCRIPTION
## Problem

The `generateSessionSummary()` prompt was misaligned with its purpose. It was framed as a **memory promotion filter** — instructing the LLM to omit greetings, small talk, and "anything the agent already knows", and to write `No significant content.` if nothing noteworthy happened. This caused sessions with real work (answered questions, created PRs, completed background tasks) to produce empty or near-empty entries.

The root cause: the prompt conflated two separate concerns:
1. **Memory promotion** — what should be persisted long-term into `MEMORY.md` (handled by the Nightly Consolidation Agent)
2. **Activity logging** — what happened in this session so the agent can recall it in future sessions

## Change

Replaced the summary prompt in `generateSessionSummary()` (`packages/core/src/agent.ts`) to reframe it as a **chronological activity log** writer:

- Clearly states the purpose: entries will be read back as `"yesterday at 14:30 we discussed X"`
- Always describes what happened — topics, decisions, completed tasks, open items, background task outcomes
- Explicitly removes the memory-worthiness filter: *"Even a single answered question is worth one sentence"*
- `Empty session.` is reserved only for bare greetings with zero substantive content
- Bumped word limit from 150 → 200 to accommodate fuller activity descriptions
- Aligned the fallback return value (`summary || ...`) from `'No significant content.'` to `'Empty session.'` for consistency with the early-return case when `conversationHistory` is absent

No other files changed.