### PR TITLE
feat(memory): add immutable sources/ layer + content-gap and source-coverage lint

### DIFF
--- a/data/skills_agent/wiki/SKILL.md
+++ b/data/skills_agent/wiki/SKILL.md
@@ -7,6 +7,16 @@ description: Maintain and search the personal LLM-Wiki (knowledge base of Markdo
 
 The wiki lives at `/data/memory/wiki/`. It is a collection of LLM-maintained Markdown files — a personal knowledge base following the Karpathy pattern.
 
+## Three-Layer Architecture
+
+| Layer | Path | Mutability | Purpose |
+|---|---|---|---|
+| Sources (raw) | `/data/memory/sources/` | Immutable — add only | Archived raw material: articles, transcripts, papers |
+| Wiki (distilled) | `/data/memory/wiki/` | LLM-maintained | Summary pages, concepts, cross-references |
+| Schema / rules | `/data/config/CONSOLIDATION.md` + this skill | Editable | How the wiki operates |
+
+Rule of thumb: **Sources are what you read. Wiki is what you learned.** Never edit sources; always cite them from wiki pages.
+
 ## Wiki Structure
 
 Each wiki page is a `.md` file under `/data/memory/wiki/`. Pages can have optional YAML frontmatter with aliases:
@@ -25,35 +35,46 @@ Page content...
 
 ### Ingest — Add a new source
 
-Goal: extract knowledge from an external source (URL, file, conversation context) and store it in the wiki.
+Goal: extract knowledge from an external source (URL, file, conversation context), **archive the raw material** under `sources/`, and distill the knowledge into the wiki.
 
 **Steps:**
 
-1. List all existing wiki pages via `list_files /data/memory/wiki/`:
+1. **Fetch the raw source.** `web_fetch` the URL, read the transcript, or capture the conversation snippet.
+
+2. **Archive the raw source under `sources/`** (skip only if the content is trivial or already archived):
+   - Choose subfolder: `articles/`, `youtube/`, `podcasts/`, `papers/`, `notes/`
+   - Filename: `<yyyy-mm-dd>-<slug>.md` (lowercase, hyphens)
+   - First block: YAML frontmatter with `source_type`, `url`, `author`, `captured`
+   - Body: the raw text as received — no interpretation, no editing
+   - **Never modify an existing source file.** If the source itself changes, add a new dated file.
+
+3. **List existing wiki pages** via `list_files /data/memory/wiki/`:
    - Which pages already exist?
    - Is there an existing page that should be extended?
 
-2. Extract the essential knowledge from the source:
+4. **Extract the essential knowledge** from the source:
    - Facts, concepts, decisions, dependencies
    - No duplication of existing knowledge
    - Focus on evergreen knowledge (durably useful, not ephemeral)
 
-3. Decide: create a new page or extend an existing one?
+5. **Decide: create a new page or extend an existing one?**
    - New page: when it covers a new topic, project, or concept
    - Existing page: when the knowledge belongs to an existing page
 
-4. Write the page:
+6. **Write the page:**
    - Filename: `topic-name.md` (lowercase, hyphens instead of spaces)
    - First heading `# Title` (clear and precise)
    - Structure: headings, bullet lists, code blocks where appropriate
    - Cross-links: reference related wiki pages (`[Page Name](page-name.md)`)
+   - **Add a `## Quellen` / `## Sources` section** citing the `sources/...` file you just archived, so the page remains verifiable.
 
 **Example — ingest a web article:**
 ```
 1. web_fetch the URL
-2. list_files /data/memory/wiki/
-3. Extract relevant knowledge, identify duplicates
-4. write_file /data/memory/wiki/topic.md with the distilled knowledge
+2. write_file /data/memory/sources/articles/2026-04-17-<slug>.md (raw text, with frontmatter)
+3. list_files /data/memory/wiki/
+4. Extract relevant knowledge, identify duplicates
+5. write_file or edit_file /data/memory/wiki/topic.md with distilled knowledge + ## Quellen pointing to the archived source
 ```
 
 **Example — ingest context from a conversation:**
@@ -62,6 +83,7 @@ Goal: extract knowledge from an external source (URL, file, conversation context
 2. Check whether a matching page exists
 3. If yes: edit_file to add a section
 4. If no: write_file to create a new page
+(No sources/ archive needed when the "source" is just conversational context.)
 ```
 
 ---
@@ -91,7 +113,7 @@ Goal: search the wiki for knowledge relevant to a current task.
 
 ### Lint — Wiki health check
 
-Goal: audit the wiki for quality — find contradictions, orphaned pages, missing links.
+Goal: audit the wiki for quality — find contradictions, orphaned pages, missing links, **and surface content gaps the wiki implies but does not cover**.
 
 **Steps:**
 
@@ -114,16 +136,27 @@ Goal: audit the wiki for quality — find contradictions, orphaned pages, missin
    - Concepts mentioned on page A for which page B exists — but no link?
    - Add cross-links with `edit_file`
 
-5. **Write a lint report:**
+5. **Surface content gaps** (Karpathy/AI-Maker-Lab pattern):
+   - Which concepts, people, projects, or tools are **referenced repeatedly across pages but have no dedicated page**?
+   - Which pages contain TODO markers, "unclear", "to verify", or open questions?
+   - Which topics are discussed in daily files across multiple sessions but never promoted to a wiki page?
+   - List these as **suggested next research directions** — do not auto-create pages, just propose.
+
+6. **Check source coverage:**
+   - Wiki pages that make factual claims but have no `## Quellen` / `## Sources` section — flag them.
+   - `sources/` files with no inbound wiki reference — either unused raw material or candidate for ingest.
+
+7. **Write a lint report:**
    - Append findings to today's daily file:
      ```
      append to /data/memory/daily/YYYY-MM-DD.md
      ## Wiki Lint Report — YYYY-MM-DD\n\n### Findings\n- ...
      ```
 
-6. **Apply fixes:**
+8. **Apply fixes:**
    - Apply obvious corrections directly (edit_file)
    - Only when certain — no speculative changes
+   - Gap suggestions are reported only, not auto-resolved
 
 **Lint report format:**
 ```markdown
@@ -140,6 +173,14 @@ Goal: audit the wiki for quality — find contradictions, orphaned pages, missin
 
 ### Outdated information
 - `setup.md` still references Node 16, current version is Node 20
+
+### Content gaps (suggested next research)
+- `llm-oekosystem.md` mentions Qwen3.6 repeatedly but no dedicated `qwen.md`
+- Multiple daily entries reference "news crawler" but no wiki page exists
+
+### Source coverage
+- `project-x.md` makes release-date claims but has no ## Quellen section
+- `sources/articles/2026-04-17-foo.md` archived but not cited from any wiki page
 ```
 
 ---
@@ -162,5 +203,6 @@ Goal: audit the wiki for quality — find contradictions, orphaned pages, missin
 ## Paths
 
 - Wiki directory: `/data/memory/wiki/`
+- Sources directory (immutable raw material): `/data/memory/sources/`
 - Today's daily file (for lint reports): `/data/memory/daily/YYYY-MM-DD.md`
 - Always use absolute paths

--- a/data/skills_agent/wiki/SKILL.md
+++ b/data/skills_agent/wiki/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: wiki
+version: 1.0.0
 description: Maintain and search the personal LLM-Wiki (knowledge base of Markdown pages). Use this skill for ingesting new sources, querying the wiki, and wiki maintenance/linting.
 ---
 

--- a/docs/skill-versioning.md
+++ b/docs/skill-versioning.md
@@ -1,0 +1,62 @@
+# Built-in Skill Versioning
+
+Built-in agent skills ship with the Docker image under
+`/app/skills_agent_defaults/` and are seeded to `/data/skills_agent/` on
+container startup by `entrypoint.sh`.
+
+Because `/data` is a persistent volume, the seeding logic must decide on every
+start: **leave the installed skill alone, or replace it with a newer version
+from the image?** This is controlled by a `version` field in the skill's
+frontmatter.
+
+## Frontmatter
+
+```yaml
+---
+name: wiki
+version: 1.0.0
+description: ...
+# Optional: mark the skill as user-owned so auto-update skips it.
+# managed: false
+---
+```
+
+- `version` — semver string. Missing/empty is treated as `0.0.0`, so any
+  shipped version will win over an old unversioned skill.
+- `managed: false` — opt-out. When present the entrypoint never touches the
+  skill, regardless of versions. Use this if you have customized the skill and
+  want to pin your version.
+
+## Startup behaviour (`entrypoint.sh`)
+
+For each skill directory under `/app/skills_agent_defaults/`:
+
+1. **Not installed** (`/data/skills_agent/<name>/` missing) → copy the default
+   in. Logged as `Seeded agent skill: <name>`.
+2. **Installed, `managed: false`** → skipped. Logged once per start.
+3. **Installed, default version > installed version** →
+   - the full installed directory is copied to
+     `/data/skills_agent/.backups/<name>-v<installed-version>-<YYYYMMDD-HHMMSS>/`
+   - the default is copied over the installed skill
+   - logged as `Updated agent skill: <name> <old> → <new> (backup: ...)`
+4. **Installed, versions equal or installed newer** → nothing happens.
+
+Backups are never garbage-collected automatically; prune
+`/data/skills_agent/.backups/` manually if needed.
+
+## Bumping a built-in skill
+
+1. Edit the skill under `data/skills_agent/<name>/`.
+2. Bump the `version:` in the SKILL.md frontmatter (semver). Use minor for
+   additive/content changes, major if the skill's contract with the agent
+   changes incompatibly.
+3. Ship a new image. Existing instances pick the update up on the next
+   container start and write a backup of the previous version.
+
+## Keeping a local fork
+
+If you have edited a built-in skill on your instance and do not want it
+overwritten, add `managed: false` to the frontmatter of
+`/data/skills_agent/<name>/SKILL.md`. Remove the flag later to opt back into
+auto-updates (the next startup will back up your fork and install the
+shipped version).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,16 +7,83 @@ echo "[openagent] Starting entrypoint..."
 mkdir -p /data/db /data/config /data/memory/daily /data/skills /data/skills_agent /data/npm-global /workspace
 
 # ---------------------------------------------------------------------------
-# Seed built-in agent skills (only if not already present — never overwrite)
+# Seed / auto-update built-in agent skills
+#   - If a skill is not installed yet → seed from image defaults.
+#   - If an installed skill has a lower `version:` (frontmatter) than the
+#     shipped default → back up the installed copy and update in place.
+#   - If the installed SKILL.md has `managed: false` → never touch, the user
+#     has taken ownership of it.
 # Skills ship with the image under /app/skills_agent_defaults/
 # ---------------------------------------------------------------------------
+
+# Extract a frontmatter value (e.g. version, managed) from a SKILL.md file.
+# Only reads the leading YAML block between the first two `---` lines.
+# Prints the value (trimmed, unquoted) or nothing if key/file is absent.
+read_skill_frontmatter() {
+    local file="$1"
+    local key="$2"
+    [ -f "$file" ] || return 0
+    awk -v key="$key" '
+        NR == 1 && $0 != "---" { exit }
+        NR == 1 { in_fm = 1; next }
+        in_fm && $0 == "---" { exit }
+        in_fm {
+            # match "key: value" at start of line, case-sensitive
+            if (match($0, "^[[:space:]]*" key "[[:space:]]*:[[:space:]]*")) {
+                val = substr($0, RSTART + RLENGTH)
+                # strip surrounding quotes and trailing whitespace/comments
+                sub(/[[:space:]]*(#.*)?$/, "", val)
+                sub(/^"/, "", val); sub(/"$/, "", val)
+                sub(/^'\''/, "", val); sub(/'\''$/, "", val)
+                print val
+                exit
+            }
+        }
+    ' "$file"
+}
+
+# Returns 0 if $1 is strictly newer than $2 in semver-ish sort order.
+# Missing/empty version is treated as 0.0.0 so any real version wins over it.
+skill_version_newer() {
+    local a="${1:-0.0.0}"
+    local b="${2:-0.0.0}"
+    [ "$a" = "$b" ] && return 1
+    local top
+    top=$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n1)
+    [ "$top" = "$a" ]
+}
+
 if [ -d /app/skills_agent_defaults ]; then
+    backup_root="/data/skills_agent/.backups"
     for skill_dir in /app/skills_agent_defaults/*/; do
         skill_name=$(basename "$skill_dir")
         target="/data/skills_agent/$skill_name"
+        default_skill_md="$skill_dir/SKILL.md"
+
         if [ ! -d "$target" ]; then
             cp -r "$skill_dir" "$target"
             echo "[openagent] Seeded agent skill: $skill_name"
+            continue
+        fi
+
+        installed_skill_md="$target/SKILL.md"
+        managed=$(read_skill_frontmatter "$installed_skill_md" managed)
+        if [ "$managed" = "false" ]; then
+            echo "[openagent] Skill '$skill_name' is user-managed (managed: false) — skipping auto-update."
+            continue
+        fi
+
+        default_version=$(read_skill_frontmatter "$default_skill_md" version)
+        installed_version=$(read_skill_frontmatter "$installed_skill_md" version)
+
+        if skill_version_newer "$default_version" "$installed_version"; then
+            mkdir -p "$backup_root"
+            ts=$(date +%Y%m%d-%H%M%S)
+            backup_path="$backup_root/${skill_name}-v${installed_version:-unknown}-${ts}"
+            cp -r "$target" "$backup_path"
+            rm -rf "$target"
+            cp -r "$skill_dir" "$target"
+            echo "[openagent] Updated agent skill: $skill_name ${installed_version:-<none>} → $default_version (backup: $backup_path)"
         fi
     done
 fi

--- a/packages/core/src/memory.test.ts
+++ b/packages/core/src/memory.test.ts
@@ -15,6 +15,7 @@ import {
   ensureUserProfile,
   readUserProfile,
   ensureWikiDir,
+  ensureSourcesDir,
   ensureProjectsDir,
   parseProjectAliases,
   listWikiPages,
@@ -54,6 +55,24 @@ describe('memory', () => {
       expect(fs.existsSync(path.join(dir, 'HEARTBEAT.md'))).toBe(false)
     })
 
+    it('creates sources/ directory with README on first run', () => {
+      const dir = makeTmpDir()
+      ensureMemoryStructure(dir)
+
+      const sourcesDir = path.join(dir, 'sources')
+      expect(fs.existsSync(sourcesDir)).toBe(true)
+
+      const readmePath = path.join(sourcesDir, 'README.md')
+      expect(fs.existsSync(readmePath)).toBe(true)
+      const readme = fs.readFileSync(readmePath, 'utf-8')
+      expect(readme).toContain('# Sources')
+      expect(readme).toContain('Immutable')
+
+      // Subfolders (articles/, youtube/, ...) should NOT be auto-created
+      expect(fs.existsSync(path.join(sourcesDir, 'articles'))).toBe(false)
+      expect(fs.existsSync(path.join(sourcesDir, 'youtube'))).toBe(false)
+    })
+
     it('migrates projects/ to wiki/ on first run', () => {
       const dir = makeTmpDir()
       fs.mkdirSync(dir, { recursive: true })
@@ -79,6 +98,25 @@ describe('memory', () => {
 
       const content = fs.readFileSync(path.join(dir, 'SOUL.md'), 'utf-8')
       expect(content).toBe('# Custom Soul')
+    })
+  })
+
+  describe('ensureSourcesDir', () => {
+    it('is idempotent and does not overwrite an existing README', () => {
+      const dir = makeTmpDir()
+      fs.mkdirSync(dir, { recursive: true })
+
+      const sourcesDir = ensureSourcesDir(dir)
+      expect(sourcesDir).toBe(path.join(dir, 'sources'))
+
+      // User edits the README
+      const readmePath = path.join(sourcesDir, 'README.md')
+      fs.writeFileSync(readmePath, '# My Custom Sources Index\n', 'utf-8')
+
+      // Second call must not overwrite user edits
+      ensureSourcesDir(dir)
+      const content = fs.readFileSync(readmePath, 'utf-8')
+      expect(content).toBe('# My Custom Sources Index\n')
     })
   })
 
@@ -357,6 +395,17 @@ describe('memory', () => {
       expect(prompt).toContain('wiki/')
       expect(prompt).toContain('read_file, write_file, and edit_file')
       expect(prompt).toContain('</memory_paths>')
+    })
+
+    it('includes Sources directory reference in memory_paths', () => {
+      const dir = makeTmpDir()
+      ensureMemoryStructure(dir)
+
+      const prompt = assembleSystemPrompt({ memoryDir: dir })
+
+      expect(prompt).toContain('<memory_paths>')
+      expect(prompt).toContain('Sources directory')
+      expect(prompt).toContain(path.join(dir, 'sources'))
     })
 
     it('includes wiki_pages section when wiki pages exist', () => {

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -98,6 +98,52 @@ const USER_PROFILE_TEMPLATE = `# User Profile — {username}
 (none yet)
 `
 
+export const SOURCES_README_TEMPLATE = `# Sources
+
+<!-- This directory holds the immutable raw material the wiki is built on. -->
+<!-- Sources are what you read. The wiki is what you learned. -->
+<!-- Never edit existing source files. Only add new ones. -->
+
+This is the **sources layer** of the memory system. Unlike \`wiki/\`, files here
+are treated as archival raw material: articles, transcripts, papers, podcast
+notes. Wiki pages cite these files so factual claims remain verifiable.
+
+## Subfolders (create on first use)
+
+- \`articles/\` — web articles, blog posts, documentation snapshots
+- \`youtube/\` — YouTube transcripts
+- \`podcasts/\` — podcast notes and transcripts
+- \`papers/\` — research papers, PDFs converted to markdown
+- \`notes/\` — longer conversation snippets or hand-captured notes
+
+## Filename pattern
+
+\`<yyyy-mm-dd>-<slug>.md\` — lowercase, hyphens instead of spaces.
+
+## Frontmatter
+
+Each source file should start with YAML frontmatter:
+
+\`\`\`markdown
+---
+source_type: article | youtube | podcast | paper | note
+url: https://...
+author: ...
+captured: YYYY-MM-DD
+---
+
+# Title
+
+<raw body — do not edit later>
+\`\`\`
+
+## Rules
+
+- **Immutable**: never rewrite an existing file. If the source itself changes, add a new dated entry.
+- **Cite from the wiki**: wiki pages that rely on a source should link to it in a \`## Sources\` / \`## Quellen\` section.
+- **Orphaned sources are a lint signal**, not an error — they just flag material that has not been distilled yet.
+`
+
 const HEARTBEAT_TEMPLATE = `# Heartbeat Tasks
 
 <!-- Define periodic tasks here. The agent will execute them during each heartbeat cycle. -->
@@ -249,6 +295,9 @@ export function ensureMemoryStructure(memoryDir?: string): void {
     fs.mkdirSync(wikiDir, { recursive: true })
   }
 
+  // Seed immutable sources/ layer (raw material for the wiki)
+  ensureSourcesDir(dir)
+
   const soulPath = path.join(dir, 'SOUL.md')
   if (!fs.existsSync(soulPath)) {
     fs.writeFileSync(soulPath, SOUL_TEMPLATE, 'utf-8')
@@ -306,6 +355,27 @@ export function ensureConfigStructure(configDir?: string): void {
   if (!fs.existsSync(consolidationPath)) {
     fs.writeFileSync(consolidationPath, CONSOLIDATION_TEMPLATE, 'utf-8')
   }
+}
+
+/**
+ * Ensure the sources/ directory exists with a README explaining the layer.
+ * Idempotent: does NOT overwrite an existing README (so user edits are preserved).
+ * Subfolders (articles/, youtube/, ...) are NOT auto-created — they are added on first use.
+ */
+export function ensureSourcesDir(memoryDir?: string): string {
+  const dir = memoryDir ?? getMemoryDir()
+  const sourcesDir = path.join(dir, 'sources')
+
+  if (!fs.existsSync(sourcesDir)) {
+    fs.mkdirSync(sourcesDir, { recursive: true })
+  }
+
+  const readmePath = path.join(sourcesDir, 'README.md')
+  if (!fs.existsSync(readmePath)) {
+    fs.writeFileSync(readmePath, SOURCES_README_TEMPLATE, 'utf-8')
+  }
+
+  return sourcesDir
 }
 
 /**
@@ -722,7 +792,7 @@ ${dailyContext}
       return `- ${n.filename}${aliasStr}`
     }).join('\n')
     sections.push(`<wiki_pages>
-The following wiki pages are available in the personal knowledge base. When discussing a topic covered by a wiki page, load it with read_file for context. Use write_file or edit_file to create or update wiki pages when you learn something worth preserving.
+The following wiki pages are available in the personal knowledge base. When discussing a topic covered by a wiki page, load it with read_file for context. Use write_file or edit_file to create or update wiki pages when you learn something worth preserving. Raw source material for the wiki lives under sources/ — wiki pages can cite it in a ## Sources section.
 
 ${pageLines}
 </wiki_pages>`)
@@ -743,6 +813,7 @@ Memory files:
 - Today's daily file: ${path.join(dir, 'daily', `${today}.md`)}
 - User profiles directory: ${path.join(dir, 'users/')}
 - Wiki pages directory: ${path.join(dir, 'wiki/')}
+- Sources directory (immutable raw material): ${path.join(dir, 'sources/')}
 
 Config files:
 - AGENTS.md (agent rules): ${path.join(cfgDir, 'AGENTS.md')}

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -166,6 +166,7 @@ The memory system has several tiers. Each piece of information should live in ex
 | MEMORY.md | Long-term core memory: learned lessons, recurring patterns, technical notes |
 | users/*.md | Per-user profiles: name, preferences, communication style, work context |
 | wiki/*.md | Wiki pages: project notes, concepts, architecture, key decisions, references |
+| sources/**/*.md | Immutable raw source material (articles, transcripts, papers). Never edited, only added to. Wiki pages cite these. |
 | daily/*.md | Ephemeral daily logs (source for consolidation, never modified) |
 
 ## What to promote to MEMORY.md
@@ -194,6 +195,21 @@ The memory system has several tiers. Each piece of information should live in ex
 - Create a new wiki page when a previously unknown project or concept is discussed repeatedly
 - For wiki page conventions (frontmatter, filenames, cross-links), load the wiki skill
 
+## What to archive under sources/ (immutable raw material)
+
+The \`sources/\` directory is the raw material the wiki is distilled from. Unlike
+wiki pages, source files are **never edited** — only added to. Wiki pages cite
+source files so their factual claims stay verifiable.
+
+- Archive an external source whenever you ingest substantive new material: an article, a YouTube transcript, a podcast note, a paper, a long conversation snippet worth preserving verbatim.
+- Layout: \`sources/articles/\`, \`sources/youtube/\`, \`sources/podcasts/\`, \`sources/papers/\`, \`sources/notes/\`. Create subfolders on first use.
+- Filename: \`<yyyy-mm-dd>-<slug>.md\` (lowercase, hyphens).
+- Frontmatter keys: \`source_type\`, \`url\`, \`author\`, \`captured\`.
+- Body is the raw captured text — do not interpret or summarize in the source file.
+- The corresponding wiki page should add a \`## Sources\` (or \`## Quellen\`) section linking to the archived file.
+- Do NOT archive trivial conversation context, one-off chats, or material already captured elsewhere.
+- Never rewrite an existing source file. If a source changes, add a new dated entry.
+
 ## What to ignore
 
 - One-off questions with no lasting value
@@ -211,6 +227,21 @@ The memory system has several tiers. Each piece of information should live in ex
 - **Preserve structure**: Keep existing markdown structure. Add new sections if needed.
 - **Be concise**: Use bullet points and short descriptions. Core memory should be scannable.
 - **Daily files are read-only**: Never modify daily log files — they are append-only source material.
+- **Sources are read-only**: Never modify files under \`sources/\` — they are the immutable archival layer.
+
+## Wiki lint: content gaps and source coverage
+
+During consolidation, also run these two checks on the wiki and report findings
+(append to today's daily file as a short lint section, do not auto-create pages):
+
+- **Content gaps** — surface topics the wiki implies but does not cover:
+  - Concepts, people, projects, or tools referenced repeatedly across multiple wiki pages but without a dedicated page of their own.
+  - Open questions or TODO markers inside wiki pages ("unclear", "to verify", "TODO").
+  - Topics discussed across multiple daily files but never promoted to the wiki.
+  - Report as suggestions. Do NOT auto-create pages — the user decides what to research next.
+- **Source coverage** — keep factual claims verifiable:
+  - Wiki pages that make factual claims (dates, numbers, quotes, attributed statements) but have no \`## Sources\` / \`## Quellen\` section → flag them.
+  - Files in \`sources/\` that are not cited by any wiki page → flag as orphaned source (either stale raw material or a candidate for ingest).
 `
 
 

--- a/packages/web-backend/src/memory-consolidation-scheduler.ts
+++ b/packages/web-backend/src/memory-consolidation-scheduler.ts
@@ -61,6 +61,8 @@ All file paths below are ABSOLUTE paths. You MUST use the full absolute paths wh
 - \`${memoryDir}/users/*.md\` — user-specific information (preferences, context, personal details)
 - \`${memoryDir}/wiki/*.md\` — wiki pages: project notes, concepts, architecture, references
 
+\`${memoryDir}/sources/**/*.md\` is the immutable raw-material layer. Consolidation READS from it when auditing the wiki but NEVER writes, edits, or deletes source files.
+
 You must NOT write to any other file. No config files, no code files, no files outside the memory directory.
 
 ## Steps
@@ -87,6 +89,8 @@ You must NOT write to any other file. No config files, no code files, no files o
    - Identify orphaned pages (no inbound links from other wiki pages)
    - Suggest missing cross-links (concepts mentioned in pages but without their own page)
    - Note outdated information that should be refreshed
+   - **Content gaps**: surface concepts referenced repeatedly across wiki pages but without a dedicated page; open questions / TODO markers inside pages; topics discussed across multiple daily files but never promoted to the wiki. Report as suggestions — do NOT auto-create pages.
+   - **Source coverage**: flag wiki pages that make factual claims but have no \`## Sources\` / \`## Quellen\` section. Flag files under \`${memoryDir}/sources/\` that are not cited by any wiki page (orphaned source or candidate for ingest).
    - If any issues are found, append a brief Lint Report section to today's daily file at \`${memoryDir}/daily/\` using \`edit_file\` or \`shell\` with \`echo\`
    - Keep the lint report concise — a bullet list of findings is sufficient
 


### PR DESCRIPTION
## Problem

Wiki pages currently make factual claims without a traceable trail back to their sources, and the nightly consolidation lint does not surface content gaps the wiki implies but does not cover (concepts referenced repeatedly with no dedicated page, open questions, un-promoted daily topics). Together these limit the Karpathy-style "LLM compiles a verifiable knowledge base" pattern the wiki is modelled after.

## Change

- **Immutable `sources/` layer** alongside `wiki/` for raw source material (articles, YouTube transcripts, papers, podcast notes, long conversation snippets).
  - `ensureSourcesDir()` creates `memory/sources/` and seeds a README on first run. Idempotent — will not overwrite user edits.
  - Subfolders (`articles/`, `youtube/`, `podcasts/`, `papers/`, `notes/`) are created on first use, not up front.
  - Filename pattern `<yyyy-mm-dd>-<slug>.md`, frontmatter keys `source_type`, `url`, `author`, `captured`.
- **`CONSOLIDATION.md` template + nightly consolidation prompt** expanded with two new lint checks:
  - *Content gaps* — concepts referenced repeatedly across wiki pages without a dedicated page; TODO/open-question markers; topics discussed across daily files but never promoted. Reported as suggestions, never auto-created.
  - *Source coverage* — wiki pages that make factual claims but have no `## Sources` / `## Quellen` section → flag; `sources/` files not cited by any wiki page → flag as orphaned or candidate for ingest.
- **`assembleSystemPrompt`** now exposes the sources path in `<memory_paths>` and notes the layer briefly in `<wiki_pages>`.
- **Wiki skill (`data/skills_agent/wiki/SKILL.md`)** updated to match: new *Three-Layer Architecture* table, Ingest operation archives raw material under `sources/` first and requires a `## Sources` citation section, Lint operation adds content-gap and source-coverage steps and an expanded report template.

## Testing

- Added three unit tests in `packages/core/src/memory.test.ts`:
  - `ensureMemoryStructure` creates `sources/` and its README.
  - `ensureSourcesDir` is idempotent and does not overwrite a user-edited README.
  - `assembleSystemPrompt` output contains the Sources directory in `<memory_paths>`.
- `vitest run packages/core/src/memory.test.ts`: 61/61 pass.
- Full suite (`npm test`) shows the same 35 pre-existing failures in `packages/web-backend/src/app.test.ts` (auth-cookie flakiness, unrelated to this change) with 3 more tests passing than baseline; no new failures introduced.

## Not included

- No subfolder scaffolding under `sources/` — intentional, to keep the layer lazy.
- No frontend changes, no lockfile changes, no refactors outside the two features.

## Inspired by

- Karpathy's LLM-Wiki pattern
- AI Maker Lab, "LLM-Wiki: Obsidian Knowledge Base à la Andrej Karpathy" — https://open.substack.com/pub/aimaker/p/llm-wiki-obsidian-knowledge-base-andrej-karphaty
