### PR TITLE
feat(core): add open threads section to session-end daily log

### DIFF
--- a/packages/core/src/agent-session-summary.test.ts
+++ b/packages/core/src/agent-session-summary.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for generateSessionSummary (session-end daily log with open threads).
+ *
+ * We test the behavior through the SessionManager + AgentCore integration:
+ * the summary returned from generateSessionSummary is written verbatim to the
+ * daily file, so we verify both the LLM prompt content and the output format.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+// ── Mocks must be hoisted before any imports that load the mocked modules ─────
+
+vi.mock('./memory.js', () => ({
+  ensureMemoryStructure: vi.fn(),
+  ensureConfigStructure: vi.fn(),
+  assembleSystemPrompt: vi.fn(() => 'test system prompt'),
+  appendToDailyFile: vi.fn(),
+  getMemoryDir: vi.fn(() => '/tmp/test-memory'),
+}))
+
+vi.mock('./config.js', () => ({
+  ensureConfigTemplates: vi.fn(),
+  loadConfig: vi.fn(() => ({})),
+  getConfigDir: vi.fn(() => '/tmp/test-config'),
+}))
+
+vi.mock('./provider-config.js', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>
+  return {
+    ...original,
+    getApiKeyForProvider: vi.fn().mockResolvedValue('test-key'),
+    buildModel: vi.fn().mockReturnValue({ id: 'mock-model' }),
+    loadProvidersDecrypted: vi.fn().mockReturnValue({ providers: [] }),
+    estimateCost: vi.fn().mockReturnValue(0),
+  }
+})
+
+vi.mock('./skill-config.js', () => ({
+  loadSkills: vi.fn().mockReturnValue({ skills: [] }),
+  getSkillDecrypted: vi.fn(),
+}))
+
+vi.mock('./web-tools.js', () => ({
+  createBuiltinWebTools: vi.fn(() => []),
+}))
+
+vi.mock('./stt-tool.js', () => ({
+  createTranscribeAudioTool: vi.fn(() => ({})),
+}))
+
+vi.mock('./stt.js', () => ({
+  loadSttSettings: vi.fn().mockReturnValue({ enabled: false }),
+}))
+
+vi.mock('./agent-skills.js', () => ({
+  createAgentSkillTools: vi.fn(() => []),
+  getAgentSkillsForPrompt: vi.fn(() => []),
+  getAgentSkillsCount: vi.fn(() => 0),
+  getAgentSkillsDir: vi.fn(() => '/tmp/test-agent-skills'),
+  trackAgentSkillUsage: vi.fn(),
+}))
+
+vi.mock('./workspace.js', () => ({
+  getWorkspaceDir: vi.fn(() => '/tmp/test-workspace'),
+}))
+
+vi.mock('./token-logger.js', () => ({
+  logTokenUsage: vi.fn(),
+  logToolCall: vi.fn(),
+}))
+
+// Mock pi-ai completeSimple so we can control LLM responses
+vi.mock('@mariozechner/pi-ai', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>
+  return {
+    ...original,
+    completeSimple: vi.fn(),
+    Type: (original as { Type: unknown }).Type,
+  }
+})
+
+// ── Imports after mocks ────────────────────────────────────────────────────────
+
+import { AgentCore } from './agent.js'
+import { initDatabase } from './database.js'
+import type { Database } from './database.js'
+import { completeSimple } from '@mariozechner/pi-ai'
+import { appendToDailyFile } from './memory.js'
+
+const mockCompleteSimple = vi.mocked(completeSimple)
+const mockAppendToDailyFile = vi.mocked(appendToDailyFile)
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeModel() {
+  return {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    api: 'openai-completions' as const,
+    provider: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    reasoning: false,
+    input: ['text' as const, 'image' as const],
+    cost: { input: 2.5, output: 10, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 16384,
+  }
+}
+
+function makeCompleteSimpleResponse(text: string) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+    model: 'gpt-4o',
+    provider: 'openai',
+    stopReason: 'end_turn' as const,
+  }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('generateSessionSummary — open threads prompt', () => {
+  let db: Database
+  let tmpDir: string
+  let memoryDir: string
+
+  beforeEach(() => {
+    tmpDir = path.join(os.tmpdir(), `openagent-summary-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    memoryDir = path.join(tmpDir, 'memory')
+    fs.mkdirSync(path.join(memoryDir, 'daily'), { recursive: true })
+
+    db = initDatabase(':memory:')
+    mockCompleteSimple.mockReset()
+    mockAppendToDailyFile.mockReset()
+  })
+
+  afterEach(() => {
+    if (db) db.close()
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('sends conversation history to completeSimple', async () => {
+    mockCompleteSimple.mockResolvedValueOnce(
+      makeCompleteSimpleResponse('Discussed Docker deployment options.')
+    )
+
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    // Access private method via type cast
+    const summary = await (agent as unknown as {
+      generateSessionSummary: (userId: string, history?: string) => Promise<string>
+    }).generateSessionSummary('user1', 'User: How do I deploy with Docker?\nAssistant: Use docker compose up.')
+
+    expect(mockCompleteSimple).toHaveBeenCalledOnce()
+    const [, callOptions] = mockCompleteSimple.mock.calls[0]
+    expect(callOptions.messages[0].content).toContain('How do I deploy with Docker?')
+    expect(summary).toBe('Discussed Docker deployment options.')
+  })
+
+  it('prompt instructs LLM to add ### Offene Fäden section for unresolved items', async () => {
+    mockCompleteSimple.mockResolvedValueOnce(
+      makeCompleteSimpleResponse('Discussed PR workflow.\n\n### Offene Fäden\n- PR for PDF upload not yet merged')
+    )
+
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    const [, callOptions] = await (async () => {
+      await (agent as unknown as {
+        generateSessionSummary: (userId: string, history?: string) => Promise<string>
+      }).generateSessionSummary('user1', 'User: Can you start the PR for PDF upload?\nAssistant: I started the PR.')
+      return mockCompleteSimple.mock.calls[0]
+    })()
+
+    // The system prompt must mention "Offene Fäden"
+    expect(callOptions.systemPrompt).toContain('Offene Fäden')
+    // The system prompt must explain what counts as open
+    expect(callOptions.systemPrompt).toContain('unfinished tasks')
+    // The system prompt must prohibit empty sections
+    expect(callOptions.systemPrompt).toContain('empty')
+  })
+
+  it('returns summary with open threads section when LLM includes it', async () => {
+    const llmOutput = 'Discussed PR for PDF upload extraction and open threads feature.\n\n### Offene Fäden\n- PR for PDF-upload-extraction started, result not yet confirmed\n- Open threads feature discussed, PR not yet started'
+    mockCompleteSimple.mockResolvedValueOnce(makeCompleteSimpleResponse(llmOutput))
+
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    const summary = await (agent as unknown as {
+      generateSessionSummary: (userId: string, history?: string) => Promise<string>
+    }).generateSessionSummary('user1', 'User: Lets work on two things...\nAssistant: Sure.')
+
+    expect(summary).toBe(llmOutput)
+    expect(summary).toContain('### Offene Fäden')
+    expect(summary).toContain('PR for PDF-upload-extraction started')
+  })
+
+  it('returns summary without open threads section when LLM omits it', async () => {
+    const llmOutput = 'Answered question about Docker compose syntax. No open items.'
+    mockCompleteSimple.mockResolvedValueOnce(makeCompleteSimpleResponse(llmOutput))
+
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    const summary = await (agent as unknown as {
+      generateSessionSummary: (userId: string, history?: string) => Promise<string>
+    }).generateSessionSummary('user1', 'User: What does --build do?\nAssistant: It rebuilds images.')
+
+    expect(summary).toBe(llmOutput)
+    expect(summary).not.toContain('### Offene Fäden')
+  })
+
+  it('returns "Empty session." when no conversation history is provided', async () => {
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    const summary = await (agent as unknown as {
+      generateSessionSummary: (userId: string, history?: string) => Promise<string>
+    }).generateSessionSummary('user1', undefined)
+
+    expect(summary).toBe('Empty session.')
+    expect(mockCompleteSimple).not.toHaveBeenCalled()
+  })
+
+  it('returns fallback text when completeSimple throws', async () => {
+    mockCompleteSimple.mockRejectedValueOnce(new Error('LLM unavailable'))
+
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    const summary = await (agent as unknown as {
+      generateSessionSummary: (userId: string, history?: string) => Promise<string>
+    }).generateSessionSummary('user1', 'User: Hello\nAssistant: Hi')
+
+    expect(summary).toBe('Session ended (summary generation failed).')
+  })
+
+  it('uses a single completeSimple call (no second call for open threads)', async () => {
+    mockCompleteSimple.mockResolvedValue(
+      makeCompleteSimpleResponse('Activity log text.\n\n### Offene Fäden\n- Something open')
+    )
+
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    await (agent as unknown as {
+      generateSessionSummary: (userId: string, history?: string) => Promise<string>
+    }).generateSessionSummary('user1', 'User: Start a task\nAssistant: Task started.')
+
+    // Must be exactly one LLM call — not two
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1)
+  })
+
+  it('daily file entry contains both activity and open threads when present', async () => {
+    // Use real appendToDailyFile logic by using a real SessionManager + fake summarizer
+    // We verify by checking the summary text that gets written
+    const llmOutput = 'Reviewed PR structure and discussed open threads feature.\n\n### Offene Fäden\n- Open threads feature: PR not yet created'
+    mockCompleteSimple.mockResolvedValueOnce(makeCompleteSimpleResponse(llmOutput))
+
+    const agent = new AgentCore({
+      model: makeModel(),
+      apiKey: 'sk-test',
+      db,
+      tools: [],
+      memoryDir,
+    })
+
+    const summary = await (agent as unknown as {
+      generateSessionSummary: (userId: string, history?: string) => Promise<string>
+    }).generateSessionSummary('user1', 'User: Lets discuss the feature\nAssistant: Sure, two parts...')
+
+    // The summary is written verbatim inside the ## HH:MM block in session-manager.ts
+    // Verify the structure is correct for downstream use
+    expect(summary).toMatch(/^Reviewed PR structure/)
+    expect(summary).toContain('\n\n### Offene Fäden\n')
+    expect(summary).toContain('- Open threads feature: PR not yet created')
+  })
+})

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -794,7 +794,9 @@ export class AgentCore {
   }
 
   /**
-   * Generate a summary of the current conversation using the LLM
+   * Generate a summary of the current conversation using the LLM.
+   * Returns a combined activity log entry that may include an optional
+   * "### Offene Fäden" (open threads) section when unresolved items exist.
    */
   private async generateSessionSummary(_userId: string, conversationHistory?: string): Promise<string> {
     // Always use DB conversation history (single source of truth).
@@ -806,13 +808,25 @@ export class AgentCore {
       const response = await completeSimple(this.model, {
         systemPrompt: `You are writing a chronological activity log entry for this session. Your output will be stored in a daily file so the agent can recall what happened in past sessions (e.g. "yesterday at 14:30 we discussed X and you asked me to do Y").
 
-Rules:
-- Write 2–5 sentences or bullet points. Max 200 words total.
-- Always describe what actually happened: topics discussed, questions answered, decisions made, tasks started or completed, PRs or files created, and anything left open.
+Your output has two parts:
+
+**Part 1 — Activity Log (always required)**
+- Write 2–5 sentences or bullet points. Max 200 words.
+- Describe what actually happened: topics discussed, questions answered, decisions made, tasks started or completed, PRs or files created.
 - If a background task completed or a task result was injected, mention its outcome (e.g. "PR #15 created for X", "wiki page updated").
 - Use neutral, factual tone. No filler words. No meta-commentary about the summary itself.
 - Do NOT filter for "memory-worthiness" — this is an activity log, not a memory promotion filter. Even a single answered question is worth one sentence.
-- Write "Empty session." ONLY if the transcript contains nothing but greetings or a bare connection with zero substantive content.`,
+- Write "Empty session." ONLY if the transcript contains nothing but greetings or a bare connection with zero substantive content.
+
+**Part 2 — Open Threads (optional)**
+If and only if there are genuinely unresolved items, append the following section after the activity log (separated by a blank line):
+
+### Offene Fäden
+- <concrete open item>
+- <concrete open item>
+
+Open items are: explicitly mentioned but unfinished tasks, background tasks started without a confirmed result, decisions that were deferred, or questions that were not answered.
+Do NOT add this section if everything discussed was resolved or if there is nothing left open. Never add an empty "### Offene Fäden" section.`,
         messages: [{
           role: 'user' as const,
           content: conversationHistory,


### PR DESCRIPTION
## Problem

The session-end daily log entry only captured an activity summary, but had no way to track explicitly unresolved items across sessions — making it hard to resume work after a break.

## Change

Extended `generateSessionSummary` in `packages/core/src/agent.ts` to produce a **two-part output** in a single LLM call:

1. **Activity log** (as before): 2–5 sentences/bullets, max 200 words, neutral factual tone
2. **Optional `### Offene Fäden`** section: concrete bullet points for any genuinely unresolved items

The open threads section is only appended when there are:
- Explicitly mentioned but unfinished tasks
- Background tasks started without a confirmed result
- Decisions that were deferred
- Questions that were not answered

An empty `### Offene Fäden` section is never generated. Both parts are produced in a **single LLM call** — no second call.

## Example Output (daily file entry)

```markdown
## 15:23

Reviewed PR structure and discussed open threads feature. Two items started: PDF upload extraction PR and the open threads session log feature.

### Offene Fäden
- PR für PDF-Upload-Extraktion gestartet, kein Ergebnis noch
- Offene Fäden Feature besprochen, PR noch nicht gestartet
```

When everything was resolved, only the activity log is written (no empty section).

## Files Changed

- `packages/core/src/agent.ts` — extended `generateSessionSummary` prompt
- `packages/core/src/agent-session-summary.test.ts` — new test file (8 tests)

## Testing

All 654 core tests pass (`npx vitest run packages/core/src`). The new test file covers:
- Conversation history forwarded to LLM
- Prompt includes `Offene Fäden` instructions and prohibits empty sections
- Summary returned verbatim when LLM includes open threads section
- Summary returned verbatim when LLM omits open threads section (nothing open)
- Empty session handling (no LLM call)
- Error fallback behavior
- Single LLM call only (no second call)