### PR TITLE
feat(webchat): display thinking/reasoning blocks

### DIFF
--- a/packages/core/src/agent-runtime-types.ts
+++ b/packages/core/src/agent-runtime-types.ts
@@ -1,6 +1,8 @@
 export interface ResponseChunk {
-  type: 'text' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done'
+  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done'
   text?: string
+  /** Streamed thinking/reasoning delta (for `type: 'thinking'`) */
+  thinking?: string
   toolName?: string
   toolCallId?: string
   toolArgs?: unknown

--- a/packages/core/src/agent-runtime.test.ts
+++ b/packages/core/src/agent-runtime.test.ts
@@ -226,4 +226,40 @@ describe('AgentRuntime boundary', () => {
     expect(chunks.map(c => c.type)).toEqual(['text', 'tool_call_start', 'tool_call_end', 'done'])
     expect(logToolCall).toHaveBeenCalledTimes(1)
   })
+
+  it('forwards thinking_delta events as thinking response chunks', async () => {
+    const db = initDatabase(':memory:')
+    const runtime = createAgentRuntime({
+      model: makeModel(),
+      apiKey: 'sk-primary',
+      db,
+      tools: [],
+    })
+
+    runtimeHarness.promptBehaviors.push(async (agent) => {
+      agent.emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'Hmm,' },
+      })
+      agent.emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: ' weighing options.' },
+      })
+      agent.emit({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Done.' },
+      })
+      agent.emit({ type: 'agent_end', messages: [] })
+    })
+
+    const chunks = [] as Array<{ type: string; text?: string; thinking?: string }>
+    for await (const chunk of runtime.streamPrompt('hello', 'session-1')) {
+      chunks.push({ type: chunk.type, text: chunk.text, thinking: chunk.thinking })
+    }
+
+    expect(chunks.map(c => c.type)).toEqual(['thinking', 'thinking', 'text', 'done'])
+    expect(chunks[0]!.thinking).toBe('Hmm,')
+    expect(chunks[1]!.thinking).toBe(' weighing options.')
+    expect(chunks[2]!.text).toBe('Done.')
+  })
 })

--- a/packages/core/src/agent-runtime.ts
+++ b/packages/core/src/agent-runtime.ts
@@ -711,6 +711,11 @@ class PiAgentRuntime implements AgentRuntimeBoundary, AgentRuntimePiAgentAccess 
             type: 'text',
             text: assistantEvent.delta,
           })
+        } else if (assistantEvent.type === 'thinking_delta') {
+          chunks.push({
+            type: 'thinking',
+            thinking: assistantEvent.delta,
+          })
         }
         break
       }

--- a/packages/web-backend/src/chat-event-bus.ts
+++ b/packages/web-backend/src/chat-event-bus.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'node:events'
  */
 export interface ChatEvent {
   /** The kind of event being broadcast */
-  type: 'user_message' | 'text' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error' | 'system' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder'
+  type: 'user_message' | 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error' | 'system' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder'
   /** The OpenAgent user ID (integer) this event belongs to */
   userId: number
   /** Where the event originated */
@@ -17,6 +17,8 @@ export interface ChatEvent {
   sessionId?: string
   /** Text content (for user_message, text, system, error) */
   text?: string
+  /** Thinking delta (for type='thinking') */
+  thinking?: string
   /** Tool name (for tool_call_start, tool_call_end) */
   toolName?: string
   /** Tool call ID */

--- a/packages/web-backend/src/ws-chat.test.ts
+++ b/packages/web-backend/src/ws-chat.test.ts
@@ -173,6 +173,96 @@ describe('setupWebSocketChat kill switch', () => {
     }
   })
 
+  it('streams thinking chunks, persists them with metadata.kind=thinking, and broadcasts them', async () => {
+    const db = initDatabase(':memory:')
+    const chatEventBus = new ChatEventBus()
+    const mockSessionManager = {
+      getOrCreateSession: vi.fn(() => ({ id: 'session-thinking', userId: '1', source: 'web', startedAt: Date.now(), lastActivity: Date.now(), messageCount: 0, summaryWritten: false, restored: false })),
+    }
+    const agentCore = {
+      sendMessage: vi.fn(async function* (): AsyncGenerator<ResponseChunk> {
+        yield { type: 'thinking', thinking: 'Hmm,' }
+        yield { type: 'thinking', thinking: ' let me think.' }
+        yield { type: 'text', text: 'Answer.' }
+        yield { type: 'done' }
+      }),
+      abort: vi.fn(),
+      resetSession: vi.fn(),
+      getSessionManager: vi.fn(() => mockSessionManager),
+    } as unknown as AgentCore
+
+    const app = createApp({ db })
+    const server = http.createServer(app)
+    const { wss } = setupWebSocketChat(server, db, agentCore, undefined, chatEventBus)
+
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    const token = generateAccessToken({ userId: 1, username: 'admin', role: 'admin' })
+
+    // Spy on the event bus so we can verify thinking broadcasts.
+    const busEvents: Array<{ type: string; thinking?: string; text?: string }> = []
+    chatEventBus.subscribe((ev) => {
+      busEvents.push({ type: ev.type, thinking: ev.thinking, text: ev.text })
+    })
+
+    try {
+      const { ws, waitForMessage } = await connectWs(port, token)
+      await waitForMessage() // authenticated
+
+      ws.send(JSON.stringify({ type: 'message', content: 'hello' }))
+
+      const firstThinking = await waitForMessage()
+      expect(firstThinking.type).toBe('thinking')
+      expect(firstThinking.thinking).toBe('Hmm,')
+
+      const secondThinking = await waitForMessage()
+      expect(secondThinking.type).toBe('thinking')
+      expect(secondThinking.thinking).toBe(' let me think.')
+
+      const text = await waitForMessage()
+      expect(text.type).toBe('text')
+      expect(text.text).toBe('Answer.')
+
+      const done = await waitForMessage()
+      expect(done.type).toBe('done')
+
+      // Thinking block persisted as its own assistant row with metadata.kind === 'thinking'
+      const rows = db.prepare(
+        "SELECT role, content, metadata FROM chat_messages WHERE session_id = 'session-thinking' ORDER BY id"
+      ).all() as Array<{ role: string; content: string; metadata: string | null }>
+      const thinkingRows = rows.filter(r => {
+        if (!r.metadata) return false
+        try {
+          return (JSON.parse(r.metadata) as { kind?: string }).kind === 'thinking'
+        } catch { return false }
+      })
+      expect(thinkingRows.length).toBe(1)
+      expect(thinkingRows[0]!.role).toBe('assistant')
+      expect(thinkingRows[0]!.content).toBe('Hmm, let me think.')
+
+      // Assistant text persisted as its own row without thinking metadata
+      const assistantTextRows = rows.filter(r => r.role === 'assistant' && (!r.metadata || !(() => { try { return (JSON.parse(r.metadata!) as { kind?: string }).kind === 'thinking' } catch { return false } })()))
+      expect(assistantTextRows.length).toBe(1)
+      expect(assistantTextRows[0]!.content).toBe('Answer.')
+
+      // Event bus broadcasts thinking chunks (in addition to user_message/text/done)
+      const broadcastedThinking = busEvents.filter(e => e.type === 'thinking')
+      expect(broadcastedThinking.length).toBe(2)
+      expect(broadcastedThinking[0]!.thinking).toBe('Hmm,')
+      expect(broadcastedThinking[1]!.thinking).toBe(' let me think.')
+
+      ws.close()
+    } finally {
+      for (const client of wss.clients) {
+        client.terminate()
+      }
+      wss.close()
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      )
+    }
+  })
+
   it('treats /kill as an alias for /stop over web chat', async () => {
     const db = initDatabase(':memory:')
     const mockSessionManager2 = {

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -19,8 +19,10 @@ interface ChatMessage {
 }
 
 interface ChatResponse {
-  type: 'text' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder'
+  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder'
   text?: string
+  /** Streamed thinking delta (for type='thinking') */
+  thinking?: string
   toolName?: string
   toolCallId?: string
   toolArgs?: unknown
@@ -293,21 +295,52 @@ export function setupWebSocketChat(
       let doneSent = false
       // Track pending tool calls to save input+output together
       const pendingToolCalls = new Map<string, { toolName: string; toolArgs: unknown }>()
+      // Buffer thinking deltas between thinking_start/thinking_end boundaries. Because
+      // the core runtime only surfaces `thinking_delta` today, we treat each contiguous
+      // run of thinking chunks (i.e. uninterrupted by text/tool/done) as a single block
+      // and persist it as its own chat_messages row with metadata.kind === 'thinking'.
+      let currentThinking = ''
+      const flushThinking = () => {
+        if (!currentThinking) return
+        const thinkingText = currentThinking
+        currentThinking = ''
+        try {
+          saveChatMessage(
+            db,
+            resolvedSessionId,
+            currentUser.userId,
+            'assistant',
+            thinkingText,
+            JSON.stringify({ kind: 'thinking' }),
+          )
+        } catch (err) {
+          console.error('Failed to persist thinking block:', err)
+        }
+      }
 
       try {
         for await (const chunk of agentCore.sendMessage(String(currentUser.userId), parsed.content, 'web', parsed.attachments)) {
           if (abortController.signal.aborted) break
 
           if (chunk.type === 'text' && chunk.text) {
+            // Any text closes an in-progress thinking block.
+            flushThinking()
             fullResponse += chunk.text
           }
 
+          if (chunk.type === 'thinking' && chunk.thinking) {
+            currentThinking += chunk.thinking
+          }
+
           if (chunk.type === 'done') {
+            flushThinking()
             doneSent = true
           }
 
           // Track tool call start
           if (chunk.type === 'tool_call_start' && chunk.toolCallId) {
+            // Tool calls also end the current thinking block.
+            flushThinking()
             pendingToolCalls.set(chunk.toolCallId, {
               toolName: chunk.toolName ?? 'unknown',
               toolArgs: chunk.toolArgs,
@@ -339,6 +372,7 @@ export function setupWebSocketChat(
             sourceConnectionId: connId,
             sessionId: resolvedSessionId,
             text: chunk.text,
+            thinking: chunk.thinking,
             toolName: chunk.toolName,
             toolCallId: chunk.toolCallId,
             toolArgs: chunk.toolArgs,
@@ -357,6 +391,9 @@ export function setupWebSocketChat(
           sendMessage(ws, { type: 'error', error: `Agent error: ${(err as Error).message}` })
         }
       } finally {
+        // Flush any trailing thinking that wasn't closed by text/tool/done (e.g.
+        // aborted/errored streams) so reload shows the partial reasoning.
+        flushThinking()
         // Always send a 'done' if one wasn't already sent, so the frontend
         // never gets stuck with a streaming indicator that never resolves.
         if (!doneSent) {
@@ -446,6 +483,7 @@ export function setupWebSocketChat(
           sendMessage(client, {
             type: event.type,
             text: event.text,
+            thinking: event.thinking,
             toolName: event.toolName,
             toolCallId: event.toolCallId,
             toolArgs: event.toolArgs,
@@ -479,6 +517,7 @@ function chunkToResponse(chunk: ResponseChunk): ChatResponse {
   return {
     type: chunk.type === 'done' ? 'done' : chunk.type,
     text: chunk.text,
+    thinking: chunk.thinking,
     toolName: chunk.toolName,
     toolCallId: chunk.toolCallId,
     toolArgs: chunk.toolArgs,

--- a/packages/web-frontend/app/composables/useChat.ts
+++ b/packages/web-frontend/app/composables/useChat.ts
@@ -44,11 +44,18 @@ export interface ChatMessage {
   taskResultStatus?: string
   /** Task duration in minutes */
   taskResultDuration?: number
+  /**
+   * Whether this assistant message is a thinking/reasoning block.
+   * Rendered as a separate collapsible card (sparkles icon).
+   */
+  isThinking?: boolean
 }
 
 interface WsMessage {
-  type: 'text' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'reminder' | 'task_completed' | 'task_failed' | 'task_question'
+  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'reminder' | 'task_completed' | 'task_failed' | 'task_question'
   text?: string
+  /** Thinking delta (for type='thinking') */
+  thinking?: string
   toolName?: string
   toolCallId?: string
   toolArgs?: unknown
@@ -111,6 +118,22 @@ function formatReminderContent(name?: string, message?: string): string {
   }
 
   return `⏰ ${trimmedName}\n\n${trimmedMessage}`
+}
+
+/**
+ * If the last message is a streaming thinking block, mark it as done.
+ * Used when a non-thinking chunk (text / tool / done) arrives so the
+ * thinking card stops showing the typing indicator.
+ */
+function closeStreamingThinking(list: ChatMessage[]): ChatMessage[] {
+  if (list.length === 0) return list
+  const last = list[list.length - 1]!
+  if (last.role === 'assistant' && last.isThinking && last.streaming) {
+    const updated = [...list]
+    updated[updated.length - 1] = { ...last, streaming: false }
+    return updated
+  }
+  return list
 }
 
 function parseAttachments(metadata?: string): ChatAttachment[] {
@@ -286,8 +309,8 @@ export function useChat() {
       case 'text':
         if (msg.text) {
           const lastMsg = messages.value[messages.value.length - 1]
-          if (lastMsg && lastMsg.role === 'assistant' && lastMsg.streaming) {
-            // Append to existing streaming message
+          if (lastMsg && lastMsg.role === 'assistant' && !lastMsg.isThinking && lastMsg.streaming) {
+            // Append to existing streaming message (but not to a thinking block)
             const updated = [...messages.value]
             updated[updated.length - 1] = {
               ...lastMsg,
@@ -296,8 +319,9 @@ export function useChat() {
             }
             messages.value = updated
           } else {
-            // Start new assistant message
-            messages.value = [...messages.value, {
+            // Close any streaming thinking block and start new assistant message
+            const closed = closeStreamingThinking(messages.value)
+            messages.value = [...closed, {
               role: 'assistant',
               content: msg.text,
               timestamp: new Date().toISOString(),
@@ -309,20 +333,48 @@ export function useChat() {
         }
         break
 
-      case 'done':
-        // Mark last message as done streaming
-        if (messages.value.length > 0) {
-          const updated = [...messages.value]
-          const last = updated[updated.length - 1]
-          if (last && last.streaming) {
+      case 'thinking':
+        if (msg.thinking) {
+          const lastMsg = messages.value[messages.value.length - 1]
+          if (lastMsg && lastMsg.role === 'assistant' && lastMsg.isThinking && lastMsg.streaming) {
+            // Append to existing streaming thinking block
+            const updated = [...messages.value]
             updated[updated.length - 1] = {
-              ...last,
-              streaming: false,
-              telegramDelivered: msg.telegramDelivered || last.telegramDelivered,
-              isTaskInjection: msg.isTaskInjection || last.isTaskInjection,
+              ...lastMsg,
+              content: lastMsg.content + msg.thinking,
             }
             messages.value = updated
+          } else {
+            // Start a new streaming thinking block (close any open non-thinking stream)
+            messages.value = [...messages.value, {
+              role: 'assistant',
+              content: msg.thinking,
+              timestamp: new Date().toISOString(),
+              streaming: true,
+              isThinking: true,
+            }]
           }
+          isStreaming.value = true
+        }
+        break
+
+      case 'done':
+        // Mark all trailing streaming messages (text + thinking) as done.
+        // A turn can end with a thinking block still streaming if the model
+        // emitted thinking without follow-up text (rare but possible).
+        if (messages.value.length > 0) {
+          const updated = [...messages.value]
+          for (let i = updated.length - 1; i >= 0; i--) {
+            const m = updated[i]!
+            if (!m.streaming) break
+            updated[i] = {
+              ...m,
+              streaming: false,
+              telegramDelivered: m.isThinking ? m.telegramDelivered : (msg.telegramDelivered || m.telegramDelivered),
+              isTaskInjection: m.isThinking ? m.isTaskInjection : (msg.isTaskInjection || m.isTaskInjection),
+            }
+          }
+          messages.value = updated
         }
         isStreaming.value = false
         break
@@ -347,7 +399,9 @@ export function useChat() {
 
       case 'tool_call_start':
         if (msg.toolName) {
-          messages.value = [...messages.value, {
+          // A tool call also ends any in-flight thinking block.
+          const closed = closeStreamingThinking(messages.value)
+          messages.value = [...closed, {
             role: 'tool',
             content: `Tool: ${msg.toolName}`,
             timestamp: new Date().toISOString(),

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -70,7 +70,9 @@
     "filterToolCalls": "Tool-Aufrufe",
     "filterInjections": "Injektionen",
     "filterSessionSummaries": "Sitzungszusammenfassungen",
+    "filterThinking": "Thinking-Blöcke anzeigen",
     "sessionSummary": "Sitzungszusammenfassung",
+    "thinking": "Überlegung",
     "scrollToBottom": "Nach unten scrollen",
     "attachments": {
       "openOriginal": "Original öffnen",

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -70,7 +70,7 @@
     "filterToolCalls": "Tool-Aufrufe",
     "filterInjections": "Injektionen",
     "filterSessionSummaries": "Sitzungszusammenfassungen",
-    "filterThinking": "Thinking-Blöcke anzeigen",
+    "filterThinking": "Thinking-Blöcke",
     "sessionSummary": "Sitzungszusammenfassung",
     "thinking": "Überlegung",
     "scrollToBottom": "Nach unten scrollen",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -70,7 +70,9 @@
     "filterToolCalls": "Tool Calls",
     "filterInjections": "Injections",
     "filterSessionSummaries": "Session Summaries",
+    "filterThinking": "Show thinking blocks",
     "sessionSummary": "Session Summary",
+    "thinking": "Thinking",
     "scrollToBottom": "Scroll to bottom",
     "attachments": {
       "openOriginal": "Open original",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -70,7 +70,7 @@
     "filterToolCalls": "Tool Calls",
     "filterInjections": "Injections",
     "filterSessionSummaries": "Session Summaries",
-    "filterThinking": "Show thinking blocks",
+    "filterThinking": "Thinking blocks",
     "sessionSummary": "Session Summary",
     "thinking": "Thinking",
     "scrollToBottom": "Scroll to bottom",

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -31,6 +31,10 @@
           <div class="flex flex-col gap-3">
             <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{{ $t('chat.displayFilters') }}</p>
             <div class="flex items-center justify-between gap-3">
+              <Label class="cursor-pointer text-sm" for="filter-thinking">{{ $t('chat.filterThinking') }}</Label>
+              <Switch id="filter-thinking" v-model:checked="showThinking" />
+            </div>
+            <div class="flex items-center justify-between gap-3">
               <Label class="cursor-pointer text-sm" for="filter-tools">{{ $t('chat.filterToolCalls') }}</Label>
               <Switch id="filter-tools" v-model:checked="showToolCalls" />
             </div>
@@ -41,10 +45,6 @@
             <div class="flex items-center justify-between gap-3">
               <Label class="cursor-pointer text-sm" for="filter-summaries">{{ $t('chat.filterSessionSummaries') }}</Label>
               <Switch id="filter-summaries" v-model:checked="showSessionSummaries" />
-            </div>
-            <div class="flex items-center justify-between gap-3">
-              <Label class="cursor-pointer text-sm" for="filter-thinking">{{ $t('chat.filterThinking') }}</Label>
-              <Switch id="filter-thinking" v-model:checked="showThinking" />
             </div>
           </div>
         </PopoverContent>

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -42,6 +42,10 @@
               <Label class="cursor-pointer text-sm" for="filter-summaries">{{ $t('chat.filterSessionSummaries') }}</Label>
               <Switch id="filter-summaries" v-model:checked="showSessionSummaries" />
             </div>
+            <div class="flex items-center justify-between gap-3">
+              <Label class="cursor-pointer text-sm" for="filter-thinking">{{ $t('chat.filterThinking') }}</Label>
+              <Switch id="filter-thinking" v-model:checked="showThinking" />
+            </div>
           </div>
         </PopoverContent>
       </Popover>
@@ -60,10 +64,10 @@
           v-for="(msg, i) in filteredMessages"
           :key="i"
           :class="[
-            msg.role === 'divider' ? 'w-full' : (msg.role === 'tool' || (msg.role === 'system' && msg.isTaskResult)) ? 'self-start w-full max-w-[80%] sm:max-w-[75%] pl-11' : 'flex max-w-[80%] gap-3 sm:max-w-[75%]',
+            msg.role === 'divider' ? 'w-full' : (msg.role === 'tool' || (msg.role === 'system' && msg.isTaskResult) || msg.isThinking) ? 'self-start w-full max-w-[80%] sm:max-w-[75%] pl-11' : 'flex max-w-[80%] gap-3 sm:max-w-[75%]',
             {
               'self-end flex-row-reverse': msg.role === 'user',
-              'self-start': msg.role === 'assistant',
+              'self-start': msg.role === 'assistant' && !msg.isThinking,
               'self-center max-w-[90%] !sm:max-w-[85%]': msg.role === 'system' && !msg.isTaskResult,
             },
           ]"
@@ -105,6 +109,31 @@
                   <span>{{ $t('chat.newSessionDivider') }}</span>
                 </div>
                 <div class="grow border-t border-border" />
+              </div>
+            </div>
+          </template>
+
+          <!-- Thinking card (clickable/expandable) -->
+          <template v-else-if="msg.isThinking">
+            <div class="w-full overflow-hidden rounded-lg border border-border">
+              <button
+                class="group flex w-full items-center gap-2 bg-muted/30 px-3 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/60"
+                :class="{ 'border-b border-border': expandedThinking.has(String(msg.id ?? i)) }"
+                @click="toggleThinking(String(msg.id ?? i))"
+              >
+                <svg class="h-3 w-3 shrink-0 transition-transform duration-200" :class="{ 'rotate-90': expandedThinking.has(String(msg.id ?? i)) }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6" /></svg>
+                <AppIcon name="sparkles" class="h-3 w-3 shrink-0 opacity-60" />
+                <span class="font-medium">{{ $t('chat.thinking') }}</span>
+                <span v-if="msg.streaming" class="ml-2 inline-flex items-center gap-1">
+                  <span class="h-1 w-1 animate-pulse rounded-full bg-current opacity-60" />
+                  <span class="h-1 w-1 animate-pulse rounded-full bg-current opacity-60" />
+                  <span class="h-1 w-1 animate-pulse rounded-full bg-current opacity-60" />
+                </span>
+              </button>
+              <div v-if="expandedThinking.has(String(msg.id ?? i))" class="bg-background text-xs">
+                <div class="max-h-80 overflow-y-auto px-3 py-2">
+                  <p class="whitespace-pre-wrap break-words text-muted-foreground">{{ msg.content }}</p>
+                </div>
               </div>
             </div>
           </template>
@@ -442,6 +471,7 @@ function saveFilters() {
     showToolCalls: showToolCalls.value,
     showInjections: showInjections.value,
     showSessionSummaries: showSessionSummaries.value,
+    showThinking: showThinking.value,
   }))
 }
 
@@ -449,8 +479,10 @@ const savedFilters = loadFilters()
 const showToolCalls = ref(savedFilters?.showToolCalls ?? true)
 const showInjections = ref(savedFilters?.showInjections ?? false)
 const showSessionSummaries = ref(savedFilters?.showSessionSummaries ?? false)
+// Thinking blocks default to visible (but collapsed) — mirrors TaskViewer behaviour.
+const showThinking = ref(savedFilters?.showThinking ?? true)
 
-watch([showToolCalls, showInjections, showSessionSummaries], () => saveFilters())
+watch([showToolCalls, showInjections, showSessionSummaries, showThinking], () => saveFilters())
 const expandedSummaries = ref<Set<string>>(new Set())
 function toggleSummary(id: string) { const updated = new Set(expandedSummaries.value); updated.has(id) ? updated.delete(id) : updated.add(id); expandedSummaries.value = updated }
 
@@ -458,6 +490,7 @@ const filteredMessages = computed(() => {
   return messages.value.filter((msg) => {
     if (!showToolCalls.value && msg.role === 'tool' && msg.toolData) return false
     if (!showInjections.value && msg.role === 'system' && msg.isTaskResult) return false
+    if (!showThinking.value && msg.isThinking) return false
     return true
   })
 })
@@ -465,6 +498,11 @@ const expandedTools = ref<Set<string>>(new Set())
 function toggleTool(toolCallId: string) { const updated = new Set(expandedTools.value); updated.has(toolCallId) ? updated.delete(toolCallId) : updated.add(toolCallId); expandedTools.value = updated }
 const expandedInjections = ref<Set<number>>(new Set())
 function toggleInjection(index: number) { const updated = new Set(expandedInjections.value); updated.has(index) ? updated.delete(index) : updated.add(index); expandedInjections.value = updated }
+// Thinking blocks default to collapsed per-message. We keep a Set of expanded IDs
+// (the DB row id when loaded from history, otherwise the array index fallback)
+// mirroring how tool calls/injections/summaries are toggled.
+const expandedThinking = ref<Set<string>>(new Set())
+function toggleThinking(id: string) { const updated = new Set(expandedThinking.value); updated.has(id) ? updated.delete(id) : updated.add(id); expandedThinking.value = updated }
 function taskResultBody(content: string): string {
   const lines = (content ?? '').split('\n')
   const bodyLines = lines.slice(1)
@@ -530,6 +568,15 @@ async function loadHistory() {
             taskResultName: meta.taskName ?? 'Background Task',
             taskResultStatus: meta.taskResultStatus ?? meta.taskStatus ?? 'completed',
             taskResultDuration: meta.durationMinutes,
+          } as ChatMessage
+        }
+
+        // Parse thinking blocks (assistant messages with metadata.kind === 'thinking').
+        // Persisted live by ws-chat so they survive a page reload.
+        if (m.role === 'assistant' && meta.kind === 'thinking') {
+          return {
+            id: m.id, role: 'assistant' as const, content: m.content, timestamp: m.timestamp, source,
+            isThinking: true,
           } as ChatMessage
         }
 


### PR DESCRIPTION
## Problem

The webchat completely drops thinking/reasoning chunks even though the backend already receives them from `pi-agent-core` (`thinking_start` / `thinking_delta` / `thinking_end`). Only the TaskViewer rendered them; the main chat had no UI, no persistence, and no filter for reasoning blocks.

## Change

Plumb thinking end-to-end through the webchat and display it as a collapsible card analogous to tool calls.

- **Core (`packages/core`)** – `ResponseChunk` gains a `'thinking'` type. `agent-runtime` forwards `thinking_delta` events as `{ type: 'thinking', thinking }` chunks.
- **Backend (`packages/web-backend/src/ws-chat.ts`)** – Forwards thinking chunks to the client, broadcasts them through `ChatEventBus` (so parallel tabs stay in sync), and persists each contiguous run of thinking deltas as its own `chat_messages` row with `role = 'assistant'` and `metadata = {"kind":"thinking"}`. Buffered between text / tool / done boundaries.
- **Frontend (`packages/web-frontend/app`)** – `useChat` now maintains a streaming thinking block; `pages/index.vue` renders it as a collapsible card (sparkles icon, `chat.thinking` label). The history loader restores rows tagged with `metadata.kind === 'thinking'` as thinking blocks. A new **Show thinking blocks** switch lives in the existing cog popover, persisted alongside the other filters in `openagent-chat-filters` localStorage under `showThinking` (default `true`).
- **i18n** – `chat.filterThinking` + `chat.thinking` added to DE / EN. The existing `taskViewer.thinking` key is left untouched.

## Implementation notes for reviewers

- **DB persistence via metadata, not schema migration.** A thinking block is just an `assistant` row with `metadata = JSON.stringify({ kind: 'thinking' })`. Keeps Postgres/SQLite schemas and cross-channel code untouched; the reveal logic lives in the frontend history mapper.
- **One row per thinking block, not per delta.** `ws-chat` accumulates deltas into `currentThinking` and flushes when a text/tool/done chunk arrives (plus a final flush in `finally` to cover aborts/errors). This matches how `task-runner.ts` persists thinking on `message_end`, just adapted to the streaming path.
- **Default behaviour:** thinking blocks are shown but collapsed, mirroring the TaskViewer. Expansion state is local (`expandedThinking`) and not persisted.
- **Streaming UX:** an in-flight thinking card shows three animated dots in the header; text chunks close the thinking block so the next assistant bubble starts fresh.

## Tests

- `packages/core/src/agent-runtime.test.ts` – new case asserting `thinking_delta` events become `thinking` chunks.
- `packages/web-backend/src/ws-chat.test.ts` – new case asserting thinking chunks are forwarded, broadcast on the event bus, and persisted as a single row with `metadata.kind === 'thinking'` distinct from the assistant text row.
- `npm run baseline:unit` and `npm run test -- packages/web-backend/src/ws-chat.test.ts` both green. (The existing `baseline:api` / `verify:critical-flows` failures on main are unrelated and unchanged by this PR.)

## Manual testing hints

1. Enable thinking: Settings → Thinking level = `medium` (or any non-`off`), with a reasoning-capable model.
2. Ask a question; expect a "Thinking" card to appear above the response, collapsed by default, with streaming dots while the model reasons.
3. Click the card to expand; content should be monospace-wrapped reasoning.
4. Reload the page — the thinking card should reappear from history (collapsed).
5. Cog menu → toggle **Show thinking blocks** off → cards disappear from the list; toggle back on → cards reappear. Value survives a reload (localStorage).
6. Open a second tab logged in as the same user, trigger a turn in tab A, verify tab B also gets the streaming thinking card.
