### PR TITLE
feat(memory): instruct agent to maintain wiki autonomously

### DIFF
--- a/packages/core/src/memory.test.ts
+++ b/packages/core/src/memory.test.ts
@@ -423,6 +423,8 @@ describe('memory', () => {
       expect(prompt).toContain('OpenAgent')
       expect(prompt).toContain('open-agent')
       expect(prompt).toContain('load it with read_file')
+      expect(prompt).toContain('Maintain and organize it autonomously')
+      expect(prompt).toContain('genuine contradiction')
       expect(prompt).toContain('</wiki_pages>')
     })
 

--- a/packages/core/src/memory.test.ts
+++ b/packages/core/src/memory.test.ts
@@ -424,6 +424,7 @@ describe('memory', () => {
       expect(prompt).toContain('open-agent')
       expect(prompt).toContain('load it with read_file')
       expect(prompt).toContain('Maintain and organize it autonomously')
+      expect(prompt).toContain('wiki/SKILL.md')
       expect(prompt).toContain('genuine contradiction')
       expect(prompt).toContain('</wiki_pages>')
     })

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -823,7 +823,9 @@ ${dailyContext}
       return `- ${n.filename}${aliasStr}`
     }).join('\n')
     sections.push(`<wiki_pages>
-The following wiki pages are available in the personal knowledge base. When discussing a topic covered by a wiki page, load it with read_file for context. Use write_file or edit_file to create or update wiki pages when you learn something worth preserving. Raw source material for the wiki lives under sources/ — wiki pages can cite it in a ## Sources section.
+The wiki is the agent's structured knowledge base. Maintain and organize it autonomously: add new pages, extend existing ones, merge duplicates, fix stale entries, and keep cross-links healthy without asking for permission. When discussing a topic covered by a wiki page, load it with read_file for context. Use write_file or edit_file to create or update wiki pages when you learn something worth preserving. Raw source material for the wiki lives under sources/ — wiki pages can cite it in a ## Sources section.
+
+Only ask the user when you hit a genuine contradiction (new information conflicts with an existing page) that you cannot resolve on your own — then present the options (A vs. B) and let the user decide. Routine edits, additions, and reorganization do not require confirmation.
 
 ${pageLines}
 </wiki_pages>`)

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -825,6 +825,8 @@ ${dailyContext}
     sections.push(`<wiki_pages>
 The wiki is the agent's structured knowledge base. Maintain and organize it autonomously: add new pages, extend existing ones, merge duplicates, fix stale entries, and keep cross-links healthy without asking for permission. When discussing a topic covered by a wiki page, load it with read_file for context. Use write_file or edit_file to create or update wiki pages when you learn something worth preserving. Raw source material for the wiki lives under sources/ — wiki pages can cite it in a ## Sources section.
 
+For non-trivial wiki work (ingesting a new source, creating a new page, running a lint pass, or auditing structure), load the built-in \`wiki\` agent skill first by reading ${options?.agentSkillsDir ?? '/data/skills_agent'}/wiki/SKILL.md — it contains the canonical conventions (frontmatter, filenames, cross-links, ## Sources/Quellen) and the ingest/query/lint workflows.
+
 Only ask the user when you hit a genuine contradiction (new information conflicts with an existing page) that you cannot resolve on your own — then present the options (A vs. B) and let the user decide. Routine edits, additions, and reorganization do not require confirmation.
 
 ${pageLines}


### PR DESCRIPTION
## Problem

The <wiki_pages> system-prompt block tells the agent where the wiki lives and that it may update pages, but it doesn't frame the wiki as a structured knowledge base the agent is responsible for. In practice the agent often asks for permission before adding, extending, or reorganizing pages — even for routine, non-destructive edits.

## Change

Expand the <wiki_pages> block in `packages/core/src/memory.ts` with two short paragraphs:

1. Frame the wiki as the agent's structured knowledge base and make autonomous maintenance explicit (add/extend/merge pages, fix stale entries, keep cross-links healthy — no permission needed).
2. Define the one case that still requires user input: a genuine contradiction between new information and an existing page that the agent cannot resolve on its own. In that case the agent presents a concrete A vs. B choice.

Routine edits, additions, and reorganization no longer require confirmation.

## Testing

- `npx vitest run packages/core/src/memory.test.ts` — 61 passed
- Existing `wiki_pages section` test extended to assert the two new phrases.