### PR TITLE
feat(skills): add required_env_vars / platforms / requires_toolsets metadata

### DIFF
--- a/packages/core/src/agent-runtime.test.ts
+++ b/packages/core/src/agent-runtime.test.ts
@@ -89,6 +89,7 @@ vi.mock('./agent-skills.js', () => ({
   getAgentSkillsCount: vi.fn(() => 1),
   getAgentSkillsDir: vi.fn(() => '/skills-agent'),
   trackAgentSkillUsage: vi.fn(),
+  currentPlatform: vi.fn(() => 'linux'),
 }))
 
 vi.mock('./memories-tool.js', () => ({

--- a/packages/core/src/agent-runtime.ts
+++ b/packages/core/src/agent-runtime.ts
@@ -21,7 +21,7 @@ import { createBuiltinWebTools } from './web-tools.js'
 import type { BuiltinToolsConfig } from './web-tools.js'
 import { createTranscribeAudioTool } from './stt-tool.js'
 import { loadSttSettings } from './stt.js'
-import { createAgentSkillTools, getAgentSkillsForPrompt, getAgentSkillsCount, getAgentSkillsDir, trackAgentSkillUsage } from './agent-skills.js'
+import { createAgentSkillTools, getAgentSkillsForPrompt, getAgentSkillsCount, getAgentSkillsDir, trackAgentSkillUsage, currentPlatform } from './agent-skills.js'
 import { createSearchMemoriesTool } from './memories-tool.js'
 import { createReadChatHistoryTool } from './chat-history-tools.js'
 import type { AgentRuntimeStateSnapshot, ResponseChunk } from './agent-runtime-types.js'
@@ -597,7 +597,23 @@ class PiAgentRuntime implements AgentRuntimeBoundary, AgentRuntimePiAgentAccess 
     const { language, timezone, builtinToolsConfig, sttEnabled } = this.readRuntimeSettings()
 
     const activeSkills = getActiveSkillEntries()
-    const agentSkillEntries = getAgentSkillsForPrompt()
+    // Build a skill-prompt context so agent skills can be gated by the current
+    // platform / active toolset and annotated with missing required env vars.
+    const activeTools = new Set<string>([
+      'shell', 'read_file', 'write_file', 'edit_file', 'list_files',
+      'create_task', 'resume_task', 'list_tasks',
+      'create_cronjob', 'edit_cronjob', 'remove_cronjob', 'list_cronjobs', 'get_cronjob',
+      'create_reminder',
+      'read_chat_history', 'search_memories', 'list_agent_skills',
+    ])
+    if (builtinToolsConfig?.webSearch?.enabled !== false) activeTools.add('web_search')
+    if (builtinToolsConfig?.webFetch?.enabled !== false) activeTools.add('web_fetch')
+    if (sttEnabled) activeTools.add('transcribe_audio')
+
+    const agentSkillEntries = getAgentSkillsForPrompt({
+      platform: currentPlatform(),
+      activeTools,
+    })
     const totalAgentSkills = getAgentSkillsCount()
     const allSkills = [...activeSkills, ...agentSkillEntries]
 

--- a/packages/core/src/agent-session-summary.test.ts
+++ b/packages/core/src/agent-session-summary.test.ts
@@ -60,6 +60,7 @@ vi.mock('./agent-skills.js', () => ({
   getAgentSkillsCount: vi.fn(() => 0),
   getAgentSkillsDir: vi.fn(() => '/tmp/test-agent-skills'),
   trackAgentSkillUsage: vi.fn(),
+  currentPlatform: vi.fn(() => 'linux'),
 }))
 
 vi.mock('./workspace.js', () => ({

--- a/packages/core/src/agent-skills.test.ts
+++ b/packages/core/src/agent-skills.test.ts
@@ -10,7 +10,10 @@ import {
   getAgentSkillsCount,
   getAgentSkillsDir,
   createAgentSkillTools,
+  filterAndAnnotateAgentSkills,
+  currentPlatform,
 } from './agent-skills.js'
+import type { AgentSkillEntry } from './agent-skills.js'
 import { assembleSystemPrompt } from './memory.js'
 import type { SkillPromptEntry } from './memory.js'
 
@@ -347,6 +350,126 @@ describe('agent-skills', () => {
       })
 
       expect(prompt).not.toContain('list_agent_skills')
+    })
+  })
+
+  describe('skill frontmatter gating', () => {
+    function createSkillWithFrontmatter(name: string, frontmatter: string): void {
+      const skillDir = path.join(tmpDir, 'skills_agent', name)
+      fs.mkdirSync(skillDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: Gated skill\n${frontmatter}---\n\nBody.`,
+        'utf-8',
+      )
+    }
+
+    it('listAgentSkills exposes the new gating fields', () => {
+      createSkillWithFrontmatter(
+        'gated',
+        'required_env_vars:\n  - FOO_KEY\nplatforms:\n  - linux\nrequires_toolsets:\n  - web_fetch\n',
+      )
+
+      const skills = listAgentSkills()
+      expect(skills).toHaveLength(1)
+      expect(skills[0].requiredEnvVars).toEqual(['FOO_KEY'])
+      expect(skills[0].platforms).toEqual(['linux'])
+      expect(skills[0].requiresToolsets).toEqual(['web_fetch'])
+    })
+
+    it('hides skills whose platform does not match', () => {
+      const skills: AgentSkillEntry[] = [
+        { name: 'linux-only', description: 'x', location: '/a', platforms: ['linux'] },
+        { name: 'mac-only', description: 'y', location: '/b', platforms: ['macos'] },
+        { name: 'any', description: 'z', location: '/c' },
+      ]
+      const filtered = filterAndAnnotateAgentSkills(skills, {
+        platform: 'linux',
+        activeTools: new Set(),
+      })
+      expect(filtered.map(s => s.name)).toEqual(['linux-only', 'any'])
+    })
+
+    it('hides skills whose requires_toolsets are not all active', () => {
+      const skills: AgentSkillEntry[] = [
+        { name: 'needs-web-fetch', description: 'x', location: '/a', requiresToolsets: ['web_fetch'] },
+        { name: 'needs-both', description: 'y', location: '/b', requiresToolsets: ['web_fetch', 'shell'] },
+        { name: 'no-deps', description: 'z', location: '/c' },
+      ]
+      const filtered = filterAndAnnotateAgentSkills(skills, {
+        platform: 'linux',
+        activeTools: new Set(['web_fetch']),
+      })
+      expect(filtered.map(s => s.name)).toEqual(['needs-web-fetch', 'no-deps'])
+    })
+
+    it('keeps skills with missing required_env_vars but marks them with a warning', () => {
+      const skills: AgentSkillEntry[] = [
+        { name: 'needs-key', description: 'x', location: '/a', requiredEnvVars: ['BRAVE_API_KEY', 'OTHER'] },
+      ]
+      const filtered = filterAndAnnotateAgentSkills(skills, {
+        platform: 'linux',
+        activeTools: new Set(),
+        getEnv: (name) => (name === 'BRAVE_API_KEY' ? 'present' : undefined),
+      })
+      expect(filtered).toHaveLength(1)
+      expect(filtered[0].warning).toBe('⚠ requires: OTHER')
+    })
+
+    it('omits the warning when all required env vars are present', () => {
+      const skills: AgentSkillEntry[] = [
+        { name: 'all-set', description: 'x', location: '/a', requiredEnvVars: ['K1', 'K2'] },
+      ]
+      const filtered = filterAndAnnotateAgentSkills(skills, {
+        platform: 'linux',
+        activeTools: new Set(),
+        getEnv: () => 'present',
+      })
+      expect(filtered[0].warning).toBeUndefined()
+    })
+
+    it('is backward compatible: skills without new fields pass through unchanged', () => {
+      const skills: AgentSkillEntry[] = [
+        { name: 'plain', description: 'x', location: '/a' },
+      ]
+      const filtered = filterAndAnnotateAgentSkills(skills, {
+        platform: 'linux',
+        activeTools: new Set(),
+      })
+      expect(filtered).toEqual([{ name: 'plain', description: 'x', location: '/a' }])
+    })
+
+    it('currentPlatform maps process.platform to canonical names', () => {
+      const p = currentPlatform()
+      // At least make sure it returns a non-empty string and maps darwin/win32 correctly.
+      expect(typeof p).toBe('string')
+      if (process.platform === 'darwin') expect(p).toBe('macos')
+      else if (process.platform === 'win32') expect(p).toBe('windows')
+      else expect(p).toBe(process.platform)
+    })
+
+    it('list_agent_skills tool output marks skills with missing env vars', async () => {
+      createSkillWithFrontmatter('needs-env', 'required_env_vars:\n  - NEVER_SET_VAR_XYZ\n')
+
+      const tools = createAgentSkillTools()
+      const result = await tools[0].execute('test-call-id', {})
+      const text = (result as { content: { text: string }[] }).content[0].text
+      expect(text).toContain('needs-env')
+      expect(text).toContain('NEVER_SET_VAR_XYZ')
+      expect(text).toContain('requires env')
+    })
+  })
+
+  describe('assembleSystemPrompt renders skill warnings', () => {
+    it('emits a <warning> tag when a skill carries a warning', () => {
+      const skills: SkillPromptEntry[] = [
+        { name: 'warn-skill', description: 'd', location: '/a', warning: '⚠ requires: FOO' },
+      ]
+      const prompt = assembleSystemPrompt({
+        memoryDir: path.join(tmpDir, 'memory'),
+        skills,
+      })
+      expect(prompt).toContain('<warning>⚠ requires: FOO</warning>')
     })
   })
 

--- a/packages/core/src/agent-skills.ts
+++ b/packages/core/src/agent-skills.ts
@@ -20,6 +20,35 @@ export interface AgentSkillEntry {
   description: string
   location: string
   lastUsed?: string // ISO timestamp
+  /** Optional `required_env_vars` from the skill's frontmatter. */
+  requiredEnvVars?: string[]
+  /** Optional `platforms` from the skill's frontmatter. */
+  platforms?: string[]
+  /** Optional `requires_toolsets` from the skill's frontmatter. */
+  requiresToolsets?: string[]
+}
+
+/**
+ * Context for filtering/annotating skills when rendering into the system prompt.
+ */
+export interface SkillPromptContext {
+  /** Current platform name: "linux" | "macos" | "windows" | other. */
+  platform: string
+  /** Names of tools currently registered in the active toolset. */
+  activeTools: Set<string>
+  /** Returns the value of an env var (or undefined if unset). */
+  getEnv?: (name: string) => string | undefined
+}
+
+/**
+ * Map Node's `process.platform` to the canonical names used in skill frontmatter.
+ */
+export function currentPlatform(): string {
+  switch (process.platform) {
+    case 'darwin': return 'macos'
+    case 'win32': return 'windows'
+    default: return process.platform // 'linux', 'freebsd', etc.
+  }
 }
 
 const USAGE_FILENAME = '.usage.json'
@@ -116,6 +145,9 @@ export function listAgentSkills(): AgentSkillEntry[] {
         description: parsed.description,
         location: path.join(dir, entry.name),
         lastUsed: usage[parsed.name] ?? usage[entry.name],
+        requiredEnvVars: parsed.requiredEnvVars,
+        platforms: parsed.platforms,
+        requiresToolsets: parsed.requiresToolsets,
       })
     } catch {
       // Skip skills with invalid SKILL.md
@@ -161,16 +193,72 @@ export function getRecentAgentSkills(limit: number = 10): AgentSkillEntry[] {
 }
 
 /**
+ * Apply platform/toolset/env-var gating rules to agent skills for the system prompt.
+ *
+ * Semantics (backward-compatible — skills without the new fields are unaffected):
+ *   - `platforms`: if set and current platform is not included, the skill is hidden.
+ *   - `requires_toolsets`: if any required tool is missing from the active toolset,
+ *     the skill is hidden (avoids prompt noise for unusable skills).
+ *   - `required_env_vars`: if any required env var is missing, the skill is kept in
+ *     the listing but marked with "⚠ requires: VAR_NAME" so the agent can warn the
+ *     user instead of failing silently.
+ */
+export function filterAndAnnotateAgentSkills(
+  skills: AgentSkillEntry[],
+  ctx: SkillPromptContext,
+): SkillPromptEntry[] {
+  const getEnv = ctx.getEnv ?? ((name: string) => process.env[name])
+  const result: SkillPromptEntry[] = []
+
+  for (const s of skills) {
+    // Platform gate
+    if (s.platforms && s.platforms.length > 0 && !s.platforms.includes(ctx.platform)) {
+      continue
+    }
+
+    // Toolset gate
+    if (s.requiresToolsets && s.requiresToolsets.length > 0) {
+      const missing = s.requiresToolsets.filter(t => !ctx.activeTools.has(t))
+      if (missing.length > 0) continue
+    }
+
+    // Env-var annotation (not a hard filter)
+    let warning: string | undefined
+    if (s.requiredEnvVars && s.requiredEnvVars.length > 0) {
+      const missing = s.requiredEnvVars.filter(v => !getEnv(v))
+      if (missing.length > 0) {
+        warning = `⚠ requires: ${missing.join(', ')}`
+      }
+    }
+
+    result.push({
+      name: s.name,
+      description: s.description,
+      location: s.location,
+      ...(warning ? { warning } : {}),
+    })
+  }
+
+  return result
+}
+
+/**
  * Get agent skills formatted for system prompt injection.
  * Returns the 10 most recently used skills as SkillPromptEntry[].
+ *
+ * Accepts an optional context to filter by platform/toolset and mark skills with
+ * missing required env vars. Without context, no gating is applied (backward compat).
  */
-export function getAgentSkillsForPrompt(): SkillPromptEntry[] {
+export function getAgentSkillsForPrompt(ctx?: SkillPromptContext): SkillPromptEntry[] {
   const recent = getRecentAgentSkills(10)
-  return recent.map(s => ({
-    name: s.name,
-    description: s.description,
-    location: s.location,
-  }))
+  if (!ctx) {
+    return recent.map(s => ({
+      name: s.name,
+      description: s.description,
+      location: s.location,
+    }))
+  }
+  return filterAndAnnotateAgentSkills(recent, ctx)
 }
 
 /**
@@ -217,7 +305,9 @@ export function createAgentSkillTools(): AgentTool[] {
 
         const lines = skills.map(s => {
           const lastUsedStr = s.lastUsed ? ` (last used: ${s.lastUsed})` : ''
-          return `- **${s.name}**: ${s.description}\n  Location: ${s.location}${lastUsedStr}`
+          const missingEnv = (s.requiredEnvVars ?? []).filter(v => !process.env[v])
+          const warnStr = missingEnv.length > 0 ? `\n  ⚠ requires env: ${missingEnv.join(', ')} (not set)` : ''
+          return `- **${s.name}**: ${s.description}\n  Location: ${s.location}${lastUsedStr}${warnStr}`
         })
 
         const dir = getAgentSkillsDir()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,8 +176,10 @@ export {
   getAgentSkillsCount,
   getAgentSkillsDir,
   createAgentSkillTools,
+  filterAndAnnotateAgentSkills,
+  currentPlatform,
 } from './agent-skills.js'
-export type { AgentSkillEntry, AgentSkillUsage } from './agent-skills.js'
+export type { AgentSkillEntry, AgentSkillUsage, SkillPromptContext } from './agent-skills.js'
 export { AgentCore, createYoloTools, getWorkspaceDir, isRetryablePreStreamError } from './agent.js'
 export type { ResponseChunk, AgentCoreOptions } from './agent.js'
 export { createAgentRuntime, createBaseAgentTools } from './agent-runtime.js'

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -697,6 +697,13 @@ export interface SkillPromptEntry {
   name: string
   description: string
   location: string
+  /**
+   * Optional warning to surface alongside the skill in the system prompt listing.
+   * Used e.g. when a skill declares `required_env_vars` that are not currently set
+   * ("⚠ requires: VAR_NAME"). The skill is still listed so the agent can inform
+   * the user instead of failing silently.
+   */
+  warning?: string
 }
 
 /**
@@ -896,9 +903,10 @@ Created skills automatically appear in <available_skills> for future conversatio
 
   // 12. Available skills (progressive disclosure)
   if (options?.skills && options.skills.length > 0) {
-    const skillEntries = options.skills.map(s =>
-      `  <skill>\n    <name>${s.name}</name>\n    <description>${s.description}</description>\n    <location>${s.location}</location>\n  </skill>`
-    ).join('\n')
+    const skillEntries = options.skills.map(s => {
+      const warningTag = s.warning ? `\n    <warning>${s.warning}</warning>` : ''
+      return `  <skill>\n    <name>${s.name}</name>\n    <description>${s.description}</description>\n    <location>${s.location}</location>${warningTag}\n  </skill>`
+    }).join('\n')
     let overflowNote = ''
     if (options?.agentSkillsOverflowCount && options.agentSkillsOverflowCount > 10) {
       overflowNote = `\n\nYou have ${options.agentSkillsOverflowCount} self-created agent skills in total (only the 10 most recent are shown above). Use \`list_agent_skills\` to browse all of them.`

--- a/packages/core/src/skill-parser.test.ts
+++ b/packages/core/src/skill-parser.test.ts
@@ -242,5 +242,54 @@ name: test-skill
 body`
       expect(() => parseSkillMd(content)).toThrow('missing required "description"')
     })
+
+    it('parses optional required_env_vars / platforms / requires_toolsets', () => {
+      const content = `---
+name: gated-skill
+description: Gated
+required_env_vars:
+  - BRAVE_API_KEY
+  - OTHER_KEY
+platforms:
+  - linux
+  - macos
+requires_toolsets:
+  - web_fetch
+  - shell
+---
+body`
+      const result = parseSkillMd(content)
+      expect(result.requiredEnvVars).toEqual(['BRAVE_API_KEY', 'OTHER_KEY'])
+      expect(result.platforms).toEqual(['linux', 'macos'])
+      expect(result.requiresToolsets).toEqual(['web_fetch', 'shell'])
+    })
+
+    it('leaves gating fields undefined when absent (backward compat)', () => {
+      const content = `---
+name: plain-skill
+description: Plain
+---
+body`
+      const result = parseSkillMd(content)
+      expect(result.requiredEnvVars).toBeUndefined()
+      expect(result.platforms).toBeUndefined()
+      expect(result.requiresToolsets).toBeUndefined()
+    })
+
+    it('ignores non-string entries in gating arrays', () => {
+      const content = `---
+name: mixed-skill
+description: Mixed
+platforms:
+  - linux
+  - 42
+  - null
+required_env_vars: "not-an-array"
+---
+body`
+      const result = parseSkillMd(content)
+      expect(result.platforms).toEqual(['linux'])
+      expect(result.requiredEnvVars).toBeUndefined()
+    })
   })
 })

--- a/packages/core/src/skill-parser.ts
+++ b/packages/core/src/skill-parser.ts
@@ -13,6 +13,24 @@ export interface ParsedSkill {
   envDescriptions: Record<string, string>
   emoji?: string
   rawMetadata?: Record<string, unknown>
+  /**
+   * Optional top-level `required_env_vars` frontmatter field.
+   * Env variables that must be set for the skill to function.
+   * When missing, the skill is still listed in the system prompt but marked as
+   * `⚠ requires: VAR_NAME` so the agent can warn the user instead of failing silently.
+   */
+  requiredEnvVars?: string[]
+  /**
+   * Optional top-level `platforms` frontmatter field (e.g. ["linux", "macos"]).
+   * When present, the skill is only surfaced on matching platforms.
+   */
+  platforms?: string[]
+  /**
+   * Optional top-level `requires_toolsets` frontmatter field (e.g. ["web_fetch", "shell"]).
+   * When any required tool is not part of the active toolset, the skill is hidden
+   * from the system prompt listing to avoid noise.
+   */
+  requiresToolsets?: string[]
 }
 
 /**
@@ -165,6 +183,11 @@ export function parseSkillMd(content: string): ParsedSkill {
     allowedTools = at.filter((v: unknown) => typeof v === 'string')
   }
 
+  // Parse optional gating fields (string arrays, top-level frontmatter)
+  const requiredEnvVars = parseStringArray(frontmatter.required_env_vars)
+  const platforms = parseStringArray(frontmatter.platforms)
+  const requiresToolsets = parseStringArray(frontmatter.requires_toolsets)
+
   return {
     name: normalizedName,
     description,
@@ -175,5 +198,14 @@ export function parseSkillMd(content: string): ParsedSkill {
     envDescriptions,
     emoji,
     rawMetadata: metadata,
+    requiredEnvVars,
+    platforms,
+    requiresToolsets,
   }
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const arr = value.filter((v): v is string => typeof v === 'string' && v.length > 0)
+  return arr.length > 0 ? arr : undefined
 }

--- a/packages/web-backend/src/routes/skills.ts
+++ b/packages/web-backend/src/routes/skills.ts
@@ -163,11 +163,18 @@ export function createSkillsRouter(options: SkillsRouterOptions = {}): Router {
   // ─── Agent Skills (self-created, read-only listing) ─────────────────────────
 
   /**
-   * GET /api/skills/agent — List all agent-created skills
+   * GET /api/skills/agent — List all agent-created skills.
+   *
+   * Annotates each entry with `missingEnvVars` (subset of `requiredEnvVars`
+   * that is not currently set in the server's environment) so the frontend
+   * can surface a warning badge without needing access to process.env.
    */
   router.get('/agent', (_req, res) => {
     try {
-      const skills = listAgentSkills()
+      const skills = listAgentSkills().map(s => {
+        const missingEnvVars = (s.requiredEnvVars ?? []).filter(v => !process.env[v])
+        return { ...s, missingEnvVars }
+      })
       res.json({ skills })
     } catch (err) {
       res.status(500).json({ error: `Failed to list agent skills: ${(err as Error).message}` })

--- a/packages/web-frontend/app/composables/useSkills.ts
+++ b/packages/web-frontend/app/composables/useSkills.ts
@@ -16,6 +16,14 @@ export interface AgentSkill {
   description: string
   location: string
   lastUsed?: string
+  /** Env vars declared as required in the skill's SKILL.md frontmatter. */
+  requiredEnvVars?: string[]
+  /** Platforms the skill targets (e.g. ["linux", "macos"]). */
+  platforms?: string[]
+  /** Toolsets the skill needs (e.g. ["web_fetch", "shell"]). */
+  requiresToolsets?: string[]
+  /** Subset of requiredEnvVars that are not currently set on the server. */
+  missingEnvVars?: string[]
 }
 
 export interface BuiltinToolsConfig {

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -724,7 +724,13 @@
     "agentTab": "Agent Skills",
     "agentEmpty": "Noch keine Agent-Skills vorhanden",
     "agentEmptyDescription": "Der Agent kann während Unterhaltungen eigene Skills erstellen. Sie werden hier angezeigt.",
-    "agentLoading": "Lade Agent-Skills..."
+    "agentLoading": "Lade Agent-Skills...",
+    "metadata": {
+      "needsPrefix": "benötigt:",
+      "platformTooltip": "Unterstützte Plattform",
+      "toolsetTooltip": "Benötigtes Toolset",
+      "missingEnvTooltip": "Benötigte Umgebungsvariable ist nicht gesetzt"
+    }
   },
   "wiki": {
     "title": "Wiki",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -724,7 +724,13 @@
     "agentTab": "Agent Skills",
     "agentEmpty": "No agent-created skills yet",
     "agentEmptyDescription": "The agent can create its own skills during conversations. They will appear here.",
-    "agentLoading": "Loading agent skills..."
+    "agentLoading": "Loading agent skills...",
+    "metadata": {
+      "needsPrefix": "needs:",
+      "platformTooltip": "Supported platform",
+      "toolsetTooltip": "Required toolset",
+      "missingEnvTooltip": "Required environment variable is not set"
+    }
   },
   "wiki": {
     "title": "Wiki",

--- a/packages/web-frontend/app/pages/skills.vue
+++ b/packages/web-frontend/app/pages/skills.vue
@@ -140,7 +140,7 @@
           <!-- Agent skills list -->
           <div v-else class="flex-1 space-y-3 overflow-y-auto min-h-0">
             <Card v-for="skill in agentSkills" :key="skill.name" class="transition-colors">
-              <div class="flex items-center gap-4 p-4">
+              <div class="flex items-start gap-4 p-4">
                 <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
                   <AppIcon name="sparkles" class="h-5 w-5 text-muted-foreground" />
                 </div>
@@ -149,6 +149,38 @@
                   <p v-if="skill.description" class="mt-0.5 text-sm text-muted-foreground line-clamp-1">
                     {{ skill.description }}
                   </p>
+                  <div
+                    v-if="hasMetadataBadges(skill)"
+                    class="mt-2 flex flex-wrap items-center gap-1.5"
+                  >
+                    <!-- Missing env vars (warning) -->
+                    <Badge
+                      v-for="envVar in skill.missingEnvVars"
+                      :key="`env-${envVar}`"
+                      variant="warning"
+                      :title="$t('skills.metadata.missingEnvTooltip')"
+                    >
+                      ⚠ {{ envVar }}
+                    </Badge>
+                    <!-- Platforms -->
+                    <Badge
+                      v-for="platform in skill.platforms"
+                      :key="`platform-${platform}`"
+                      variant="secondary"
+                      :title="$t('skills.metadata.platformTooltip')"
+                    >
+                      {{ platform }}
+                    </Badge>
+                    <!-- Required toolsets -->
+                    <Badge
+                      v-for="toolset in skill.requiresToolsets"
+                      :key="`toolset-${toolset}`"
+                      variant="muted"
+                      :title="$t('skills.metadata.toolsetTooltip')"
+                    >
+                      {{ $t('skills.metadata.needsPrefix') }} {{ toolset }}
+                    </Badge>
+                  </div>
                 </div>
               </div>
             </Card>
@@ -458,7 +490,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Skill } from '~/composables/useSkills'
+import type { Skill, AgentSkill } from '~/composables/useSkills'
 
 const { user } = useAuth()
 const isAdmin = computed(() => user.value?.role === 'admin')
@@ -751,6 +783,14 @@ async function handleToggleWebFetch() {
 }
 
 const { t } = useI18n()
+
+function hasMetadataBadges(skill: AgentSkill): boolean {
+  return (
+    (skill.missingEnvVars?.length ?? 0) > 0 ||
+    (skill.platforms?.length ?? 0) > 0 ||
+    (skill.requiresToolsets?.length ?? 0) > 0
+  )
+}
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`


### PR DESCRIPTION
## Problem

Skills that depend on optional env vars (e.g. `BRAVE_API_KEY`), specific platforms, or certain built-in tools are currently listed unconditionally in the system prompt. That means:

- Skills requiring toolsets that are disabled (e.g. a `web_fetch`-based skill when web tools are off) add prompt noise.
- Skills requiring env vars that are unset fail silently when invoked instead of letting the agent warn the user up front.
- There is no way for a skill to declare a platform constraint.

## Change

Extends `skill-parser.ts` with three optional, top-level frontmatter fields and wires them into the system-prompt injection in `agent-runtime.ts` / `memory.ts` / `agent-skills.ts`:

- `required_env_vars: string[]` — skill stays in the listing but is tagged `⚠ requires: VAR_NAME` when any referenced env var is unset. Same marker is surfaced in the `list_agent_skills` tool output.
- `platforms: string[]` — skill is hidden on non-matching platforms (`process.platform` is mapped to `linux` / `macos` / `windows`).
- `requires_toolsets: string[]` — skill is hidden when any required tool is missing from the active toolset, so the prompt doesn't advertise unusable skills.

Rendering is backward-compatible: skills without these fields behave exactly as today. A new `<warning>` sub-tag is only emitted inside `<skill>` when a warning is actually attached.

Filtering/annotation is implemented as a pure helper (`filterAndAnnotateAgentSkills`) so it can be unit-tested without touching the runtime.

## Testing

- `npx vitest run packages/core` — 769 passed, 40 files (incl. new cases in `skill-parser.test.ts` and `agent-skills.test.ts` covering parsing of the new fields, platform/toolset gating, env-var annotation, backward compatibility, and the `<warning>` rendering in the assembled system prompt).
- `npm run build` — all workspaces build clean.
- `npm run lint` — clean.

Pre-existing failures in `packages/web-backend/src/app.test.ts` (auth 401s, reproducible on `upstream/main` before any changes) are unrelated to this PR.