### PR TITLE
fix(tasks): merge tool_call_start and tool_call_end in view

### DIFF
--- a/packages/web-backend/src/api/modules/tasks/service.ts
+++ b/packages/web-backend/src/api/modules/tasks/service.ts
@@ -167,5 +167,12 @@ export function createTasksService(options: TasksServiceOptions): TasksService {
 
 function safeParseJson(rawValue: string | null): unknown {
   if (!rawValue) return null
-  return JSON.parse(rawValue)
+  try {
+    return JSON.parse(rawValue)
+  } catch {
+    // Historical rows may contain non-JSON metadata (legacy data, truncation,
+    // etc.). Fall back to the raw string so a single bad row doesn't break
+    // the whole timeline request.
+    return rawValue
+  }
 }

--- a/packages/web-frontend/app/features/tasks/composables/useTaskEvents.ts
+++ b/packages/web-frontend/app/features/tasks/composables/useTaskEvents.ts
@@ -16,7 +16,9 @@ export function useTaskEvents() {
   const isLive = ref(false)
 
   let ws: WebSocket | null = null
-  const pendingToolCalls = new Map<string, TaskEventItem>()
+  // Maps toolCallId -> index in `events.value` so `tool_call_end` can merge
+  // into the existing `tool_call_start` entry (same panel, like the chat view).
+  const pendingToolCalls = new Map<string, number>()
 
   const textBuffer = ref('')
 
@@ -110,15 +112,38 @@ export function useTaskEvents() {
         loading.value = false
         break
 
-      case 'tool_call_start':
-        pendingToolCalls.set((data.toolCallId as string) ?? '', data as unknown as TaskEventItem)
+      case 'tool_call_start': {
+        const toolCallId = (data.toolCallId as string) ?? ''
         events.value.push(data as unknown as TaskEventItem)
+        if (toolCallId) {
+          pendingToolCalls.set(toolCallId, events.value.length - 1)
+        }
         break
+      }
 
-      case 'tool_call_end':
-        pendingToolCalls.delete((data.toolCallId as string) ?? '')
-        events.value.push(data as unknown as TaskEventItem)
+      case 'tool_call_end': {
+        const toolCallId = (data.toolCallId as string) ?? ''
+        const existingIdx = toolCallId ? pendingToolCalls.get(toolCallId) : undefined
+        const endEvent = data as unknown as TaskEventItem
+        if (existingIdx !== undefined && events.value[existingIdx]) {
+          // Merge result into the existing start entry so it renders as a
+          // single panel with args + result, matching the chat view.
+          const existing = events.value[existingIdx]!
+          events.value[existingIdx] = {
+            ...existing,
+            ...endEvent,
+            type: 'tool_call_end',
+            // Preserve args from start in case end payload omits them.
+            toolArgs: endEvent.toolArgs ?? existing.toolArgs,
+            toolName: endEvent.toolName ?? existing.toolName,
+          }
+          pendingToolCalls.delete(toolCallId)
+        } else {
+          // No matching start (e.g. missed backlog entry) — append as-is.
+          events.value.push(endEvent)
+        }
         break
+      }
 
       case 'text_delta':
         events.value.push(data as unknown as TaskEventItem)


### PR DESCRIPTION
- Wrap JSON.parse with try/catch to gracefully handle malformed metadata
- Fall back to raw string on parse error instead of crashing endpoint
- Prevents entire task events request from failing due to single bad row
- Matches error handling pattern used in web-frontend and ws-task