### PR TITLE
feat(telegram): add reply-to-message context

### DIFF
--- a/packages/telegram/src/bot.test.ts
+++ b/packages/telegram/src/bot.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type, @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import type { AgentCore, ResponseChunk } from '@openagent/core'
+import type { AgentCore, ResponseChunk, Database } from '@openagent/core'
 
 // Mock grammy before importing the module under test
 vi.mock('grammy', () => {
@@ -72,8 +72,8 @@ vi.mock('@openagent/core', () => ({
   }),
 }))
 
-import { TelegramBot, createTelegramBot } from './bot.js'
-import type { TelegramConfig } from './bot.js'
+import { TelegramBot, createTelegramBot, extractReplyContext, buildAgentMessage } from './bot.js'
+import type { TelegramConfig, TelegramChatEvent } from './bot.js'
 import { loadConfig } from '@openagent/core'
 
 function createMockAgentCore(): AgentCore {
@@ -670,6 +670,254 @@ describe('TelegramBot', () => {
         'telegram-group',
         undefined
       )
+    })
+  })
+
+  describe('reply-to message context', () => {
+    it('extractReplyContext returns the replied-to text', () => {
+      expect(extractReplyContext({ text: 'hello there' })).toBe('hello there')
+    })
+
+    it('extractReplyContext falls back to caption for photo/document replies', () => {
+      expect(extractReplyContext({ caption: 'a caption' })).toBe('a caption')
+    })
+
+    it('extractReplyContext prefers text over caption when both exist', () => {
+      expect(extractReplyContext({ text: 'the text', caption: 'ignored' })).toBe('the text')
+    })
+
+    it('extractReplyContext returns undefined for non-text replies (sticker/voice)', () => {
+      expect(extractReplyContext({ sticker: { file_id: 'x' } })).toBeUndefined()
+      expect(extractReplyContext(undefined)).toBeUndefined()
+      expect(extractReplyContext(null)).toBeUndefined()
+    })
+
+    it('extractReplyContext truncates long texts at 500 chars with a single ellipsis', () => {
+      const long = 'x'.repeat(600)
+      const result = extractReplyContext({ text: long })!
+      // 500 chars + U+2026
+      expect(result).toHaveLength(501)
+      expect(result.endsWith('\u2026')).toBe(true)
+      expect(result.slice(0, 500)).toBe('x'.repeat(500))
+    })
+
+    it('buildAgentMessage wraps the reply context and leaves the body below', () => {
+      expect(buildAgentMessage('do it again', 'Previous answer'))
+        .toBe('<reply-context>Previous answer</reply-context>\ndo it again')
+    })
+
+    it('buildAgentMessage returns the body unchanged when no reply context is present', () => {
+      expect(buildAgentMessage('just a message', undefined)).toBe('just a message')
+    })
+
+    it('prepends <reply-context> wrapper to the agent-facing message when the user replied to a bot message', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      const ctx = createMockContext({
+        message: {
+          text: 'can you explain?',
+          message_id: 10,
+          reply_to_message: { message_id: 9, text: 'The capital of France is Paris.', from: { id: 123456, is_bot: true } },
+        },
+      })
+      await handler(ctx)
+      await vi.advanceTimersByTimeAsync(2500)
+
+      expect(agentCore.sendMessage).toHaveBeenCalledWith(
+        'telegram-12345',
+        '<reply-context>The capital of France is Paris.</reply-context>\ncan you explain?',
+        'telegram',
+        undefined,
+      )
+    })
+
+    it('prepends wrapper when replying to another user message (non-bot)', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      const ctx = createMockContext({
+        message: {
+          text: 'agree',
+          message_id: 11,
+          reply_to_message: { message_id: 2, text: "let's ship it", from: { id: 77, is_bot: false } },
+        },
+      })
+      await handler(ctx)
+      await vi.advanceTimersByTimeAsync(2500)
+
+      expect(agentCore.sendMessage).toHaveBeenCalledWith(
+        'telegram-12345',
+        "<reply-context>let's ship it</reply-context>\nagree",
+        'telegram',
+        undefined,
+      )
+    })
+
+    it('does not inject any wrapper when there is no reply_to_message', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      await handler(createMockContext({ message: { text: 'hi', message_id: 1 } }))
+      await vi.advanceTimersByTimeAsync(2500)
+
+      expect(agentCore.sendMessage).toHaveBeenCalledWith(
+        'telegram-12345',
+        'hi',
+        'telegram',
+        undefined,
+      )
+    })
+
+    it('truncates long reply-to texts at 500 chars with a single ellipsis', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      const long = 'x'.repeat(600)
+      const ctx = createMockContext({
+        message: {
+          text: 'hm',
+          message_id: 12,
+          reply_to_message: { message_id: 11, text: long },
+        },
+      })
+      await handler(ctx)
+      await vi.advanceTimersByTimeAsync(2500)
+
+      const [, forwarded] = vi.mocked(agentCore.sendMessage).mock.calls[0]
+      const expected = `<reply-context>${'x'.repeat(500)}\u2026</reply-context>\nhm`
+      expect(forwarded).toBe(expected)
+    })
+
+    it('uses caption when replying to a photo with a caption', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      const ctx = createMockContext({
+        message: {
+          text: 'nice pic',
+          message_id: 13,
+          reply_to_message: { message_id: 12, caption: 'sunset over the mountains', photo: [{ file_id: 'p1' }] },
+        },
+      })
+      await handler(ctx)
+      await vi.advanceTimersByTimeAsync(2500)
+
+      expect(agentCore.sendMessage).toHaveBeenCalledWith(
+        'telegram-12345',
+        '<reply-context>sunset over the mountains</reply-context>\nnice pic',
+        'telegram',
+        undefined,
+      )
+    })
+
+    it('silently omits the wrapper when replying to a non-text message (sticker)', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      const ctx = createMockContext({
+        message: {
+          text: 'lol',
+          message_id: 14,
+          reply_to_message: { message_id: 13, sticker: { file_id: 's1' } },
+        },
+      })
+      await handler(ctx)
+      await vi.advanceTimersByTimeAsync(2500)
+
+      expect(agentCore.sendMessage).toHaveBeenCalledWith(
+        'telegram-12345',
+        'lol',
+        'telegram',
+        undefined,
+      )
+    })
+
+    it('stores the original user text in chat_messages (wrapper only in agent-facing string)', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      // Capture DB writes
+      const inserts: Array<{ sql: string; args: unknown[] }> = []
+      const mockDb = {
+        prepare: (sql: string) => ({
+          run: (...args: unknown[]) => { inserts.push({ sql, args }); return { changes: 1, lastInsertRowid: 1 } },
+          // Any SELECT returns an approved linked user row (covers
+          // ensureTelegramUser + resolveNumericUserId + resolveUsername).
+          get: () => ({ id: 1, telegram_id: '12345', telegram_username: 'johndoe', telegram_display_name: 'John Doe', status: 'approved', user_id: 42, username: 'john', created_at: 'now', updated_at: 'now' }),
+          all: () => [],
+        }),
+      } as unknown as Database
+
+      const bot = new TelegramBot({ agentCore, db: mockDb, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      const ctx = createMockContext({
+        message: {
+          text: 'follow-up question',
+          message_id: 15,
+          reply_to_message: { message_id: 14, text: 'the earlier answer' },
+        },
+      })
+      await handler(ctx)
+      await vi.advanceTimersByTimeAsync(2500)
+
+      const chatInsert = inserts.find(i => i.sql.startsWith('INSERT INTO chat_messages'))
+      expect(chatInsert).toBeDefined()
+      // content column must be the user's original text, NOT the wrapped string
+      const content = chatInsert!.args[3]
+      expect(content).toBe('follow-up question')
+      expect(String(content)).not.toContain('<reply-context>')
+      // metadata JSON carries the replyContext excerpt for the web UI
+      const metadata = chatInsert!.args[4] as string | null
+      expect(metadata).not.toBeNull()
+      expect(JSON.parse(metadata!)).toEqual({ replyContext: 'the earlier answer' })
+    })
+
+    it('forwards replyContext on the onChatEvent user_message for cross-channel sync', async () => {
+      vi.mocked(agentCore.sendMessage).mockReturnValue(doneOnlyStream())
+
+      const events: TelegramChatEvent[] = []
+      const bot = new TelegramBot({
+        agentCore,
+        config: defaultConfig,
+        onChatEvent: (e) => { events.push(e) },
+      })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._handlers.get('message:text')!
+
+      const ctx = createMockContext({
+        message: {
+          text: 'do X',
+          message_id: 16,
+          reply_to_message: { message_id: 15, text: 'previous bot reply' },
+        },
+      })
+      await handler(ctx)
+      await vi.advanceTimersByTimeAsync(2500)
+
+      const userMessageEvent = events.find(e => e.type === 'user_message')
+      expect(userMessageEvent).toBeDefined()
+      expect(userMessageEvent!.text).toBe('do X')
+      expect(userMessageEvent!.replyContext).toBe('previous bot reply')
     })
   })
 

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -45,6 +45,12 @@ export interface TelegramChatEvent {
   senderName?: string
   /** Uploaded file attached to the current assistant turn (for type='attachment') */
   attachment?: UploadDescriptor
+  /**
+   * Excerpt of the message the user replied to in Telegram (truncated to 500 chars).
+   * Forwarded to the web UI so it can render a quote bubble above the user
+   * message. Absent for non-reply messages.
+   */
+  replyContext?: string
 }
 
 export interface TelegramBotOptions {
@@ -77,11 +83,24 @@ interface QueuedMessage {
   ctx: Context
   text: string
   attachments?: UploadDescriptor[]
+  /**
+   * Plain-text excerpt of the message the user replied to (`reply_to_message`),
+   * already truncated to REPLY_CONTEXT_MAX_LENGTH. Present only when the incoming
+   * Telegram update carried a `reply_to_message` with extractable text/caption.
+   * Used to:
+   *   1. wrap the agent-facing prompt with `<reply-context>…</reply-context>`,
+   *   2. persist alongside the user's message in `chat_messages.metadata` so the
+   *      web UI can render a quote bubble on reload,
+   *   3. ship to live web clients via the `user_message` chat event.
+   */
+  replyContext?: string
 }
 
 interface PendingBatch {
   ctx: Context
   text: string
+  /** Reply context of the first message in the batch that carried one. */
+  replyContext?: string
   timer: ReturnType<typeof setTimeout>
 }
 
@@ -94,6 +113,42 @@ interface ChatState {
 
 /** Telegram's maximum message length */
 const MAX_MESSAGE_LENGTH = 4096
+
+/**
+ * Maximum number of characters kept from a replied-to message. Longer texts are
+ * truncated with a trailing ellipsis (U+2026) before being stored / forwarded.
+ */
+const REPLY_CONTEXT_MAX_LENGTH = 500
+
+/**
+ * Extract the plain-text excerpt from a Telegram `reply_to_message`, if any.
+ * Returns the truncated text (<=500 chars, trailing `…` when truncated) or
+ * `undefined` for non-text replies (stickers, voice without caption, …).
+ */
+export function extractReplyContext(replyTo: unknown): string | undefined {
+  if (!replyTo || typeof replyTo !== 'object') return undefined
+  const r = replyTo as { text?: unknown; caption?: unknown }
+  const raw = (typeof r.text === 'string' && r.text)
+    || (typeof r.caption === 'string' && r.caption)
+    || ''
+  if (!raw) return undefined
+  return raw.length > REPLY_CONTEXT_MAX_LENGTH
+    ? raw.slice(0, REPLY_CONTEXT_MAX_LENGTH) + '\u2026'
+    : raw
+}
+
+/**
+ * Build the agent-facing prompt string for a Telegram turn. When `replyContext`
+ * is present the original user text is prefixed with a `<reply-context>…</reply-context>`
+ * wrapper on its own line so the model can see what the user replied to without
+ * confusing it with the user's own words. The DB-persisted `content` field
+ * stores the user's original text unchanged — the wrapper lives only in the
+ * agent-facing string.
+ */
+export function buildAgentMessage(text: string, replyContext?: string): string {
+  if (!replyContext) return text
+  return `<reply-context>${replyContext}</reply-context>\n${text}`
+}
 const STOP_COMMANDS = new Set(['/stop', '/kill'])
 
 /**
@@ -570,7 +625,8 @@ export class TelegramBot {
 
     if (!await this.checkAuthorized(ctx)) return
 
-    this.bufferMessage(ctx, text)
+    const replyContext = extractReplyContext(ctx.message?.reply_to_message)
+    this.bufferMessage(ctx, text, replyContext)
   }
 
   private async downloadTelegramFile(fileId: string): Promise<{ buffer: Buffer; mimeType?: string }> {
@@ -680,7 +736,7 @@ export class TelegramBot {
     }
   }
 
-  private bufferMessage(ctx: Context, text: string): void {
+  private bufferMessage(ctx: Context, text: string, replyContext?: string): void {
     const chatKey = getChatKey(ctx)
     const state = this.getOrCreateChatState(chatKey)
 
@@ -689,12 +745,17 @@ export class TelegramBot {
       state.pendingBatch = {
         ctx,
         text: `${state.pendingBatch.text}\n${text}`,
+        // Keep the first reply context we saw in this batch; later messages in
+        // the same batch don't usually come with their own reply and would
+        // otherwise drop the context.
+        replyContext: state.pendingBatch.replyContext ?? replyContext,
         timer: this.createBatchTimer(chatKey),
       }
     } else {
       state.pendingBatch = {
         ctx,
         text,
+        replyContext,
         timer: this.createBatchTimer(chatKey),
       }
     }
@@ -714,7 +775,7 @@ export class TelegramBot {
 
     const batch = state.pendingBatch
     state.pendingBatch = null
-    state.queue.push({ ctx: batch.ctx, text: batch.text })
+    state.queue.push({ ctx: batch.ctx, text: batch.text, replyContext: batch.replyContext })
     this.emitQueueDepthChanged()
 
     await this.processQueue(chatKey)
@@ -813,10 +874,12 @@ export class TelegramBot {
     const state = this.chatStates.get(chatKey)
     if (!state) return
 
-    const { ctx, text, attachments } = queuedMessage
+    const { ctx, text, attachments, replyContext } = queuedMessage
     const userId = this.resolveUserId(ctx)
     const numericUserId = this.resolveNumericUserId(ctx)
-    const messageForAgent = text
+    // Agent sees the reply context wrapped as a pseudo-system hint on its own
+    // line; the DB-stored `content` remains exactly what the user typed.
+    const messageForAgent = buildAgentMessage(text, replyContext)
     const senderName = this.getSenderName(ctx)
 
     // Resolve username for DM chats to enable user profile injection
@@ -828,11 +891,14 @@ export class TelegramBot {
     const sessionId = smSession.id
 
     // Save user message to chat_messages (if linked to a web user)
-    // Skip if this came from handleIncomingAttachment (already saved)
+    // Skip if this came from handleIncomingAttachment (already saved).
+    // When a reply context is present we stash it in the metadata JSON blob so
+    // the web UI can render a WhatsApp/Telegram-style quote bubble on reload.
     if (this.db && numericUserId && !attachments?.length) {
+      const metadata = replyContext ? JSON.stringify({ replyContext }) : null
       this.db.prepare(
-        'INSERT INTO chat_messages (session_id, user_id, role, content) VALUES (?, ?, ?, ?)'
-      ).run(sessionId, numericUserId, 'user', text)
+        'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
+      ).run(sessionId, numericUserId, 'user', text, metadata)
     }
 
     // Broadcast user message event (skip if already broadcast by attachment handler)
@@ -843,6 +909,7 @@ export class TelegramBot {
         sessionId,
         text,
         senderName,
+        replyContext,
       })
     }
 

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -776,6 +776,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
       toolIsError: event.toolIsError,
       senderName: event.senderName,
       attachment: event.attachment,
+      replyContext: event.replyContext,
     })
   }
 

--- a/packages/web-backend/src/chat-event-bus.ts
+++ b/packages/web-backend/src/chat-event-bus.ts
@@ -58,6 +58,12 @@ export interface ChatEvent {
   isTaskInjection?: boolean
   /** Uploaded file attached to the current assistant turn (for type='attachment') */
   attachment?: UploadDescriptor
+  /**
+   * Excerpt of the message the user replied to (e.g. in Telegram), truncated to 500 chars.
+   * Forwarded to web clients so they can render a quote bubble above the user message.
+   * Only set for `type: 'user_message'`.
+   */
+  replyContext?: string
 }
 
 /**

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -37,6 +37,11 @@ interface ChatResponse {
   source?: string
   /** Sender display name (for external_user_message) */
   senderName?: string
+  /**
+   * Excerpt of the message the user replied to (Telegram reply-to), truncated to 500 chars.
+   * Rendered as a quote bubble above the user message. Only set for `external_user_message`.
+   */
+  replyContext?: string
   /** Task ID (for task events) */
   taskId?: string
   /** Task name (for task events) */
@@ -503,6 +508,7 @@ export function setupWebSocketChat(
             text: event.text,
             source: event.source,
             senderName: event.senderName,
+            replyContext: event.replyContext,
           })
         } else if (event.type === 'session_end') {
           // Session ended (timeout or explicit /new). Clear the cached ID and

--- a/packages/web-frontend/app/composables/useChat.ts
+++ b/packages/web-frontend/app/composables/useChat.ts
@@ -49,6 +49,12 @@ export interface ChatMessage {
    * Rendered as a separate collapsible card (sparkles icon).
    */
   isThinking?: boolean
+  /**
+   * Excerpt of the message the user replied to (e.g. Telegram reply-to), truncated to 500 chars.
+   * When present, the UI renders a WhatsApp/Telegram-style quote bubble above the
+   * message body with `[Replying to: "…"]`. Only set for `role: 'user'`.
+   */
+  replyContext?: string
 }
 
 interface WsMessage {
@@ -69,6 +75,8 @@ interface WsMessage {
   source?: string
   /** Sender display name */
   senderName?: string
+  /** Excerpt of the message the user replied to (for type='external_user_message') */
+  replyContext?: string
   /** Reminder message */
   reminderMessage?: string
   /** Reminder name */
@@ -305,6 +313,7 @@ export function useChat() {
             timestamp: new Date().toISOString(),
             source: (msg.source as 'web' | 'telegram') ?? undefined,
             senderName: msg.senderName,
+            replyContext: msg.replyContext,
           }]
         }
         break

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -286,6 +286,15 @@
               <p v-else-if="msg.telegramDelivered" class="mb-1 text-xs font-medium text-[#2AABEE]">
                 via Telegram
               </p>
+              <!-- Reply-to quote bubble (WhatsApp/Telegram style). Shown above the
+                   user message body when the incoming Telegram message replied to
+                   another message. -->
+              <div
+                v-if="msg.role === 'user' && msg.replyContext"
+                class="mb-1.5 rounded-md border-l-2 border-primary/60 bg-background/60 px-2 py-1 text-xs text-muted-foreground"
+              >
+                <span class="whitespace-pre-wrap break-words">[Replying to: "{{ msg.replyContext }}"]</span>
+              </div>
               <div v-if="msg.role === 'assistant'" class="prose-chat break-words" v-html="renderMarkdown(msg.content ?? '')" />
               <p v-else class="whitespace-pre-wrap break-words">{{ msg.content }}</p>
               <ChatAttachments v-if="msg.attachments?.length" :attachments="msg.attachments" />
@@ -681,6 +690,11 @@ async function loadHistory() {
         }
         if (meta.type === 'task_injection_response') {
           base.isTaskInjection = true
+        }
+        // Reply-to context (Telegram reply-to-message) lives in metadata.replyContext
+        // so the quote bubble survives a page reload.
+        if (m.role === 'user' && typeof meta.replyContext === 'string' && meta.replyContext) {
+          base.replyContext = meta.replyContext
         }
         return base
       })


### PR DESCRIPTION
## Problem

When a Telegram user replies to one of the bot's earlier messages, the bot has no visibility into what they are referring to. Short follow-ups like "can you expand on that?" or "do it again" arrive at the agent with no context, which leads to confused or wrong responses. The web UI also has no way to show that a Telegram turn was a reply.

## Change

- **Telegram** (`packages/telegram/src/bot.ts`): new `extractReplyContext()` helper reads `text` (or falls back to `caption`) from `reply_to_message`, truncates at 500 characters with a trailing `…` (U+2026), and returns `undefined` for non-text replies (stickers, voice without caption, …). The excerpt is threaded through the message-batch queue. For each turn it is:
  1. prepended to the agent-facing prompt as `<reply-context>…</reply-context>\n<user text>` (`buildAgentMessage()`), so the model sees the quoted context on its own line without confusing it with the user's words;
  2. stored alongside the user message in `chat_messages.metadata` as `{ replyContext }` — the `content` column keeps the user's raw text unchanged, so history queries and FTS are not polluted by the wrapper;
  3. emitted on the `user_message` chat event for live web clients.
- **Web backend** (`chat-event-bus.ts`, `ws-chat.ts`, `bootstrap/runtime-composition.ts`): optional `replyContext` field propagated through the chat event and the `external_user_message` websocket frame.
- **Web frontend** (`composables/useChat.ts`, `pages/index.vue`): `ChatMessage.replyContext` accepted from both live WS events and persisted metadata on history reload. Rendered as a WhatsApp/Telegram-style quote bubble (`[Replying to: "…"]`) above the user message body — so the context survives reloads without ever exposing the agent-facing wrapper in the UI.

## Testing

- `npx vitest run packages/telegram/src` → **43/43 pass** (8 new tests cover: reply-to-bot, reply-to-user, no reply, long-reply truncation, photo caption reply, non-text reply (sticker), DB metadata storage vs. raw content, and `onChatEvent` propagation; plus unit tests for `extractReplyContext` / `buildAgentMessage`).
- `npx vitest run packages/core/src` → 757/757 pass (unchanged).
- `npx vitest run packages/web-frontend` → 18/18 pass (unchanged).
- `npx vitest run packages/web-backend/src` → 134 pass / 35 fail. The 35 failures are identical on `upstream/main` (auth-related `app.test.ts` suite, pre-existing) and are not introduced by this change.
- `npm run lint` → 52 errors, same count as `upstream/main` (no new lint errors).
- `npm run lint:boundaries` → clean.

Closes #24