### PR TITLE
chore: fix all ESLint errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,4 +7,20 @@ export default tseslint.config(
   {
     ignores: ['**/dist/**', '**/node_modules/**', '**/.nuxt/**', '**/.output/**'],
   },
+  {
+    rules: {
+      // Allow intentionally unused variables/parameters prefixed with `_`.
+      // This convention is used throughout the codebase (e.g. `for (const _ of iter)`
+      // to consume an async iterator without naming the yielded value).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
 )

--- a/packages/core/src/agent-skills.test.ts
+++ b/packages/core/src/agent-skills.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
@@ -134,7 +134,7 @@ describe('agent-skills', () => {
       trackAgentSkillUsage('skill-a')
 
       // Wait a tiny bit so timestamps differ
-      const first = JSON.parse(fs.readFileSync(path.join(tmpDir, 'skills_agent', '.usage.json'), 'utf-8'))
+      JSON.parse(fs.readFileSync(path.join(tmpDir, 'skills_agent', '.usage.json'), 'utf-8'))
 
       trackAgentSkillUsage('skill-b')
       const second = JSON.parse(fs.readFileSync(path.join(tmpDir, 'skills_agent', '.usage.json'), 'utf-8'))
@@ -146,8 +146,7 @@ describe('agent-skills', () => {
     it('updates timestamp for already tracked skill', () => {
       fs.mkdirSync(path.join(tmpDir, 'skills_agent'), { recursive: true })
       trackAgentSkillUsage('my-skill')
-      const firstUsage = JSON.parse(fs.readFileSync(path.join(tmpDir, 'skills_agent', '.usage.json'), 'utf-8'))
-      const firstTimestamp = firstUsage['my-skill']
+      JSON.parse(fs.readFileSync(path.join(tmpDir, 'skills_agent', '.usage.json'), 'utf-8'))
 
       // Small delay to ensure different timestamp
       const later = new Date(Date.now() + 1000).toISOString()

--- a/packages/core/src/agent-skills.ts
+++ b/packages/core/src/agent-skills.ts
@@ -143,7 +143,6 @@ export function trackAgentSkillUsage(skillName: string): void {
  */
 export function getRecentAgentSkills(limit: number = 10): AgentSkillEntry[] {
   const allSkills = listAgentSkills()
-  const usage = readUsageFile()
 
   // Separate skills with usage data from those without
   const withUsage = allSkills.filter(s => s.lastUsed)

--- a/packages/core/src/message-queue.test.ts
+++ b/packages/core/src/message-queue.test.ts
@@ -166,6 +166,7 @@ describe('MessageQueue', () => {
       const queue = new MessageQueue()
 
       const failingProcessor = () => {
+        // eslint-disable-next-line require-yield -- intentionally throws before yielding to test error path
         return (async function* () {
           throw new Error('processor error')
         })()

--- a/packages/core/src/provider-config.test.ts
+++ b/packages/core/src/provider-config.test.ts
@@ -410,7 +410,7 @@ describe('provider CRUD', () => {
 
   it('setFallbackProvider sets the fallback provider', () => {
     setupEmpty()
-    const p1 = addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })
+    addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })
     const p2 = addProvider({ name: 'fallback', providerType: 'anthropic', apiKey: 'sk-2', defaultModel: 'claude-3-5-sonnet-20241022' })
 
     setFallbackProvider(p2.id)
@@ -420,7 +420,7 @@ describe('provider CRUD', () => {
 
   it('getFallbackProvider returns the decrypted fallback provider config', () => {
     setupEmpty()
-    const p1 = addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })
+    addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })
     const p2 = addProvider({ name: 'fallback', providerType: 'anthropic', apiKey: 'sk-fb-key', defaultModel: 'claude-3-5-sonnet-20241022' })
 
     setFallbackProvider(p2.id)
@@ -451,7 +451,7 @@ describe('provider CRUD', () => {
 
   it('clearFallbackProvider removes the fallback provider setting', () => {
     setupEmpty()
-    const p1 = addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })
+    addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })
     const p2 = addProvider({ name: 'fallback', providerType: 'anthropic', apiKey: 'sk-2', defaultModel: 'claude-3-5-sonnet-20241022' })
 
     setFallbackProvider(p2.id)

--- a/packages/core/src/skill-config.test.ts
+++ b/packages/core/src/skill-config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
-import { loadSkills, saveSkills, addSkill, updateSkill, deleteSkill, getSkill, getSkillDecrypted, loadSkillsDecrypted } from './skill-config.js'
+import { loadSkills, addSkill, updateSkill, deleteSkill, getSkill, getSkillDecrypted, loadSkillsDecrypted } from './skill-config.js'
 import { ensureConfigTemplates } from './config.js'
 import { decrypt } from './encryption.js'
 

--- a/packages/core/src/skill-loading.test.ts
+++ b/packages/core/src/skill-loading.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'

--- a/packages/core/src/skill-parser.ts
+++ b/packages/core/src/skill-parser.ts
@@ -125,7 +125,7 @@ function extractEmoji(metadata: Record<string, unknown> | undefined): string | u
  * Parse a SKILL.md file content and extract structured skill metadata.
  */
 export function parseSkillMd(content: string): ParsedSkill {
-  const { frontmatter, body } = extractFrontmatter(content)
+  const { frontmatter } = extractFrontmatter(content)
 
   if (!frontmatter) {
     throw new Error('SKILL.md has no valid YAML frontmatter')

--- a/packages/core/src/stt-tool.test.ts
+++ b/packages/core/src/stt-tool.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import fs from 'node:fs'
 import nodePath from 'node:path'
 

--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -108,7 +108,7 @@ describe('TaskRunner', () => {
 
     const options: TaskRunnerOptions = {
       db,
-      buildModel: () => ({} as any),
+      buildModel: () => ({} as ReturnType<TaskRunnerOptions['buildModel']>),
       getApiKey: async () => 'test-key',
       tools: [],
       memoryDir: undefined,
@@ -191,7 +191,7 @@ describe('TaskRunner', () => {
       expect(updated.estimatedCost).toBeGreaterThan(0)
 
       // Check that token usage was logged to the token_usage table
-      const tokenRows = db.prepare('SELECT * FROM token_usage WHERE session_id = ?').all('task-token-session') as any[]
+      const tokenRows = db.prepare('SELECT * FROM token_usage WHERE session_id = ?').all('task-token-session') as Array<Record<string, unknown>>
       expect(tokenRows.length).toBeGreaterThan(0)
       expect(tokenRows[0].prompt_tokens).toBe(100)
       expect(tokenRows[0].completion_tokens).toBe(50)
@@ -565,7 +565,7 @@ describe('TaskRunner', () => {
       expect(runner.isPaused(task.id)).toBe(true)
 
       // Manually set pausedAt to >24h ago by accessing private field
-      const pausedTasks = (runner as any).pausedTasks as Map<string, any>
+      const pausedTasks = (runner as unknown as { pausedTasks: Map<string, { pausedAt: number }> }).pausedTasks
       const pausedTask = pausedTasks.get(task.id)!
       pausedTask.pausedAt = Date.now() - (25 * 60 * 60 * 1000) // 25 hours ago
 
@@ -714,7 +714,7 @@ describe('TaskRunner', () => {
       })
       store.update(task.id, { status: 'running', provider: 'unknown-provider', model: 'model' })
 
-      const result = await runner.recoverTasks(
+      await runner.recoverTasks(
         () => null,
         mockProvider,
       )
@@ -734,10 +734,10 @@ describe('TaskRunner', () => {
       const { Agent } = await import('@mariozechner/pi-agent-core')
       const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
 
-      let capturedOptions: any = null
+      let capturedOptions: { initialState: { tools: Array<{ name: string }>; systemPrompt: string } } | null = null
       const messages: unknown[] = []
-      MockAgent.mockImplementationOnce((options: any) => {
-        capturedOptions = options
+      MockAgent.mockImplementationOnce((options: unknown) => {
+        capturedOptions = options as typeof capturedOptions
         return {
           subscribe: vi.fn(() => () => {}),
           prompt: vi.fn(async () => {
@@ -758,9 +758,9 @@ describe('TaskRunner', () => {
 
       const runnerWithTools = new TaskRunner({
         db,
-        buildModel: () => ({} as any),
+        buildModel: () => ({} as ReturnType<TaskRunnerOptions['buildModel']>),
         getApiKey: async () => 'test-key',
-        tools: [toolA, toolB, toolC] as any,
+        tools: [toolA, toolB, toolC] as unknown as TaskRunnerOptions['tools'],
         onTaskComplete: () => {},
         sessionManager,
       })
@@ -812,10 +812,10 @@ describe('TaskRunner', () => {
       const { Agent } = await import('@mariozechner/pi-agent-core')
       const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
 
-      let capturedOptions: any = null
+      let capturedOptions: { initialState: { tools: Array<{ name: string }>; systemPrompt: string } } | null = null
       const messages: unknown[] = []
-      MockAgent.mockImplementationOnce((options: any) => {
-        capturedOptions = options
+      MockAgent.mockImplementationOnce((options: unknown) => {
+        capturedOptions = options as typeof capturedOptions
         return {
           subscribe: vi.fn(() => () => {}),
           prompt: vi.fn(async () => {
@@ -856,10 +856,10 @@ describe('TaskRunner', () => {
       const { Agent } = await import('@mariozechner/pi-agent-core')
       const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
 
-      let capturedOptions: any = null
+      let capturedOptions: { initialState: { tools: Array<{ name: string }>; systemPrompt: string } } | null = null
       const messages: unknown[] = []
-      MockAgent.mockImplementationOnce((options: any) => {
-        capturedOptions = options
+      MockAgent.mockImplementationOnce((options: unknown) => {
+        capturedOptions = options as typeof capturedOptions
         return {
           subscribe: vi.fn(() => () => {}),
           prompt: vi.fn(async () => {

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -372,7 +372,7 @@ export class TaskRunner {
   private async runTaskAsync(
     runningTask: RunningTask,
     unsubscribe: () => void,
-    sessionId: string,
+    _sessionId: string,
   ): Promise<void> {
     const { taskId, agent } = runningTask
 
@@ -1261,7 +1261,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
     }
 
     // Abort running tasks
-    for (const [taskId, runningTask] of this.runningTasks) {
+    for (const [, runningTask] of this.runningTasks) {
       runningTask.agent.abort()
       if (runningTask.timeoutTimer) {
         clearTimeout(runningTask.timeoutTimer)
@@ -1273,7 +1273,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
     this.runningTasks.clear()
 
     // Free paused tasks
-    for (const [taskId, pausedTask] of this.pausedTasks) {
+    for (const [, pausedTask] of this.pausedTasks) {
       pausedTask.agent.abort()
     }
     this.pausedTasks.clear()

--- a/packages/core/src/task-store.test.ts
+++ b/packages/core/src/task-store.test.ts
@@ -103,7 +103,7 @@ describe('TaskStore', () => {
     })
 
     it('filters by status', () => {
-      const t1 = store.create({ name: 'Running', prompt: 'p1', triggerType: 'agent' })
+      store.create({ name: 'Running', prompt: 'p1', triggerType: 'agent' })
       const t2 = store.create({ name: 'Completed', prompt: 'p2', triggerType: 'agent' })
       store.update(t2.id, { status: 'completed' })
 

--- a/packages/core/src/web-tools.ts
+++ b/packages/core/src/web-tools.ts
@@ -23,9 +23,8 @@ export interface WebSearchConfig {
   }
 }
 
-export interface WebFetchConfig {
-  // Currently no provider-specific config needed
-}
+// Currently no provider-specific config needed, but reserved for future options.
+export type WebFetchConfig = Record<string, never>
 
 export interface BuiltinToolsConfig {
   webSearch?: {

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -211,8 +211,12 @@ function markdownToTelegramHtml(text: string): string {
   // Links: [text](url)
   result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>')
 
-  // Step 4: Restore code blocks and inline code
+  // Step 4: Restore code blocks and inline code.
+  // NUL bytes (\x00) are used as placeholder sentinels because they cannot
+  // appear in normal Telegram text, so the control characters are intentional.
+  // eslint-disable-next-line no-control-regex
   result = result.replace(/\x00CODEBLOCK(\d+)\x00/g, (_match, idx) => codeBlocks[Number(idx)])
+  // eslint-disable-next-line no-control-regex
   result = result.replace(/\x00INLINECODE(\d+)\x00/g, (_match, idx) => inlineCodes[Number(idx)])
 
   return result
@@ -882,9 +886,7 @@ export class TelegramBot {
     const messageForAgent = buildAgentMessage(text, replyContext)
     const senderName = this.getSenderName(ctx)
 
-    // Resolve username for DM chats to enable user profile injection
     const isDM = this.isDMChat(ctx)
-    const username = isDM ? this.resolveUsername(ctx) : null
 
     // Resolve session ID from SessionManager (aligns chat_messages with session tracking)
     const smSession = this.agentCore.getSessionManager().getOrCreateSession(userId, 'telegram')

--- a/packages/web-backend/src/bootstrap/http-boundary.ts
+++ b/packages/web-backend/src/bootstrap/http-boundary.ts
@@ -56,7 +56,6 @@ export async function startHttpBoundary(
     taskEventBus: runtimeComposition.taskEventBus,
   })
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { wss: _logsWss, broadcast: broadcastLog } = setupWebSocketLogs(server)
   void broadcastLog
 

--- a/packages/web-backend/src/ws-task.test.ts
+++ b/packages/web-backend/src/ws-task.test.ts
@@ -305,7 +305,7 @@ describe('WebSocket /ws/task/:id', () => {
     const token = getToken()
     const messages: Record<string, unknown>[] = []
 
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve, _reject) => {
       const ws = new WebSocket(`${wsBaseUrl}/ws/task/nonexistent?token=${token}`)
       const timeout = setTimeout(() => {
         ws.close()


### PR DESCRIPTION
## Problem
`npm run lint` reported 52 pre-existing ESLint errors on `upstream/main`. No existing PR was addressing them.

## Changes
Fixed all 52 ESLint errors across the codebase. No behaviour changes — only type annotations, unused import removals, and similar static fixes.

## Testing
- `npm run lint` → 0 errors
- `npm run lint:boundaries` → clean
- `npm run baseline:unit` → 818/818 passing (no regressions)