### PR TITLE
fix(core): add debug logging to session summary generation

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -802,7 +802,12 @@ export class AgentCore {
     // Always use DB conversation history (single source of truth).
     // In-memory agent messages can disappear on provider change or restart,
     // but chat_messages in the DB are always reliable.
-    if (!conversationHistory) return 'Empty session.'
+    if (!conversationHistory) {
+      console.warn('[session-summary] No conversation history available, returning Empty session.')
+      return 'Empty session.'
+    }
+
+    console.log(`[session-summary] Generating summary for ${conversationHistory.length} chars of history`)
 
     try {
       const response = await completeSimple(this.model, {
@@ -837,11 +842,20 @@ Do NOT add this section if everything discussed was resolved or if there is noth
         temperature: 0,
       })
 
-      const summary = response.content
-        .filter(c => c.type === 'text')
+      const textContent = response.content.filter(c => c.type === 'text')
+
+      if (textContent.length === 0) {
+        console.warn('[session-summary] API response contained no text content. Full response.content:', JSON.stringify(response.content))
+      }
+
+      const summary = textContent
         .map(c => (c as { type: 'text'; text: string }).text)
         .join('')
         .trim()
+
+      if (!summary) {
+        console.warn('[session-summary] Summary was empty after filtering, falling back to "Empty session."')
+      }
 
       return summary || 'Empty session.'
     } catch (err) {


### PR DESCRIPTION
## What changed

Added debug logging to the `generateSessionSummary` method in `packages/core/src/agent.ts`.

## Why

When session summary generation silently returns `"Empty session."` or an empty string, there is currently no way to tell from logs whether:
- the conversation history was missing/undefined before the API call, or
- the API call was made but returned no text content, or
- the API returned text that was empty after trimming.

This makes it impossible to debug production issues where sessions are recorded as `"Empty session."` unexpectedly.

## What the logs now show

1. **`[session-summary] No conversation history available, returning Empty session.`** — warns when `conversationHistory` is falsy, so we know the API was never called.
2. **`[session-summary] Generating summary for N chars of history`** — logs the character count of what was sent to the API, confirming the call is being made with real content.
3. **`[session-summary] API response contained no text content. Full response.content: [...]`** — warns and dumps the full `response.content` array when the API returns no text elements (e.g. only tool use blocks or an unexpected structure).
4. **`[session-summary] Summary was empty after filtering, falling back to "Session ended."`** — warns when the text content joined to an empty string after trimming.