### PR TITLE
feat(core): add send_file_to_user tool for agent-to-user files

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -265,6 +265,18 @@ export class AgentCore {
   }
 
   /**
+   * Returns the numeric user id of the user currently being served (set
+   * during `processUserMessage`/`processTaskInjection`). Tools that need to
+   * attribute side-effects (uploads, notifications, ...) to a concrete user
+   * consume this via the same indirection used by AgentRuntime.
+   *
+   * Returns `undefined` outside an active turn.
+   */
+  getCurrentToolUserId(): number | undefined {
+    return this.currentToolUserId
+  }
+
+  /**
    * Process a task injection by sending it through the runtime boundary.
    *
    * The injection is logged under the target user's active interactive

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -210,6 +210,8 @@ export { createTaskTool, createResumeTaskTool, listTasksTool } from './task-tool
 export type { TaskToolsOptions } from './task-tools.js'
 export { createReadChatHistoryTool } from './chat-history-tools.js'
 export type { ChatHistoryToolsOptions } from './chat-history-tools.js'
+export { createSendFileTool, extractUploadsFromToolResult } from './send-file-tool.js'
+export type { SendFileToolOptions, SendFileToolDetails } from './send-file-tool.js'
 export {
   searchMemories,
   listMemories,

--- a/packages/core/src/send-file-tool.test.ts
+++ b/packages/core/src/send-file-tool.test.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AgentTool } from '@mariozechner/pi-agent-core'
+import { createSendFileTool, extractUploadsFromToolResult } from './send-file-tool.js'
+import type { UploadDescriptor } from './uploads.js'
+
+function textOf(result: Awaited<ReturnType<AgentTool['execute']>>): string {
+  if (!result || !('content' in result)) return ''
+  const content = (result as { content: { type: string; text?: string }[] }).content
+  return content.filter(c => c.type === 'text').map(c => c.text ?? '').join('')
+}
+
+function detailsOf(result: Awaited<ReturnType<AgentTool['execute']>>): Record<string, unknown> {
+  if (!result || !('details' in result)) return {}
+  return (result as { details: Record<string, unknown> }).details
+}
+
+describe('send_file_to_user tool', () => {
+  let dataDir: string
+  let workspaceDir: string
+  let originalEnv: { DATA_DIR?: string; WORKSPACE_DIR?: string }
+
+  beforeEach(() => {
+    originalEnv = { DATA_DIR: process.env.DATA_DIR, WORKSPACE_DIR: process.env.WORKSPACE_DIR }
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openagent-send-file-'))
+    workspaceDir = path.join(dataDir, 'workspace')
+    fs.mkdirSync(workspaceDir, { recursive: true })
+    fs.mkdirSync(path.join(dataDir, 'uploads'), { recursive: true })
+    process.env.DATA_DIR = dataDir
+    process.env.WORKSPACE_DIR = workspaceDir
+  })
+
+  afterEach(() => {
+    process.env.DATA_DIR = originalEnv.DATA_DIR
+    process.env.WORKSPACE_DIR = originalEnv.WORKSPACE_DIR
+    fs.rmSync(dataDir, { recursive: true, force: true })
+  })
+
+  it('refuses to run without an active user (background context)', async () => {
+    const tool = createSendFileTool({ getCurrentToolUserId: () => undefined })
+    fs.writeFileSync(path.join(workspaceDir, 'a.txt'), 'hi')
+
+    const result = await tool.execute('call-1', { path: 'a.txt' })
+
+    expect(textOf(result)).toMatch(/background contexts/i)
+    expect(detailsOf(result)).toMatchObject({ error: true })
+  })
+
+  it('fails cleanly when the file does not exist', async () => {
+    const tool = createSendFileTool({ getCurrentToolUserId: () => 1 })
+    const result = await tool.execute('call-2', { path: 'missing.txt' })
+    expect(textOf(result)).toMatch(/file not found/i)
+    expect(detailsOf(result)).toMatchObject({ error: true })
+  })
+
+  it('rejects directories', async () => {
+    const tool = createSendFileTool({ getCurrentToolUserId: () => 1 })
+    const result = await tool.execute('call-3', { path: workspaceDir })
+    expect(textOf(result)).toMatch(/not a regular file/i)
+    expect(detailsOf(result)).toMatchObject({ error: true })
+  })
+
+  it('rejects empty files', async () => {
+    const tool = createSendFileTool({ getCurrentToolUserId: () => 1 })
+    const filePath = path.join(workspaceDir, 'empty.txt')
+    fs.writeFileSync(filePath, '')
+    const result = await tool.execute('call-4', { path: filePath })
+    expect(textOf(result)).toMatch(/is empty/i)
+    expect(detailsOf(result)).toMatchObject({ error: true })
+  })
+
+  it('saves an upload and returns an UploadDescriptor in details', async () => {
+    const tool = createSendFileTool({
+      getCurrentToolUserId: () => 42,
+      getCurrentInteractiveSessionId: () => 'session-abc',
+    })
+    fs.writeFileSync(path.join(workspaceDir, 'report.md'), '# Report\n')
+
+    const result = await tool.execute('call-5', { path: 'report.md' })
+
+    const details = detailsOf(result) as { uploadedFile?: UploadDescriptor; error?: boolean }
+    expect(details.error).toBeFalsy()
+    expect(details.uploadedFile).toBeDefined()
+    const upload = details.uploadedFile!
+    expect(upload.kind).toBe('file')
+    expect(upload.originalName).toBe('report.md')
+    expect(upload.mimeType).toMatch(/text\/markdown/)
+    expect(upload.urlPath).toMatch(/^\/api\/uploads\//)
+    expect(upload.size).toBeGreaterThan(0)
+
+    // Ensure the copied file actually lives in the uploads dir
+    const copiedPath = path.join(dataDir, 'uploads', upload.relativePath)
+    expect(fs.existsSync(copiedPath)).toBe(true)
+    expect(fs.readFileSync(copiedPath, 'utf8')).toBe('# Report\n')
+  })
+
+  it('honours the optional filename param as display name', async () => {
+    const tool = createSendFileTool({ getCurrentToolUserId: () => 1 })
+    fs.writeFileSync(path.join(workspaceDir, 'abc123-tmp.dat'), 'hello')
+
+    const result = await tool.execute('call-6', {
+      path: 'abc123-tmp.dat',
+      filename: 'Greeting.txt',
+    })
+
+    const details = detailsOf(result) as { uploadedFile?: UploadDescriptor }
+    expect(details.uploadedFile?.originalName).toBe('Greeting.txt')
+    // Mime type is derived from the display name extension, not the stored name
+    expect(details.uploadedFile?.mimeType).toMatch(/text\/plain/)
+  })
+
+  it('detects image kind from extension', async () => {
+    const tool = createSendFileTool({ getCurrentToolUserId: () => 1 })
+    const pngPath = path.join(workspaceDir, 'dot.png')
+    // Minimal 1x1 PNG
+    const pngHeader = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      // IHDR chunk
+      0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+      0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+    ])
+    fs.writeFileSync(pngPath, pngHeader)
+
+    const result = await tool.execute('call-7', { path: pngPath })
+    const details = detailsOf(result) as { uploadedFile?: UploadDescriptor }
+    expect(details.uploadedFile?.kind).toBe('image')
+    expect(details.uploadedFile?.mimeType).toBe('image/png')
+  })
+
+  it('threads caption through to details', async () => {
+    const tool = createSendFileTool({ getCurrentToolUserId: () => 1 })
+    fs.writeFileSync(path.join(workspaceDir, 'f.txt'), 'x')
+
+    const result = await tool.execute('call-8', {
+      path: 'f.txt',
+      caption: '  Q3 results  ',
+    })
+    const details = detailsOf(result) as { caption?: string }
+    expect(details.caption).toBe('Q3 results')
+  })
+})
+
+describe('extractUploadsFromToolResult', () => {
+  const sample: UploadDescriptor = {
+    kind: 'file',
+    originalName: 'a.txt',
+    storedName: 'xyz-a.txt',
+    relativePath: '2025/04/20/xyz-a.txt',
+    urlPath: '/api/uploads/2025/04/20/xyz-a.txt',
+    mimeType: 'text/plain',
+    size: 4,
+  }
+
+  it('returns [] for undefined / non-object inputs', () => {
+    expect(extractUploadsFromToolResult(undefined)).toEqual([])
+    expect(extractUploadsFromToolResult(null)).toEqual([])
+    expect(extractUploadsFromToolResult('nope')).toEqual([])
+    expect(extractUploadsFromToolResult({})).toEqual([])
+    expect(extractUploadsFromToolResult({ details: null })).toEqual([])
+  })
+
+  it('extracts uploadedFile', () => {
+    const result = extractUploadsFromToolResult({ details: { uploadedFile: sample } })
+    expect(result).toEqual([sample])
+  })
+
+  it('extracts uploadedFiles array', () => {
+    const second = { ...sample, relativePath: 'b', urlPath: '/api/uploads/b', originalName: 'b.txt' }
+    const result = extractUploadsFromToolResult({
+      details: { uploadedFiles: [sample, second, { not: 'a descriptor' }] },
+    })
+    expect(result).toHaveLength(2)
+    expect(result[0]?.relativePath).toBe(sample.relativePath)
+    expect(result[1]?.relativePath).toBe('b')
+  })
+
+  it('de-duplicates by relativePath', () => {
+    const result = extractUploadsFromToolResult({
+      details: { uploadedFile: sample, uploadedFiles: [sample] },
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('ignores malformed entries silently', () => {
+    const result = extractUploadsFromToolResult({
+      details: { uploadedFile: { kind: 'file' /* missing required fields */ } },
+    })
+    expect(result).toEqual([])
+  })
+})

--- a/packages/core/src/send-file-tool.ts
+++ b/packages/core/src/send-file-tool.ts
@@ -1,0 +1,304 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { AgentTool } from '@mariozechner/pi-agent-core'
+import { Type } from '@mariozechner/pi-ai'
+import { saveUpload, type UploadDescriptor } from './uploads.js'
+import { getWorkspaceDir } from './workspace.js'
+
+/**
+ * Options for the `send_file_to_user` tool.
+ *
+ * The tool needs to know which user and session the file belongs to so that
+ * downstream channels (ws-chat, telegram-bot) can correlate the generated
+ * {@link UploadDescriptor} with the active conversation. Both getters are
+ * expected to return `undefined`/`null` when invoked from a background
+ * context (tasks, heartbeats, etc.) — in that case the tool refuses to run
+ * because there is no user to deliver the file to.
+ */
+export interface SendFileToolOptions {
+  /** Resolve the current user id (numeric, matches `users.id`). */
+  getCurrentToolUserId: () => number | undefined
+  /** Resolve the currently active interactive session id, if any. */
+  getCurrentInteractiveSessionId?: () => string | null
+}
+
+/**
+ * Payload attached to a `send_file_to_user` tool result so channels can
+ * generically pick up the uploaded file without sniffing for specific tool
+ * names.
+ *
+ * Channel layers should check `toolResult.details.uploadedFile` (single) or
+ * `toolResult.details.uploadedFiles` (array) on every `tool_call_end` chunk.
+ * Other tools may populate this field in the future to deliver files too.
+ */
+export interface SendFileToolDetails {
+  uploadedFile?: UploadDescriptor
+  uploadedFiles?: UploadDescriptor[]
+  caption?: string
+  error?: boolean
+}
+
+/**
+ * Very small extension → MIME map. Kept local (not pulled from a dependency)
+ * because the set of file types agents realistically produce is tiny and we
+ * want zero dependency creep. Falls through to `application/octet-stream`
+ * for unknown extensions, which is fine for downloads.
+ */
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.json': 'application/json',
+  '.yaml': 'application/yaml',
+  '.yml': 'application/yaml',
+  '.csv': 'text/csv; charset=utf-8',
+  '.tsv': 'text/tab-separated-values; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.htm': 'text/html; charset=utf-8',
+  '.xml': 'application/xml',
+  '.log': 'text/plain; charset=utf-8',
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.tar': 'application/x-tar',
+  '.gz': 'application/gzip',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+}
+
+function guessMimeType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase()
+  return MIME_BY_EXTENSION[ext] ?? 'application/octet-stream'
+}
+
+/** Maximum size (bytes) a single agent-produced file may have. Matches the
+ *  user upload limit (see `web-backend/src/uploads.ts`). */
+const MAX_FILE_SIZE = 50 * 1024 * 1024
+
+/**
+ * Resolve `inputPath` against the workspace dir (same semantics as the
+ * `read_file`/`write_file` YOLO tools). Returns an absolute path.
+ */
+function resolvePath(inputPath: string): string {
+  if (path.isAbsolute(inputPath)) return inputPath
+  return path.resolve(getWorkspaceDir(), inputPath)
+}
+
+function formatBytes(size: number): string {
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/**
+ * Create the `send_file_to_user` agent tool.
+ *
+ * The agent calls this tool with a path to an existing file (typically one
+ * it just wrote via `shell`/`write_file` into the workspace). The tool:
+ *   1. Reads the file from disk.
+ *   2. Copies it into the uploads dir via {@link saveUpload}, producing a
+ *      stable, sandboxed URL served by `/api/uploads/...`.
+ *   3. Returns a tool result whose `details.uploadedFile` holds the
+ *      {@link UploadDescriptor}. The channel layers (`ws-chat`, telegram
+ *      bot) watch for this field and deliver the file through their
+ *      transport.
+ *
+ * The tool itself does NOT talk to any channel. Delivery is a channel-layer
+ * concern (same architectural split as user uploads).
+ */
+export function createSendFileTool(options: SendFileToolOptions): AgentTool {
+  return {
+    name: 'send_file_to_user',
+    label: 'Send File to User',
+    description:
+      'Send a file to the current user via their active channel (web chat or Telegram). ' +
+      'The file must already exist on disk — typically one you created with shell or write_file ' +
+      'inside the workspace. The user will see a download button / attachment card for the file ' +
+      'on your assistant message; on Telegram, the file is delivered as a document (or photo for images). ' +
+      'Use this to deliver generated reports, exported data, rendered images, compiled archives, etc. ' +
+      'Do NOT use this for large model outputs that fit in a normal chat reply — only for actual files.',
+    parameters: Type.Object({
+      path: Type.String({
+        description:
+          'Absolute path to the file to send, or a path relative to the workspace dir. ' +
+          'The file must exist and be readable. Max size: 50 MB.',
+      }),
+      filename: Type.Optional(
+        Type.String({
+          description:
+            'Optional display name shown to the user. Defaults to the basename of `path`. ' +
+            'Use this to give a hashed/temporary file a human-friendly name (e.g. "report.pdf").',
+        }),
+      ),
+      caption: Type.Optional(
+        Type.String({
+          description:
+            'Optional short caption describing the file (1–2 sentences). Shown by some channels ' +
+            '(e.g. Telegram) next to the file. If omitted, the file is delivered without a caption.',
+        }),
+      ),
+    }),
+    execute: async (_toolCallId, params) => {
+      const { path: inputPath, filename, caption } = params as {
+        path: string
+        filename?: string
+        caption?: string
+      }
+
+      const userId = options.getCurrentToolUserId()
+      if (userId === undefined) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'Error: send_file_to_user cannot be used in background contexts (no active user).',
+          }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      const sessionId = options.getCurrentInteractiveSessionId?.() ?? null
+
+      let absolutePath: string
+      try {
+        absolutePath = resolvePath(inputPath)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: `Error: failed to resolve path "${inputPath}": ${message}` }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      let stat: fs.Stats
+      try {
+        stat = fs.statSync(absolutePath)
+      } catch {
+        return {
+          content: [{ type: 'text' as const, text: `Error: file not found at "${absolutePath}".` }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      if (!stat.isFile()) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: "${absolutePath}" is not a regular file.` }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      if (stat.size === 0) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: file "${absolutePath}" is empty.` }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      if (stat.size > MAX_FILE_SIZE) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error: file too large (${formatBytes(stat.size)}). Max allowed: ${formatBytes(MAX_FILE_SIZE)}.`,
+          }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      let buffer: Buffer
+      try {
+        buffer = fs.readFileSync(absolutePath)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: `Error reading "${absolutePath}": ${message}` }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      const displayName = filename?.trim() || path.basename(absolutePath)
+      const mimeType = guessMimeType(displayName)
+
+      let uploaded: UploadDescriptor
+      try {
+        uploaded = saveUpload({
+          buffer,
+          originalName: displayName,
+          mimeType,
+          // `source` is an advisory hint only (saveUpload doesn't persist it).
+          // The delivery channel is determined dynamically at chunk time by
+          // ws-chat / telegram-bot from the assistant's response context.
+          source: 'web',
+          userId,
+          sessionId,
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          content: [{ type: 'text' as const, text: `Error storing upload: ${message}` }],
+          details: { error: true } satisfies SendFileToolDetails,
+        }
+      }
+
+      const details: SendFileToolDetails = {
+        uploadedFile: uploaded,
+        caption: caption?.trim() || undefined,
+      }
+
+      const summary = `File prepared for delivery: ${uploaded.originalName} (${formatBytes(uploaded.size)}). ` +
+        `The user sees a download card on this turn.`
+
+      return {
+        content: [{ type: 'text' as const, text: summary }],
+        details,
+      }
+    },
+  }
+}
+
+/**
+ * Channel-layer helper: extract any uploads attached to a tool result.
+ *
+ * Looks at `toolResult.details.uploadedFile` (single) and
+ * `toolResult.details.uploadedFiles` (array). Returns a de-duplicated list.
+ * Unknown / malformed details are silently ignored so channels can call this
+ * on every `tool_call_end` chunk without guarding themselves.
+ */
+export function extractUploadsFromToolResult(toolResult: unknown): UploadDescriptor[] {
+  if (!toolResult || typeof toolResult !== 'object') return []
+  const details = (toolResult as { details?: unknown }).details
+  if (!details || typeof details !== 'object') return []
+  const d = details as { uploadedFile?: unknown; uploadedFiles?: unknown }
+
+  const out: UploadDescriptor[] = []
+  if (isUploadDescriptor(d.uploadedFile)) out.push(d.uploadedFile)
+  if (Array.isArray(d.uploadedFiles)) {
+    for (const entry of d.uploadedFiles) {
+      if (isUploadDescriptor(entry)) out.push(entry)
+    }
+  }
+
+  // De-duplicate by relativePath
+  const seen = new Set<string>()
+  return out.filter(u => {
+    if (seen.has(u.relativePath)) return false
+    seen.add(u.relativePath)
+    return true
+  })
+}
+
+function isUploadDescriptor(value: unknown): value is UploadDescriptor {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Partial<UploadDescriptor>
+  return typeof v.relativePath === 'string'
+    && typeof v.urlPath === 'string'
+    && typeof v.originalName === 'string'
+    && typeof v.mimeType === 'string'
+    && typeof v.size === 'number'
+    && (v.kind === 'image' || v.kind === 'file')
+}

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { Bot, GrammyError, HttpError, InputFile } from 'grammy'
 import type { Context } from 'grammy'
 import type { AgentCore, Database } from '@openagent/core'
-import { loadConfig, saveUpload, serializeUploadsMetadata, parseUploadsMetadata, loadSttSettings, transcribeAudio } from '@openagent/core'
+import { loadConfig, saveUpload, serializeUploadsMetadata, parseUploadsMetadata, loadSttSettings, transcribeAudio, extractUploadsFromToolResult } from '@openagent/core'
 import type { UploadDescriptor } from '@openagent/core'
 
 /**
@@ -22,7 +22,7 @@ export interface TelegramConfig {
  * Chat event emitted by the Telegram bot for cross-channel sync.
  */
 export interface TelegramChatEvent {
-  type: 'user_message' | 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error'
+  type: 'user_message' | 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error' | 'attachment'
   /** OpenAgent user ID (integer) — only set for linked users */
   userId: number | null
   /** Session ID used for chat_messages */
@@ -43,6 +43,8 @@ export interface TelegramChatEvent {
   toolIsError?: boolean
   /** Display name of the sender */
   senderName?: string
+  /** Uploaded file attached to the current assistant turn (for type='attachment') */
+  attachment?: UploadDescriptor
 }
 
 export interface TelegramBotOptions {
@@ -850,7 +852,15 @@ export class TelegramBot {
 
       // Collect the full response from agent
       let fullResponse = ''
-      let assistantUploads = [] as ReturnType<typeof parseUploadsMetadata>
+      // Uploads produced by tools during this turn (e.g. `send_file_to_user`).
+      // These are:
+      //   1. delivered to the Telegram chat as documents/photos right after
+      //      the text response (see sendAssistantResponseToTelegram),
+      //   2. merged into the saved assistant message's metadata so history
+      //      rehydration surfaces them alongside the text,
+      //   3. broadcast as `attachment` chat events so concurrently connected
+      //      web tabs render the same download card.
+      const assistantUploads: UploadDescriptor[] = []
       // Track pending tool calls to save input+output together
       const pendingToolCalls = new Map<string, { toolName: string; toolArgs: unknown }>()
 
@@ -881,20 +891,36 @@ export class TelegramBot {
           }
 
           // Save completed tool call to DB
-          if (chunk.type === 'tool_call_end' && chunk.toolCallId && this.db && numericUserId) {
+          if (chunk.type === 'tool_call_end' && chunk.toolCallId) {
             const pending = pendingToolCalls.get(chunk.toolCallId)
             const toolName = pending?.toolName ?? chunk.toolName ?? 'unknown'
-            const metadata = JSON.stringify({
-              toolName,
-              toolCallId: chunk.toolCallId,
-              toolArgs: pending?.toolArgs ?? null,
-              toolResult: chunk.toolResult ?? null,
-              toolIsError: chunk.toolIsError ?? false,
-            })
-            this.db.prepare(
-              'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
-            ).run(sessionId, numericUserId, 'tool', `Tool: ${toolName}`, metadata)
+            if (this.db && numericUserId) {
+              const metadata = JSON.stringify({
+                toolName,
+                toolCallId: chunk.toolCallId,
+                toolArgs: pending?.toolArgs ?? null,
+                toolResult: chunk.toolResult ?? null,
+                toolIsError: chunk.toolIsError ?? false,
+              })
+              this.db.prepare(
+                'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
+              ).run(sessionId, numericUserId, 'tool', `Tool: ${toolName}`, metadata)
+            }
             pendingToolCalls.delete(chunk.toolCallId)
+
+            // Harvest uploads produced by the tool (generic, not tool-name
+            // specific) and fan them out to cross-channel listeners so
+            // any concurrently-connected web tab also shows the card.
+            const newUploads = extractUploadsFromToolResult(chunk.toolResult)
+            for (const upload of newUploads) {
+              assistantUploads.push(upload)
+              this.onChatEvent?.({
+                type: 'attachment',
+                userId: numericUserId,
+                sessionId,
+                attachment: upload,
+              })
+            }
           }
 
           // Broadcast response chunks for cross-channel sync
@@ -915,29 +941,21 @@ export class TelegramBot {
         clearInterval(typingInterval)
       }
 
-      if (this.db && numericUserId) {
-        const latestAssistant = this.db.prepare(
-          `SELECT content, metadata
-           FROM chat_messages
-           WHERE user_id = ? AND role = 'assistant'
-           ORDER BY id DESC
-           LIMIT 1`
-        ).get(numericUserId) as { content: string; metadata: string | null } | undefined
-
-        if (latestAssistant && latestAssistant.content === fullResponse.trim()) {
-          assistantUploads = parseUploadsMetadata(latestAssistant.metadata)
-        }
-      }
-
       if (!state.abortRequested && (fullResponse.trim() || assistantUploads.length > 0)) {
         await this.sendAssistantResponseToTelegram(ctx.chat!.id, fullResponse, assistantUploads)
       }
 
-      // Save assistant response to chat_messages (if linked to a web user)
-      if (this.db && numericUserId && fullResponse.trim()) {
+      // Save assistant response to chat_messages (if linked to a web user).
+      // Text-only responses get a plain row; if the turn also produced
+      // attachments we persist them in metadata so history rehydration
+      // surfaces the download card alongside the text.
+      if (this.db && numericUserId && (fullResponse.trim() || assistantUploads.length > 0)) {
+        const metadata = assistantUploads.length > 0
+          ? serializeUploadsMetadata(assistantUploads)
+          : null
         this.db.prepare(
-          'INSERT INTO chat_messages (session_id, user_id, role, content) VALUES (?, ?, ?, ?)'
-        ).run(sessionId, numericUserId, 'assistant', fullResponse.trim())
+          'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
+        ).run(sessionId, numericUserId, 'assistant', fullResponse.trim(), metadata)
       }
     } catch (err) {
       if (state.abortRequested) {

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -5,6 +5,7 @@ import {
   createBaseAgentTools,
   createCronjobTool,
   createReminderTool,
+  createSendFileTool,
   createResumeTaskTool,
   createTaskRuntime,
   createTaskTool,
@@ -727,6 +728,16 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
     listCronjobsTool(cronjobToolsOptions),
     getCronjobTool(cronjobToolsOptions),
     createReminderTool(cronjobToolsOptions),
+    // `send_file_to_user` needs late-bound access to the active turn's user
+    // id and interactive session id — both are set on `agentCore` at the
+    // start of every `processUserMessage`/`processTaskInjection` call.
+    // Agents built without a running AgentCore (e.g. background task
+    // runner) never invoke this tool because its `getCurrentToolUserId`
+    // returns `undefined` and the tool refuses to run.
+    createSendFileTool({
+      getCurrentToolUserId: () => agentCore?.getCurrentToolUserId(),
+      getCurrentInteractiveSessionId: () => agentCore?.getCurrentInteractiveSessionId() ?? null,
+    }),
   ]
 
   taskRuntime.schedules.start()
@@ -764,6 +775,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
       toolResult: event.toolResult,
       toolIsError: event.toolIsError,
       senderName: event.senderName,
+      attachment: event.attachment,
     })
   }
 

--- a/packages/web-backend/src/chat-event-bus.ts
+++ b/packages/web-backend/src/chat-event-bus.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import type { UploadDescriptor } from '@openagent/core'
 
 /**
  * A chat event emitted when messages flow through any channel (web, telegram).
@@ -6,7 +7,7 @@ import { EventEmitter } from 'node:events'
  */
 export interface ChatEvent {
   /** The kind of event being broadcast */
-  type: 'user_message' | 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error' | 'system' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder'
+  type: 'user_message' | 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error' | 'system' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder' | 'attachment'
   /** The OpenAgent user ID (integer) this event belongs to */
   userId: number
   /** Where the event originated */
@@ -55,6 +56,8 @@ export interface ChatEvent {
   telegramDelivered?: boolean
   /** Whether this event is part of a task injection response */
   isTaskInjection?: boolean
+  /** Uploaded file attached to the current assistant turn (for type='attachment') */
+  attachment?: UploadDescriptor
 }
 
 /**

--- a/packages/web-backend/src/ws-chat.test.ts
+++ b/packages/web-backend/src/ws-chat.test.ts
@@ -263,6 +263,101 @@ describe('setupWebSocketChat kill switch', () => {
     }
   })
 
+  it('forwards uploads attached to a tool_call_end chunk as an `attachment` ws message and persists them on the assistant row', async () => {
+    const db = initDatabase(':memory:')
+    const chatEventBus = new ChatEventBus()
+    const mockSessionManager = {
+      getOrCreateSession: vi.fn(() => ({ id: 'session-file', userId: '1', source: 'web', startedAt: Date.now(), lastActivity: Date.now(), messageCount: 0, summaryWritten: false, restored: false })),
+    }
+    const uploadDescriptor = {
+      kind: 'file' as const,
+      originalName: 'report.md',
+      storedName: 'abc-report.md',
+      relativePath: '2026/04/20/abc-report.md',
+      urlPath: '/api/uploads/2026/04/20/abc-report.md',
+      mimeType: 'text/markdown',
+      size: 42,
+    }
+    const agentCore = {
+      sendMessage: vi.fn(async function* (): AsyncGenerator<ResponseChunk> {
+        yield { type: 'tool_call_start', toolName: 'send_file_to_user', toolCallId: 'tc-1', toolArgs: { path: 'report.md' } }
+        yield {
+          type: 'tool_call_end',
+          toolName: 'send_file_to_user',
+          toolCallId: 'tc-1',
+          toolResult: { details: { uploadedFile: uploadDescriptor } },
+        }
+        yield { type: 'text', text: 'Here you go.' }
+        yield { type: 'done' }
+      }),
+      abort: vi.fn(),
+      resetSession: vi.fn(),
+      getSessionManager: vi.fn(() => mockSessionManager),
+    } as unknown as AgentCore
+
+    const app = createApp({ db })
+    const server = http.createServer(app)
+    const { wss } = setupWebSocketChat(server, db, agentCore, undefined, chatEventBus)
+
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    const token = generateAccessToken({ userId: 1, username: 'admin', role: 'admin' })
+
+    const busEvents: Array<{ type: string; attachment?: unknown }> = []
+    chatEventBus.subscribe((ev) => {
+      busEvents.push({ type: ev.type, attachment: ev.attachment })
+    })
+
+    try {
+      const { ws, waitForMessage } = await connectWs(port, token)
+      await waitForMessage() // authenticated
+
+      ws.send(JSON.stringify({ type: 'message', content: 'send me the report' }))
+
+      // Drain chunks until we see both the attachment ws msg and the done.
+      const seen: string[] = []
+      let attachmentMsg: Record<string, unknown> | null = null
+      for (let i = 0; i < 20; i++) {
+        const msg = await waitForMessage()
+        seen.push(msg.type as string)
+        if (msg.type === 'attachment') attachmentMsg = msg
+        if (msg.type === 'done') break
+      }
+
+      expect(seen).toContain('attachment')
+      expect(seen).toContain('done')
+      expect(attachmentMsg?.attachment).toMatchObject({
+        relativePath: uploadDescriptor.relativePath,
+        originalName: uploadDescriptor.originalName,
+      })
+
+      // Attachment is also broadcast on the event bus for other tabs
+      const busAttachments = busEvents.filter(e => e.type === 'attachment')
+      expect(busAttachments.length).toBe(1)
+
+      // Assistant row persists the upload as metadata.files so history reload
+      // shows the download card
+      const assistantRow = db.prepare(
+        "SELECT content, metadata FROM chat_messages WHERE session_id = 'session-file' AND role = 'assistant'"
+      ).get() as { content: string; metadata: string } | undefined
+      expect(assistantRow).toBeDefined()
+      expect(assistantRow!.content).toBe('Here you go.')
+      const meta = JSON.parse(assistantRow!.metadata) as { files: Array<{ relativePath: string }> }
+      expect(meta.files).toHaveLength(1)
+      expect(meta.files[0]!.relativePath).toBe(uploadDescriptor.relativePath)
+
+      ws.close()
+    } finally {
+      for (const client of wss.clients) {
+        client.terminate()
+      }
+      wss.close()
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      )
+    }
+  })
+
   it('treats /kill as an alias for /stop over web chat', async () => {
     const db = initDatabase(':memory:')
     const mockSessionManager2 = {

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -2,6 +2,7 @@ import { WebSocketServer, WebSocket } from 'ws'
 import type { Server } from 'node:http'
 import type { Database, UploadDescriptor } from '@openagent/core'
 import type { AgentCore, ResponseChunk } from '@openagent/core'
+import { extractUploadsFromToolResult, serializeUploadsMetadata } from '@openagent/core'
 import { verifyToken } from './auth.js'
 import type { JwtPayload } from './auth.js'
 import { URL } from 'node:url'
@@ -19,8 +20,10 @@ interface ChatMessage {
 }
 
 interface ChatResponse {
-  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder' | 'pong'
+  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'reminder' | 'pong' | 'attachment'
   text?: string
+  /** Uploaded file attached to the current assistant turn (for type='attachment') */
+  attachment?: UploadDescriptor
   /** Streamed thinking delta (for type='thinking') */
   thinking?: string
   toolName?: string
@@ -301,6 +304,16 @@ export function setupWebSocketChat(
       let doneSent = false
       // Track pending tool calls to save input+output together
       const pendingToolCalls = new Map<string, { toolName: string; toolArgs: unknown }>()
+      // Collect any uploads produced by tools during this turn (e.g.
+      // `send_file_to_user`). These are:
+      //   1. streamed live to the client via `attachment` ws messages so
+      //      the download card appears next to the assistant bubble
+      //      without a reload, and
+      //   2. merged into the saved assistant message's metadata so a
+      //      history reload shows the same attachment(s).
+      // Channel-agnostic extraction (via `extractUploadsFromToolResult`)
+      // means any tool can produce files, not just the built-in sender.
+      const assistantUploads: UploadDescriptor[] = []
       // Buffer thinking deltas between thinking_start/thinking_end boundaries. Because
       // the core runtime only surfaces `thinking_delta` today, we treat each contiguous
       // run of thinking chunks (i.e. uninterrupted by text/tool/done) as a single block
@@ -366,6 +379,26 @@ export function setupWebSocketChat(
             })
             saveChatMessage(db, resolvedSessionId, currentUser.userId, 'tool', `Tool: ${toolName}`, metadata)
             pendingToolCalls.delete(chunk.toolCallId)
+
+            // Harvest any uploads produced by this tool and forward them as
+            // `attachment` events so the frontend can render them inline
+            // on the active assistant message.
+            const newUploads = extractUploadsFromToolResult(chunk.toolResult)
+            for (const upload of newUploads) {
+              assistantUploads.push(upload)
+              sendMessage(ws, { type: 'attachment', attachment: upload })
+              // Fan out to other tabs of the same user so every connected
+              // client renders the attachment, not just the one that drove
+              // the turn.
+              chatEventBus?.broadcast({
+                type: 'attachment',
+                userId: currentUser.userId,
+                source: 'web',
+                sourceConnectionId: connId,
+                sessionId: resolvedSessionId,
+                attachment: upload,
+              })
+            }
           }
 
           sendMessage(ws, chunkToResponse(chunk))
@@ -388,9 +421,22 @@ export function setupWebSocketChat(
           })
         }
 
-        // Save the full assistant response
-        if (fullResponse) {
-          saveChatMessage(db, resolvedSessionId, currentUser.userId, 'assistant', fullResponse)
+        // Save the full assistant response, including attachment metadata.
+        // If the turn produced only attachments (no text), we still persist
+        // an assistant row with empty content so the download card is
+        // recoverable on history reload.
+        if (fullResponse || assistantUploads.length > 0) {
+          const metadata = assistantUploads.length > 0
+            ? serializeUploadsMetadata(assistantUploads)
+            : undefined
+          saveChatMessage(
+            db,
+            resolvedSessionId,
+            currentUser.userId,
+            'assistant',
+            fullResponse,
+            metadata,
+          )
         }
       } catch (err) {
         if (!abortController.signal.aborted) {
@@ -484,6 +530,11 @@ export function setupWebSocketChat(
             reminderMessage: event.reminderMessage,
             reminderName: event.reminderName,
             cronjobId: event.cronjobId,
+          })
+        } else if (event.type === 'attachment') {
+          sendMessage(client, {
+            type: 'attachment',
+            attachment: event.attachment,
           })
         } else {
           sendMessage(client, {

--- a/packages/web-frontend/app/composables/useChat.ts
+++ b/packages/web-frontend/app/composables/useChat.ts
@@ -52,8 +52,10 @@ export interface ChatMessage {
 }
 
 interface WsMessage {
-  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'reminder' | 'task_completed' | 'task_failed' | 'task_question' | 'pong'
+  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'reminder' | 'task_completed' | 'task_failed' | 'task_question' | 'pong' | 'attachment'
   text?: string
+  /** Uploaded file the agent sent for the current turn (for type='attachment') */
+  attachment?: ChatAttachment
   /** Thinking delta (for type='thinking') */
   thinking?: string
   toolName?: string
@@ -460,6 +462,44 @@ export function useChat() {
       case 'pong':
         // Clear the pong-timeout so the heartbeat knows the connection is alive
         if (pongTimeout) { clearTimeout(pongTimeout); pongTimeout = null }
+        break
+
+      case 'attachment':
+        // A file sent by the agent for the current assistant turn (e.g. via
+        // the `send_file_to_user` tool). We attach it to the in-progress
+        // assistant message so the download card renders inside the bubble
+        // — same visual treatment as user-side attachments, just on the
+        // opposite side.
+        //
+        // If no assistant message is currently streaming (rare: the tool
+        // fired mid-thinking, or the model hasn't emitted text yet) we
+        // synthesize a minimal assistant bubble so the attachment still
+        // appears in the flow.
+        if (msg.attachment) {
+          const attachment = msg.attachment
+          const updated = [...messages.value]
+          const lastIdx = updated.length - 1
+          const last = lastIdx >= 0 ? updated[lastIdx]! : null
+          if (last && last.role === 'assistant' && !last.isThinking) {
+            const existing = last.attachments ?? []
+            // Guard against duplicates (e.g. if the same upload is
+            // broadcast twice by ws-chat + chatEventBus echo).
+            if (!existing.some(a => a.relativePath === attachment.relativePath)) {
+              updated[lastIdx] = { ...last, attachments: [...existing, attachment] }
+              messages.value = updated
+            }
+          } else {
+            // Close any open thinking block before inserting the new bubble.
+            const closed = closeStreamingThinking(messages.value)
+            messages.value = [...closed, {
+              role: 'assistant',
+              content: '',
+              timestamp: new Date().toISOString(),
+              streaming: true,
+              attachments: [attachment],
+            }]
+          }
+        }
         break
 
       case 'tool_call_end':


### PR DESCRIPTION
Add a new agent tool that allows the agent to send files to the current user
via web chat or Telegram. The tool reads a file from disk (workspace or
absolute path), saves it via saveUpload(), and returns an UploadDescriptor
in tool result details so channels can detect and deliver the file.

- createSendFileTool: validates path, reads file, saves upload, returns descriptor
- extractUploadsFromToolResult: generic helper for channels to detect uploads
  in any tool result (not just send_file_to_user)
- Includes comprehensive test coverage (13 tests) for validation, success paths,
  and the extraction helper