### PR TITLE
fix(frontend): remove legacy projects tab

### DIFF
--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -285,10 +285,6 @@
     "factsDeleteError": "Fakt konnte nicht gelöscht werden.",
     "factsDeleteConfirmTitle": "Fakt löschen?",
     "factsDeleteConfirmDescription": "Diesen Fakt löschen? \"{content}\"",
-    "projectsTab": "Projekte",
-    "noProjectFiles": "Noch keine Projektdateien vorhanden.",
-    "projectColumnName": "Projekt",
-    "projectEditorDescription": "Projektnotizen werden vom Agenten für projektspezifischen Kontext genutzt.",
     "wikiTab": "Wiki"
   },
   "settings": {

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -285,10 +285,6 @@
     "factsDeleteError": "Could not delete fact.",
     "factsDeleteConfirmTitle": "Delete fact?",
     "factsDeleteConfirmDescription": "Delete this fact? \"{content}\"",
-    "projectsTab": "Projects",
-    "noProjectFiles": "No project files yet.",
-    "projectColumnName": "Project",
-    "projectEditorDescription": "Project notes are used by the agent for project-specific context.",
     "wikiTab": "Wiki"
   },
   "settings": {

--- a/packages/web-frontend/app/pages/memory.vue
+++ b/packages/web-frontend/app/pages/memory.vue
@@ -37,7 +37,6 @@
           <TabsTrigger value="wiki" @click="switchTab('wiki')">{{ $t('memory.wikiTab') }}</TabsTrigger>
           <TabsTrigger value="core" @click="switchTab('core')">{{ $t('memory.coreMemoryTab') }}</TabsTrigger>
           <TabsTrigger value="facts" @click="switchTab('facts')">{{ $t('memory.factsTab') }}</TabsTrigger>
-          <TabsTrigger value="projects" @click="switchTab('projects')">{{ $t('memory.projectsTab') }}</TabsTrigger>
           <TabsTrigger value="profile" @click="switchTab('profile')">{{ $t('memory.profileTab') }}</TabsTrigger>
           <TabsTrigger value="soul" @click="switchTab('soul')">{{ $t('memory.soulTab') }}</TabsTrigger>
           <TabsTrigger value="daily" @click="switchTab('daily')">{{ $t('memory.dailyTab') }}</TabsTrigger>
@@ -325,102 +324,6 @@
         </div>
       </TabsContent>
 
-      <!-- Projects tab -->
-      <TabsContent value="projects" class="flex flex-1 flex-col overflow-hidden min-h-0 mt-0">
-        <!-- Projects list view -->
-        <div v-if="!selectedProject" class="flex flex-1 flex-col overflow-hidden min-h-0">
-          <div v-if="loading" class="flex items-center justify-center py-16 text-sm text-muted-foreground">
-            {{ $t('memory.loading') }}
-          </div>
-          <div v-else-if="projectFiles.length === 0" class="flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
-            <AppIcon name="folder" size="xl" class="h-10 w-10 opacity-40" />
-            <p class="text-sm">{{ $t('memory.noProjectFiles') }}</p>
-          </div>
-
-          <!-- Table + Pagination -->
-          <div v-else class="flex flex-1 flex-col overflow-hidden min-h-0">
-            <div class="flex-1 overflow-y-auto min-h-0 rounded-xl border border-border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{{ $t('memory.projectColumnName') }}</TableHead>
-                    <TableHead>{{ $t('memory.dailyColumnUpdated') }}</TableHead>
-                    <TableHead class="text-right">{{ $t('memory.dailyColumnSize') }}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  <TableRow
-                    v-for="(file, idx) in paginatedProjectFiles"
-                    :key="file.name"
-                    class="cursor-pointer"
-                    :class="idx % 2 === 1 ? 'bg-muted/50' : ''"
-                    @click="openProjectFile(file.name)"
-                  >
-                    <TableCell class="font-semibold">{{ file.name }}</TableCell>
-                    <TableCell class="text-muted-foreground">{{ formatDate(file.modifiedAt) }}</TableCell>
-                    <TableCell class="text-right text-muted-foreground">{{ formatSize(file.size) }}</TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </div>
-
-            <!-- Pagination -->
-            <div v-if="projectTotalPages > 1" class="flex shrink-0 items-center justify-between pt-3">
-              <span class="text-xs text-muted-foreground">
-                {{ $t('memory.dailyPagination', { from: projectPaginationFrom, to: projectPaginationTo, total: projectFiles.length }) }}
-              </span>
-              <div class="flex items-center gap-1">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  :disabled="projectCurrentPage <= 1"
-                  :aria-label="$t('memory.dailyPrevPage')"
-                  @click="projectCurrentPage--"
-                >
-                  <AppIcon name="arrowLeft" class="h-4 w-4" />
-                </Button>
-                <span class="px-2 text-xs text-muted-foreground">
-                  {{ projectCurrentPage }} / {{ projectTotalPages }}
-                </span>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  :disabled="projectCurrentPage >= projectTotalPages"
-                  :aria-label="$t('memory.dailyNextPage')"
-                  @click="projectCurrentPage++"
-                >
-                  <AppIcon name="arrowRight" class="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Project editor view -->
-        <div v-else class="flex flex-1 flex-col overflow-hidden min-h-0">
-          <div class="mb-3 flex shrink-0 flex-wrap items-center gap-3">
-            <Button variant="outline" size="icon" class="h-8 w-8" :aria-label="$t('memory.backToList')" @click="closeProjectFile">
-              <AppIcon name="arrowLeft" class="h-4 w-4" />
-            </Button>
-            <div>
-              <span class="block text-base font-bold text-foreground">{{ selectedProject }}</span>
-              <p class="text-xs text-muted-foreground">{{ $t('memory.projectEditorDescription') }}</p>
-            </div>
-          </div>
-
-          <div v-if="loading" class="flex flex-1 items-center justify-center py-20 text-sm text-muted-foreground">
-            {{ $t('memory.loading') }}
-          </div>
-          <div v-else class="flex flex-1 flex-col overflow-hidden min-h-0">
-            <MarkdownEditor
-              v-model="projectContent"
-              :saving="saving"
-              :file-path="`.data/memory/projects/${selectedProject}.md`"
-              @save="handleSaveProject"
-            />
-          </div>
-        </div>
-      </TabsContent>
     </Tabs>
     </div>
 
@@ -454,9 +357,6 @@ const {
   loadDailyFiles,
   loadDailyFile,
   saveDailyFile,
-  loadProjectFiles,
-  loadProjectFile,
-  saveProjectFile,
   clearMessages,
 } = useMemory()
 
@@ -467,7 +367,7 @@ const {
   deleteWikiPage,
 } = useWiki()
 
-const activeTab = ref<'soul' | 'core' | 'facts' | 'profile' | 'daily' | 'projects' | 'wiki'>('wiki')
+const activeTab = ref<'soul' | 'core' | 'facts' | 'profile' | 'daily' | 'wiki'>('wiki')
 
 // Wiki state
 interface WikiFile {
@@ -587,9 +487,6 @@ const profileUsername = ref('')
 const dailyContent = ref('')
 const dailyFiles = ref<{ filename: string; date: string; size: number; modifiedAt: string }[]>([])
 const selectedDaily = ref<string | null>(null)
-const projectContent = ref('')
-const projectFiles = ref<{ filename: string; name: string; size: number; modifiedAt: string }[]>([])
-const selectedProject = ref<string | null>(null)
 
 // Date range filter — default to last 7 days
 const fmt = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
@@ -626,18 +523,6 @@ const paginationFrom = computed(() => {
 
 const paginationTo = computed(() => Math.min(currentPage.value * PAGE_SIZE, filteredDailyFiles.value.length))
 
-// Project pagination
-const projectCurrentPage = ref(1)
-const projectTotalPages = computed(() => Math.max(1, Math.ceil(projectFiles.value.length / PAGE_SIZE)))
-const paginatedProjectFiles = computed(() => {
-  const start = (projectCurrentPage.value - 1) * PAGE_SIZE
-  return projectFiles.value.slice(start, start + PAGE_SIZE)
-})
-const projectPaginationFrom = computed(() => {
-  if (projectFiles.value.length === 0) return 0
-  return (projectCurrentPage.value - 1) * PAGE_SIZE + 1
-})
-const projectPaginationTo = computed(() => Math.min(projectCurrentPage.value * PAGE_SIZE, projectFiles.value.length))
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -669,9 +554,7 @@ async function switchTab(tab: typeof activeTab.value) {
     return
   } else if (tab === 'daily') {
     await refreshDailyFiles()
-  } else if (tab === 'projects') {
-    await refreshProjectFiles()
-  }
+   }
 }
 
 async function refreshDailyFiles() {
@@ -722,34 +605,6 @@ function closeDailyFile() {
   clearMessages()
 }
 
-async function refreshProjectFiles() {
-  selectedProject.value = null
-  projectCurrentPage.value = 1
-  projectFiles.value = await loadProjectFiles()
-}
-
-async function openProjectFile(name: string) {
-  clearMessages()
-  selectedProject.value = name
-  projectContent.value = await loadProjectFile(name)
-}
-
-function closeProjectFile() {
-  selectedProject.value = null
-  projectContent.value = ''
-  clearMessages()
-}
-
-async function handleSaveProject() {
-  if (!selectedProject.value) return
-  const saved = await saveProjectFile(selectedProject.value, projectContent.value)
-  if (saved) {
-    const currentName = selectedProject.value
-    await refreshProjectFiles()
-    selectedProject.value = currentName
-  }
-  autoHideSuccess()
-}
 
 function autoHideSuccess() {
   setTimeout(() => {


### PR DESCRIPTION
The projects/ directory was renamed to wiki/ in PR #16, which added a dedicated Wiki tab. The old Projects tab was not removed and now points to a non-existent legacy path. This PR removes the Projects tab entirely.

## Changes
- Removed the `<TabsTrigger value="projects">` tab button from memory.vue
- Removed the `<TabsContent value="projects">` section entirely  
- Removed all projects-related reactive state, computed properties, and functions
- Removed `projects` case from `switchTab()`
- Removed projects imports from `useMemory()` destructuring
- Removed `'projects'` from the `activeTab` type union
- Removed projects-specific i18n keys from en.json and de.json