### PR TITLE
feat: inject attached skills into cronjob task prompts

### DIFF
--- a/packages/core/src/cronjob-tools.test.ts
+++ b/packages/core/src/cronjob-tools.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { initDatabase } from './database.js'
+import { ScheduledTaskStore } from './scheduled-task-store.js'
+import type { ScheduledTask } from './scheduled-task-store.js'
+import { createCronjobTool, editCronjobTool } from './cronjob-tools.js'
+import type { TaskRuntimeScheduleBoundary } from './task-runtime.js'
+import type { Database } from './database.js'
+
+/**
+ * Build a thin in-memory TaskRuntimeScheduleBoundary backed by the real
+ * ScheduledTaskStore. register/unregister/triggerNow/getActiveSchedules are
+ * stubs — the cronjob tools don't exercise the scheduler, only the store.
+ */
+function buildScheduleBoundary(db: Database): TaskRuntimeScheduleBoundary {
+  const store = new ScheduledTaskStore(db)
+  return {
+    create: (input) => store.create(input),
+    getById: (id) => store.getById(id),
+    list: () => store.list(),
+    listEnabled: () => store.listEnabled(),
+    update: (id, updates) => store.update(id, updates),
+    delete: (id) => store.delete(id),
+    register: () => {},
+    unregister: () => {},
+    triggerNow: async () => null,
+    getActiveSchedules: () => [],
+    start: () => {},
+    stop: () => {},
+    restart: () => {},
+  }
+}
+
+describe('cronjob-tools: attachedSkills', () => {
+  let db: Database
+  let dbPath: string
+  let boundary: TaskRuntimeScheduleBoundary
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `openagent-cronjob-tools-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+    db = initDatabase(dbPath)
+    boundary = buildScheduleBoundary(db)
+  })
+
+  afterEach(() => {
+    db.close()
+    try { fs.unlinkSync(dbPath) } catch { /* ignore */ }
+  })
+
+  it('create_cronjob persists attached_skills when provided', async () => {
+    const tool = createCronjobTool({ taskRuntime: boundary })
+    const result = await tool.execute('call-1', {
+      name: 'Daily Nitter Scan',
+      prompt: 'Scan Nitter for mentions.',
+      schedule: '0 9 * * *',
+      attached_skills: ['nitter', 'reddit'],
+    })
+    expect(result.details?.error).not.toBe(true)
+    const details = result.details as { cronjobId: string; attachedSkills: string[] | null }
+    expect(details.attachedSkills).toEqual(['nitter', 'reddit'])
+
+    const stored = boundary.getById(details.cronjobId)!
+    expect(stored.attachedSkills).toEqual(['nitter', 'reddit'])
+  })
+
+  it('create_cronjob normalizes attached_skills (dedupe + trim + drop empty)', async () => {
+    const tool = createCronjobTool({ taskRuntime: boundary })
+    const result = await tool.execute('call-2', {
+      name: 'N',
+      prompt: 'P',
+      schedule: '0 9 * * *',
+      attached_skills: ['nitter', '  nitter  ', '', 'reddit'],
+    })
+    const details = result.details as { cronjobId: string; attachedSkills: string[] | null }
+    expect(details.attachedSkills).toEqual(['nitter', 'reddit'])
+  })
+
+  it('create_cronjob without attached_skills stores null (backward-compatible)', async () => {
+    const tool = createCronjobTool({ taskRuntime: boundary })
+    const result = await tool.execute('call-3', {
+      name: 'Legacy',
+      prompt: 'P',
+      schedule: '0 9 * * *',
+    })
+    const details = result.details as { cronjobId: string; attachedSkills: string[] | null }
+    expect(details.attachedSkills).toBeNull()
+
+    const stored = boundary.getById(details.cronjobId)!
+    expect(stored.attachedSkills).toBeNull()
+  })
+
+  it('edit_cronjob replaces the attached_skills list', async () => {
+    // Seed a cronjob
+    const seed: ScheduledTask = boundary.create({
+      name: 'Seed',
+      prompt: 'P',
+      schedule: '0 9 * * *',
+      attachedSkills: ['nitter'],
+    })
+
+    const edit = editCronjobTool({ taskRuntime: boundary })
+    const result = await edit.execute('call-4', {
+      id: seed.id,
+      attached_skills: ['reddit', 'wiki'],
+    })
+    const details = result.details as { attachedSkills: string[] | null }
+    expect(details.attachedSkills).toEqual(['reddit', 'wiki'])
+
+    const stored = boundary.getById(seed.id)!
+    expect(stored.attachedSkills).toEqual(['reddit', 'wiki'])
+  })
+
+  it('edit_cronjob with attached_skills: [] clears the list', async () => {
+    const seed = boundary.create({
+      name: 'Seed',
+      prompt: 'P',
+      schedule: '0 9 * * *',
+      attachedSkills: ['nitter', 'reddit'],
+    })
+
+    const edit = editCronjobTool({ taskRuntime: boundary })
+    const result = await edit.execute('call-5', {
+      id: seed.id,
+      attached_skills: [],
+    })
+    const details = result.details as { attachedSkills: string[] | null }
+    expect(details.attachedSkills).toBeNull()
+
+    const stored = boundary.getById(seed.id)!
+    expect(stored.attachedSkills).toBeNull()
+  })
+
+  it('edit_cronjob without attached_skills leaves the list unchanged', async () => {
+    const seed = boundary.create({
+      name: 'Seed',
+      prompt: 'P',
+      schedule: '0 9 * * *',
+      attachedSkills: ['nitter'],
+    })
+
+    const edit = editCronjobTool({ taskRuntime: boundary })
+    await edit.execute('call-6', {
+      id: seed.id,
+      name: 'Seed renamed',
+    })
+
+    const stored = boundary.getById(seed.id)!
+    expect(stored.name).toBe('Seed renamed')
+    expect(stored.attachedSkills).toEqual(['nitter'])
+  })
+})

--- a/packages/core/src/cronjob-tools.ts
+++ b/packages/core/src/cronjob-tools.ts
@@ -57,14 +57,20 @@ export function createCronjobTool(options: CronjobToolsOptions): AgentTool {
           description: 'Provider to use for this cronjob. Only specify if the user explicitly requests a specific provider. Only relevant for action_type "task".',
         })
       ),
+      attached_skills: Type.Optional(
+        Type.Array(Type.String(), {
+          description: 'Optional list of agent-skill names (directory names under /data/skills_agent/<name>/) whose SKILL.md should be injected directly into the task prompt on each run. Use this to bake skill rules into the prompt deterministically instead of requiring the task agent to read_file them at run time. Only relevant for action_type "task". Example: ["nitter", "reddit"]. Missing SKILL.md files are skipped with a warning, the task still runs.',
+        })
+      ),
     }),
     execute: async (_toolCallId, params) => {
-      const { prompt, name, schedule, action_type, provider } = params as {
+      const { prompt, name, schedule, action_type, provider, attached_skills } = params as {
         prompt: string
         name: string
         schedule: string
         action_type?: string
         provider?: string
+        attached_skills?: string[]
       }
 
       try {
@@ -80,6 +86,16 @@ export function createCronjobTool(options: CronjobToolsOptions): AgentTool {
         // Validate action_type
         const actionType: ScheduledTaskActionType = action_type === 'injection' ? 'injection' : 'task'
 
+        // Normalize attached skills: keep only non-empty strings, drop duplicates, trim
+        const normalizedAttachedSkills = Array.isArray(attached_skills)
+          ? Array.from(new Set(
+              attached_skills
+                .filter((v): v is string => typeof v === 'string')
+                .map(v => v.trim())
+                .filter(v => v.length > 0),
+            ))
+          : undefined
+
         // Create in DB
         const scheduledTask = options.taskRuntime.create({
           name,
@@ -88,6 +104,7 @@ export function createCronjobTool(options: CronjobToolsOptions): AgentTool {
           actionType,
           provider: provider ?? undefined,
           enabled: true,
+          attachedSkills: normalizedAttachedSkills && normalizedAttachedSkills.length > 0 ? normalizedAttachedSkills : undefined,
         })
 
         // Register with scheduler
@@ -97,10 +114,14 @@ export function createCronjobTool(options: CronjobToolsOptions): AgentTool {
 
         const actionLabel = actionType === 'injection' ? 'Injection (lightweight)' : 'Task (full agent)'
 
+        const attachedSkillsLine = scheduledTask.attachedSkills && scheduledTask.attachedSkills.length > 0
+          ? `Attached skills: ${scheduledTask.attachedSkills.join(', ')}\n`
+          : ''
+
         return {
           content: [{
             type: 'text' as const,
-            text: `Cronjob created successfully.\n\nID: ${scheduledTask.id}\nName: ${name}\nSchedule: ${humanSchedule} (${schedule})\nAction: ${actionLabel}\n${provider ? `Provider: ${provider}\n` : ''}Status: Enabled\n\nThe cronjob is now active and will run on the specified schedule.`,
+            text: `Cronjob created successfully.\n\nID: ${scheduledTask.id}\nName: ${name}\nSchedule: ${humanSchedule} (${schedule})\nAction: ${actionLabel}\n${provider ? `Provider: ${provider}\n` : ''}${attachedSkillsLine}Status: Enabled\n\nThe cronjob is now active and will run on the specified schedule.`,
           }],
           details: {
             cronjobId: scheduledTask.id,
@@ -109,6 +130,7 @@ export function createCronjobTool(options: CronjobToolsOptions): AgentTool {
             humanSchedule,
             actionType,
             provider: provider ?? null,
+            attachedSkills: scheduledTask.attachedSkills ?? null,
           },
         }
       } catch (err) {
@@ -166,9 +188,14 @@ export function editCronjobTool(options: CronjobToolsOptions): AgentTool {
           description: 'Enable or disable the cronjob.',
         })
       ),
+      attached_skills: Type.Optional(
+        Type.Array(Type.String(), {
+          description: 'Replace the list of agent skills attached to this cronjob. Pass an array of skill names (directory names under /data/skills_agent/<name>/). Pass an empty array [] to clear all attached skills. Omit to leave unchanged.',
+        })
+      ),
     }),
     execute: async (_toolCallId, params) => {
-      const { id, prompt, name, schedule, action_type, provider, enabled } = params as {
+      const { id, prompt, name, schedule, action_type, provider, enabled, attached_skills } = params as {
         id: string
         prompt?: string
         name?: string
@@ -176,6 +203,7 @@ export function editCronjobTool(options: CronjobToolsOptions): AgentTool {
         action_type?: string
         provider?: string
         enabled?: boolean
+        attached_skills?: string[]
       }
 
       try {
@@ -204,6 +232,22 @@ export function editCronjobTool(options: CronjobToolsOptions): AgentTool {
           ? (action_type === 'injection' ? 'injection' : 'task')
           : undefined
 
+        // Normalize attached skills if provided: [] explicitly clears, undefined leaves unchanged.
+        let attachedSkillsUpdate: string[] | null | undefined
+        if (attached_skills === undefined) {
+          attachedSkillsUpdate = undefined
+        } else if (Array.isArray(attached_skills) && attached_skills.length === 0) {
+          attachedSkillsUpdate = null
+        } else {
+          attachedSkillsUpdate = Array.from(new Set(
+            (attached_skills as unknown[])
+              .filter((v): v is string => typeof v === 'string')
+              .map(v => v.trim())
+              .filter(v => v.length > 0),
+          ))
+          if (attachedSkillsUpdate.length === 0) attachedSkillsUpdate = null
+        }
+
         // Update in DB
         const updated = options.taskRuntime.update(id, {
           prompt,
@@ -212,6 +256,7 @@ export function editCronjobTool(options: CronjobToolsOptions): AgentTool {
           actionType,
           provider,
           enabled,
+          attachedSkills: attachedSkillsUpdate,
         })
 
         if (!updated) {
@@ -228,10 +273,14 @@ export function editCronjobTool(options: CronjobToolsOptions): AgentTool {
 
         const actionLabel = updated.actionType === 'injection' ? 'Injection (lightweight)' : 'Task (full agent)'
 
+        const attachedSkillsText = updated.attachedSkills && updated.attachedSkills.length > 0
+          ? updated.attachedSkills.join(', ')
+          : 'none'
+
         return {
           content: [{
             type: 'text' as const,
-            text: `Cronjob updated successfully.\n\nID: ${updated.id}\nName: ${updated.name}\nSchedule: ${humanSchedule} (${updated.schedule})\nAction: ${actionLabel}\nProvider: ${updated.provider ?? 'default'}\nStatus: ${updated.enabled ? 'Enabled' : 'Disabled'}`,
+            text: `Cronjob updated successfully.\n\nID: ${updated.id}\nName: ${updated.name}\nSchedule: ${humanSchedule} (${updated.schedule})\nAction: ${actionLabel}\nProvider: ${updated.provider ?? 'default'}\nAttached skills: ${attachedSkillsText}\nStatus: ${updated.enabled ? 'Enabled' : 'Disabled'}`,
           }],
           details: {
             cronjobId: updated.id,
@@ -241,6 +290,7 @@ export function editCronjobTool(options: CronjobToolsOptions): AgentTool {
             actionType: updated.actionType,
             provider: updated.provider,
             enabled: updated.enabled,
+            attachedSkills: updated.attachedSkills ?? null,
           },
         }
       } catch (err) {
@@ -392,8 +442,11 @@ export function listCronjobsTool(options: CronjobToolsOptions): AgentTool {
             : 'never'
 
           const actionLabel = cj.actionType === 'injection' ? 'injection' : 'task'
+          const attachedSkillsLine = cj.attachedSkills && cj.attachedSkills.length > 0
+            ? `\n  Attached skills: ${cj.attachedSkills.join(', ')}`
+            : ''
 
-          return `\u2022 [${status}] ${cj.name}\n  ID: ${cj.id}\n  Schedule: ${humanSchedule} (${cj.schedule})\n  Action: ${actionLabel}\n  Provider: ${cj.provider ?? 'default'}\n  Last run: ${lastRun}${nextRunsStr}`
+          return `\u2022 [${status}] ${cj.name}\n  ID: ${cj.id}\n  Schedule: ${humanSchedule} (${cj.schedule})\n  Action: ${actionLabel}\n  Provider: ${cj.provider ?? 'default'}${attachedSkillsLine}\n  Last run: ${lastRun}${nextRunsStr}`
         })
 
         return {
@@ -445,12 +498,17 @@ export function getCronjobTool(options: CronjobToolsOptions): AgentTool {
           ? `${cj.lastRunStatus ?? 'unknown'} at ${cj.lastRunAt}`
           : 'never'
 
+        const attachedSkillsText = cj.attachedSkills && cj.attachedSkills.length > 0
+          ? cj.attachedSkills.join(', ')
+          : 'none'
+
         const text = [
           `[${status}] ${cj.name}`,
           `ID: ${cj.id}`,
           `Schedule: ${humanSchedule} (${cj.schedule})`,
           `Action: ${actionLabel}`,
           `Provider: ${cj.provider ?? 'default'}`,
+          `Attached skills: ${attachedSkillsText}`,
           `Last run: ${lastRun}`,
           ``,
           `Prompt:`,

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -304,6 +304,11 @@ export function initDatabase(dbPath?: string): Database {
     db.exec("ALTER TABLE scheduled_tasks ADD COLUMN action_type TEXT NOT NULL DEFAULT 'task'")
   }
 
+  // Migration: add attached_skills column to scheduled_tasks (JSON array of skill names)
+  if (!scheduledCols.find(c => c.name === 'attached_skills')) {
+    db.exec("ALTER TABLE scheduled_tasks ADD COLUMN attached_skills TEXT")
+  }
+
   // Migration: add 'paused' to tasks status CHECK constraint
   // Test by inserting a paused row — if CHECK fails, recreate the table
   try {

--- a/packages/core/src/scheduled-task-store.ts
+++ b/packages/core/src/scheduled-task-store.ts
@@ -14,6 +14,14 @@ export interface ScheduledTask {
   toolsOverride: string | null
   skillsOverride: string | null
   systemPromptOverride: string | null
+  /**
+   * Optional list of agent-skill names (matching directories under
+   * `/data/skills_agent/<name>/`) whose `SKILL.md` content should be
+   * injected verbatim into the task prompt under an `<attached_skills>`
+   * block. Lets cronjobs bake skill rules into the prompt deterministically
+   * instead of requiring the task agent to `read_file` them on every run.
+   */
+  attachedSkills: string[] | null
   lastRunAt: string | null
   lastRunTaskId: string | null
   lastRunStatus: string | null
@@ -28,6 +36,7 @@ export interface CreateScheduledTaskInput {
   actionType?: ScheduledTaskActionType
   provider?: string
   enabled?: boolean
+  attachedSkills?: string[] | null
 }
 
 export interface UpdateScheduledTaskInput {
@@ -40,6 +49,7 @@ export interface UpdateScheduledTaskInput {
   toolsOverride?: string | null
   skillsOverride?: string | null
   systemPromptOverride?: string | null
+  attachedSkills?: string[] | null
   lastRunAt?: string
   lastRunTaskId?: string
   lastRunStatus?: string
@@ -56,11 +66,31 @@ interface ScheduledTaskRow {
   tools_override: string | null
   skills_override: string | null
   system_prompt_override: string | null
+  attached_skills: string | null
   last_run_at: string | null
   last_run_task_id: string | null
   last_run_status: string | null
   created_at: string
   updated_at: string
+}
+
+function parseAttachedSkills(raw: string | null): string[] | null {
+  if (raw === null || raw === undefined) return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed) && parsed.every(v => typeof v === 'string')) {
+      return parsed as string[]
+    }
+  } catch {
+    // Fall through — treat as null on malformed data
+  }
+  return null
+}
+
+function serializeAttachedSkills(value: string[] | null | undefined): string | null {
+  if (value === null || value === undefined) return null
+  if (!Array.isArray(value)) return null
+  return JSON.stringify(value.filter(v => typeof v === 'string'))
 }
 
 function rowToScheduledTask(row: ScheduledTaskRow): ScheduledTask {
@@ -75,6 +105,7 @@ function rowToScheduledTask(row: ScheduledTaskRow): ScheduledTask {
     toolsOverride: row.tools_override,
     skillsOverride: row.skills_override,
     systemPromptOverride: row.system_prompt_override,
+    attachedSkills: parseAttachedSkills(row.attached_skills),
     lastRunAt: row.last_run_at,
     lastRunTaskId: row.last_run_task_id,
     lastRunStatus: row.last_run_status,
@@ -98,6 +129,7 @@ export function initScheduledTasksTable(db: Database): void {
       tools_override TEXT,
       skills_override TEXT,
       system_prompt_override TEXT,
+      attached_skills TEXT,
       last_run_at TEXT,
       last_run_task_id TEXT,
       last_run_status TEXT,
@@ -121,8 +153,8 @@ export class ScheduledTaskStore {
     const now = new Date().toISOString().replace('T', ' ').slice(0, 19)
 
     this.db.prepare(`
-      INSERT INTO scheduled_tasks (id, name, prompt, schedule, action_type, provider, enabled, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO scheduled_tasks (id, name, prompt, schedule, action_type, provider, enabled, attached_skills, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       input.name,
@@ -131,6 +163,7 @@ export class ScheduledTaskStore {
       input.actionType ?? 'task',
       input.provider ?? null,
       input.enabled !== undefined ? (input.enabled ? 1 : 0) : 1,
+      serializeAttachedSkills(input.attachedSkills ?? null),
       now,
       now,
     )
@@ -204,6 +237,10 @@ export class ScheduledTaskStore {
     if (input.systemPromptOverride !== undefined) {
       setClauses.push('system_prompt_override = ?')
       params.push(input.systemPromptOverride)
+    }
+    if (input.attachedSkills !== undefined) {
+      setClauses.push('attached_skills = ?')
+      params.push(serializeAttachedSkills(input.attachedSkills))
     }
     if (input.lastRunAt !== undefined) {
       setClauses.push('last_run_at = ?')

--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -910,4 +910,128 @@ describe('TaskRunner', () => {
       expect(updated.status).toBe('completed')
     })
   })
+
+  describe('attached skills injection', () => {
+    let skillsTmpDir: string
+    let originalDataDir: string | undefined
+
+    beforeEach(() => {
+      originalDataDir = process.env.DATA_DIR
+      skillsTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openagent-skills-'))
+      process.env.DATA_DIR = skillsTmpDir
+      // Create two skills
+      const nitterDir = path.join(skillsTmpDir, 'skills_agent', 'nitter')
+      fs.mkdirSync(nitterDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(nitterDir, 'SKILL.md'),
+        '---\nname: nitter\ndescription: Fetch tweets via Nitter.\n---\n\n# Nitter Skill\nAlways rotate Nitter mirrors.',
+        'utf-8',
+      )
+      const redditDir = path.join(skillsTmpDir, 'skills_agent', 'reddit')
+      fs.mkdirSync(redditDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(redditDir, 'SKILL.md'),
+        '---\nname: reddit\ndescription: Fetch Reddit threads.\n---\n\n# Reddit Skill\nUse .json endpoints.',
+        'utf-8',
+      )
+    })
+
+    afterEach(() => {
+      if (originalDataDir === undefined) {
+        delete process.env.DATA_DIR
+      } else {
+        process.env.DATA_DIR = originalDataDir
+      }
+      try { fs.rmSync(skillsTmpDir, { recursive: true, force: true }) } catch { /* ignore */ }
+    })
+
+    async function captureSystemPrompt(overrides: TaskOverrides): Promise<string> {
+      const { Agent } = await import('@mariozechner/pi-agent-core')
+      const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+
+      type Captured = { initialState: { systemPrompt: string } }
+      const captured: { value: Captured | null } = { value: null }
+      const messages: unknown[] = []
+      MockAgent.mockImplementationOnce((options: unknown) => {
+        captured.value = options as Captured
+        return {
+          subscribe: vi.fn(() => () => {}),
+          prompt: vi.fn(async () => {
+            messages.push({
+              role: 'assistant',
+              content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: ok' }],
+            })
+          }),
+          abort: vi.fn(),
+          state: { get messages() { return messages } },
+        }
+      })
+
+      const task = store.create({
+        name: 'Attached Skills Task',
+        prompt: 'Do work',
+        triggerType: 'cronjob',
+      })
+      await runner.startTask(task, mockProvider, overrides)
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      if (!captured.value) throw new Error('Agent was not instantiated')
+      return captured.value.initialState.systemPrompt
+    }
+
+    it('injects <attached_skills> block with SKILL.md content before the base prompt', async () => {
+      const systemPrompt = await captureSystemPrompt({ attachedSkills: ['nitter', 'reddit'] })
+
+      expect(systemPrompt.startsWith('<attached_skills>')).toBe(true)
+      expect(systemPrompt).toContain('<skill name="nitter">')
+      expect(systemPrompt).toContain('Nitter Skill')
+      expect(systemPrompt).toContain('Always rotate Nitter mirrors.')
+      expect(systemPrompt).toContain('<skill name="reddit">')
+      expect(systemPrompt).toContain('Use .json endpoints.')
+      expect(systemPrompt).toContain('</attached_skills>')
+
+      // Base task prompt must still follow the attached-skills block
+      expect(systemPrompt).toContain('background task agent')
+      expect(systemPrompt).toContain('Do work')
+      const blockEnd = systemPrompt.indexOf('</attached_skills>')
+      const baseStart = systemPrompt.indexOf('background task agent')
+      expect(blockEnd).toBeGreaterThan(-1)
+      expect(baseStart).toBeGreaterThan(blockEnd)
+    })
+
+    it('skips missing SKILL.md files with a warning and still runs the task', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const systemPrompt = await captureSystemPrompt({ attachedSkills: ['nitter', 'does-not-exist'] })
+
+        expect(systemPrompt).toContain('<skill name="nitter">')
+        expect(systemPrompt).not.toContain('<skill name="does-not-exist">')
+        expect(warnSpy).toHaveBeenCalled()
+        const warned = warnSpy.mock.calls.some(args => String(args[0] ?? '').includes('does-not-exist'))
+        expect(warned).toBe(true)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('does not add an attached-skills block when attachedSkills is empty/null', async () => {
+      const systemPromptNull = await captureSystemPrompt({ attachedSkills: null })
+      expect(systemPromptNull).not.toContain('<attached_skills>')
+
+      const systemPromptEmpty = await captureSystemPrompt({ attachedSkills: [] })
+      expect(systemPromptEmpty).not.toContain('<attached_skills>')
+    })
+
+    it('rejects unsafe skill names containing path separators', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const systemPrompt = await captureSystemPrompt({ attachedSkills: ['../etc/passwd', 'nitter'] })
+        expect(systemPrompt).toContain('<skill name="nitter">')
+        expect(systemPrompt).not.toContain('../etc/passwd')
+        expect(warnSpy).toHaveBeenCalled()
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
 })

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -1,7 +1,10 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { Agent as PiAgent } from '@mariozechner/pi-agent-core'
 import type { AgentEvent, AgentTool } from '@mariozechner/pi-agent-core'
 import type { AssistantMessage, Message, Model, Api } from '@mariozechner/pi-ai'
 import type { Database } from './database.js'
+import { getAgentSkillsDir } from './agent-skills.js'
 import type { SettingsThinkingLevel } from './contracts/settings.js'
 import { readBackgroundThinkingLevelFromConfig } from './thinking-level.js'
 import { TaskStore } from './task-store.js'
@@ -28,6 +31,13 @@ export interface TaskOverrides {
   skillsOverride?: string | null
   /** Custom system prompt — replaces default entirely when set */
   systemPromptOverride?: string | null
+  /**
+   * Names of agent skills (directories under `/data/skills_agent/<name>/`)
+   * whose `SKILL.md` content is injected verbatim into the task system
+   * prompt under an `<attached_skills>` block. Missing files are skipped
+   * with a warning so the task still runs.
+   */
+  attachedSkills?: string[] | null
 }
 
 export interface TaskRunnerOptions {
@@ -113,6 +123,51 @@ interface PausedTask {
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000
 /** Max time a task can remain paused before being cleaned up (24 hours) */
 const MAX_PAUSE_DURATION_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Read an agent skill's SKILL.md and return its content, or null if not found / unreadable.
+ * Logs a warning but never throws — missing skills must not crash a task.
+ */
+export function loadAttachedSkillContent(skillName: string, skillsDir: string = getAgentSkillsDir()): string | null {
+  // Reject obviously unsafe names (path traversal / absolute paths).
+  if (!skillName || skillName.includes('/') || skillName.includes('\\') || skillName === '.' || skillName === '..') {
+    console.warn(`[task-runner] attachedSkills: ignoring invalid skill name "${skillName}"`)
+    return null
+  }
+
+  const skillPath = path.join(skillsDir, skillName, 'SKILL.md')
+  try {
+    return fs.readFileSync(skillPath, 'utf-8')
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    console.warn(`[task-runner] attachedSkills: could not read ${skillPath}: ${reason}`)
+    return null
+  }
+}
+
+/**
+ * Render an `<attached_skills>` XML-ish block for injection into a task prompt.
+ * Returns an empty string if no skills were loaded successfully so callers can
+ * unconditionally concatenate the result.
+ */
+export function renderAttachedSkillsBlock(
+  skillNames: readonly string[] | null | undefined,
+  skillsDir: string = getAgentSkillsDir(),
+): string {
+  if (!skillNames || skillNames.length === 0) return ''
+
+  const parts: string[] = []
+  for (const name of skillNames) {
+    const content = loadAttachedSkillContent(name, skillsDir)
+    if (content === null) continue
+    // Escape any closing tag in the content so the block stays well-formed.
+    const safe = content.replace(/<\/skill>/gi, '</ skill>')
+    parts.push(`<skill name="${name}">\n${safe.trim()}\n</skill>`)
+  }
+
+  if (parts.length === 0) return ''
+  return `<attached_skills>\n${parts.join('\n\n')}\n</attached_skills>`
+}
 
 /**
  * Build the system prompt for a task agent
@@ -284,9 +339,16 @@ export class TaskRunner {
     const apiKey = await this.options.getApiKey(provider)
 
     // Determine effective system prompt
-    const systemPrompt = overrides?.systemPromptOverride
+    const baseSystemPrompt = overrides?.systemPromptOverride
       ? overrides.systemPromptOverride
       : buildTaskSystemPrompt(task.prompt, this.options.memoryDir)
+
+    // Inject attached-skills block (before the base prompt) so skill rules are
+    // anchored at the top and apply regardless of the rest of the prompt.
+    const attachedSkillsBlock = renderAttachedSkillsBlock(overrides?.attachedSkills ?? null)
+    const systemPrompt = attachedSkillsBlock
+      ? `${attachedSkillsBlock}\n\n${baseSystemPrompt}`
+      : baseSystemPrompt
 
     // Determine effective tools (filter out disabled tools)
     let effectiveTools = this.options.tools

--- a/packages/core/src/task-scheduler.ts
+++ b/packages/core/src/task-scheduler.ts
@@ -373,6 +373,7 @@ export class TaskScheduler {
       toolsOverride: scheduledTask.toolsOverride,
       skillsOverride: scheduledTask.skillsOverride,
       systemPromptOverride: scheduledTask.systemPromptOverride,
+      attachedSkills: scheduledTask.attachedSkills,
     }
 
     // Start the task

--- a/packages/web-backend/src/routes/cronjobs.ts
+++ b/packages/web-backend/src/routes/cronjobs.ts
@@ -44,13 +44,14 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
    */
   router.post('/', (req: AuthenticatedRequest, res) => {
     try {
-      const { name, prompt, schedule, actionType, provider, enabled } = req.body as {
+      const { name, prompt, schedule, actionType, provider, enabled, attachedSkills } = req.body as {
         name?: string
         prompt?: string
         schedule?: string
         actionType?: string
         provider?: string
         enabled?: boolean
+        attachedSkills?: string[] | null
       }
 
       if (!name || !prompt || !schedule) {
@@ -65,6 +66,22 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
         return
       }
 
+      // Validate attachedSkills if provided
+      let normalizedAttachedSkills: string[] | null | undefined = undefined
+      if (attachedSkills !== undefined) {
+        if (attachedSkills === null) {
+          normalizedAttachedSkills = null
+        } else if (!Array.isArray(attachedSkills) || !attachedSkills.every((v: unknown) => typeof v === 'string')) {
+          res.status(400).json({ error: 'attachedSkills must be an array of strings' })
+          return
+        } else {
+          normalizedAttachedSkills = Array.from(new Set(
+            attachedSkills.map(v => v.trim()).filter(v => v.length > 0),
+          ))
+          if (normalizedAttachedSkills.length === 0) normalizedAttachedSkills = null
+        }
+      }
+
       const taskRuntime = getTaskRuntime()
       const cronjob = taskRuntime
         ? taskRuntime.create({
@@ -74,6 +91,7 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
             actionType: actionType === 'injection' ? 'injection' : 'task',
             provider: provider || undefined,
             enabled: enabled !== undefined ? enabled : true,
+            attachedSkills: normalizedAttachedSkills,
           })
         : store.create({
             name,
@@ -82,6 +100,7 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
             actionType: actionType === 'injection' ? 'injection' : 'task',
             provider: provider || undefined,
             enabled: enabled !== undefined ? enabled : true,
+            attachedSkills: normalizedAttachedSkills,
           })
 
       // Register with scheduler boundary when available
@@ -114,7 +133,7 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
         return
       }
 
-      const { name, prompt, schedule, actionType, provider, enabled, toolsOverride, skillsOverride, systemPromptOverride } = req.body as {
+      const { name, prompt, schedule, actionType, provider, enabled, toolsOverride, skillsOverride, systemPromptOverride, attachedSkills } = req.body as {
         name?: string
         prompt?: string
         schedule?: string
@@ -124,6 +143,7 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
         toolsOverride?: string | null
         skillsOverride?: string | null
         systemPromptOverride?: string | null
+        attachedSkills?: string[] | null
       }
 
       // Validate cron expression if provided
@@ -167,6 +187,22 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
         return
       }
 
+      // Validate + normalize attachedSkills if provided
+      let attachedSkillsUpdate: string[] | null | undefined = undefined
+      if (attachedSkills !== undefined) {
+        if (attachedSkills === null) {
+          attachedSkillsUpdate = null
+        } else if (!Array.isArray(attachedSkills) || !attachedSkills.every((v: unknown) => typeof v === 'string')) {
+          res.status(400).json({ error: 'attachedSkills must be an array of strings' })
+          return
+        } else {
+          const normalized = Array.from(new Set(
+            attachedSkills.map(v => v.trim()).filter(v => v.length > 0),
+          ))
+          attachedSkillsUpdate = normalized.length === 0 ? null : normalized
+        }
+      }
+
       const updated = taskRuntime
         ? taskRuntime.update(id, {
             name,
@@ -178,6 +214,7 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
             toolsOverride: toolsOverride !== undefined ? toolsOverride : undefined,
             skillsOverride: skillsOverride !== undefined ? skillsOverride : undefined,
             systemPromptOverride: systemPromptOverride !== undefined ? systemPromptOverride : undefined,
+            attachedSkills: attachedSkillsUpdate,
           })
         : store.update(id, {
             name,
@@ -189,6 +226,7 @@ export function createCronjobsRouter(options: CronjobsRouterOptions): Router {
             toolsOverride: toolsOverride !== undefined ? toolsOverride : undefined,
             skillsOverride: skillsOverride !== undefined ? skillsOverride : undefined,
             systemPromptOverride: systemPromptOverride !== undefined ? systemPromptOverride : undefined,
+            attachedSkills: attachedSkillsUpdate,
           })
 
       if (!updated) {

--- a/packages/web-frontend/app/components/CronjobFormDialog.vue
+++ b/packages/web-frontend/app/components/CronjobFormDialog.vue
@@ -153,6 +153,42 @@
 
             <Separator />
 
+            <!-- Attached Skills -->
+            <div class="space-y-3">
+              <Label>{{ $t('cronjobs.form.attachedSkills') }}</Label>
+              <p class="text-xs text-muted-foreground">
+                {{ $t('cronjobs.form.attachedSkillsHelp') }}
+              </p>
+              <div v-if="availableAgentSkillNames.length > 0" class="space-y-2">
+                <div
+                  v-for="skill in availableAgentSkillNames"
+                  :key="`attached-${skill}`"
+                  class="flex items-center justify-between py-1"
+                >
+                  <span class="text-sm font-mono">{{ skill }}</span>
+                  <Switch
+                    :checked="attachedSkills.includes(skill)"
+                    @update:checked="(val: boolean) => toggleAttachedSkill(skill, val)"
+                  />
+                </div>
+                <div v-if="attachedSkills.length > 0" class="flex flex-wrap gap-1.5 pt-1">
+                  <Badge
+                    v-for="skill in attachedSkills"
+                    :key="`attached-selected-${skill}`"
+                    variant="secondary"
+                    class="text-xs font-normal"
+                  >
+                    📎 {{ skill }}
+                  </Badge>
+                </div>
+              </div>
+              <p v-else class="text-xs text-muted-foreground italic">
+                {{ $t('cronjobs.form.noAgentSkills') }}
+              </p>
+            </div>
+
+            <Separator />
+
             <!-- System Prompt Override -->
             <div class="space-y-2">
               <Label for="cronjob-system-prompt">{{ $t('cronjobs.form.systemPromptOverride') }}</Label>
@@ -204,10 +240,12 @@ const emit = defineEmits<{
     toolsOverride?: string | null
     skillsOverride?: string | null
     systemPromptOverride?: string | null
+    attachedSkills?: string[] | null
   }]
 }>()
 
 const { providers, fetchProviders } = useProviders()
+const { agentSkills, fetchAgentSkills } = useSkills()
 
 const advancedOpen = ref(false)
 
@@ -241,16 +279,34 @@ const form = reactive({
 
 const disabledTools = ref<string[]>([])
 const disabledSkills = ref<string[]>([])
+const attachedSkills = ref<string[]>([])
+
+/** List of agent skill names available for the attached-skills picker. */
+const availableAgentSkillNames = computed<string[]>(() =>
+  (agentSkills.value ?? []).map(s => s.name).sort((a, b) => a.localeCompare(b)),
+)
 
 const hasOverrides = computed(() => {
   return disabledTools.value.length > 0
     || disabledSkills.value.length > 0
+    || attachedSkills.value.length > 0
     || (form.systemPromptOverride && form.systemPromptOverride.trim().length > 0)
 })
+
+function toggleAttachedSkill(skill: string, enabled: boolean) {
+  if (enabled) {
+    if (!attachedSkills.value.includes(skill)) {
+      attachedSkills.value = [...attachedSkills.value, skill]
+    }
+  } else {
+    attachedSkills.value = attachedSkills.value.filter(s => s !== skill)
+  }
+}
 
 watch(() => props.open, (isOpen) => {
   if (isOpen) {
     fetchProviders()
+    fetchAgentSkills()
     if (props.mode === 'edit' && props.cronjob) {
       form.name = props.cronjob.name
       form.prompt = props.cronjob.prompt
@@ -281,9 +337,15 @@ watch(() => props.open, (isOpen) => {
         disabledSkills.value = []
       }
 
+      // Attached skills (array on the cronjob)
+      attachedSkills.value = Array.isArray(props.cronjob.attachedSkills)
+        ? [...props.cronjob.attachedSkills]
+        : []
+
       // Auto-expand advanced section if there are overrides
       advancedOpen.value = disabledTools.value.length > 0
         || disabledSkills.value.length > 0
+        || attachedSkills.value.length > 0
         || (form.systemPromptOverride?.trim().length ?? 0) > 0
     } else {
       form.name = ''
@@ -294,6 +356,7 @@ watch(() => props.open, (isOpen) => {
       form.systemPromptOverride = ''
       disabledTools.value = []
       disabledSkills.value = []
+      attachedSkills.value = []
       advancedOpen.value = false
     }
   }
@@ -333,6 +396,9 @@ function onSubmit() {
       disabledSkills.value.length > 0 ? JSON.stringify(disabledSkills.value) : null
     ),
     systemPromptOverride: form.actionType === 'injection' ? null : (form.systemPromptOverride?.trim() || null),
+    attachedSkills: form.actionType === 'injection'
+      ? null
+      : (attachedSkills.value.length > 0 ? [...attachedSkills.value] : null),
   })
 }
 </script>

--- a/packages/web-frontend/app/composables/useCronjobs.ts
+++ b/packages/web-frontend/app/composables/useCronjobs.ts
@@ -12,6 +12,7 @@ export interface Cronjob {
   toolsOverride: string | null
   skillsOverride: string | null
   systemPromptOverride: string | null
+  attachedSkills: string[] | null
   lastRunAt: string | null
   lastRunTaskId: string | null
   lastRunStatus: string | null
@@ -37,6 +38,7 @@ export interface CronjobFormData {
   toolsOverride?: string | null
   skillsOverride?: string | null
   systemPromptOverride?: string | null
+  attachedSkills?: string[] | null
 }
 
 export function useCronjobs() {

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -880,6 +880,9 @@
       "skillOverrides": "Skill-Überschreibungen",
       "skillOverridesHelp": "Aktivieren oder deaktivieren Sie einzelne Skills für diesen Cronjob. Deaktivierte Skills werden vom Task-Agenten ausgeschlossen.",
       "noSkills": "Keine Skills verfügbar.",
+      "attachedSkills": "Angehängte Skills",
+      "attachedSkillsHelp": "Agent-Skills, deren SKILL.md beim Auslösen dieses Cronjobs direkt in den Task-Prompt eingefügt wird. Nützlich für Skills, die der Cronjob immer benötigt (z.B. nitter, wiki).",
+      "noAgentSkills": "Keine Agent-Skills gefunden.",
       "systemPromptOverride": "System-Prompt-Überschreibung",
       "systemPromptOverrideHelp": "Wenn gesetzt, ersetzt dies den Standard-System-Prompt des Task-Agenten vollständig.",
       "systemPromptPlaceholder": "Du bist ein Hintergrund-Task-Agent. Deine Aufgabe: ...\n\nLeer lassen, um den Standard-System-Prompt zu verwenden."
@@ -887,7 +890,8 @@
     "badges": {
       "customTools": "eigene Tools",
       "customSkills": "eigene Skills",
-      "customPrompt": "eigener Prompt"
+      "customPrompt": "eigener Prompt",
+      "attachedSkillTooltip": "Angehängter Skill: {name}"
     }
   },
   "taskViewer": {

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -880,6 +880,9 @@
       "skillOverrides": "Skill Overrides",
       "skillOverridesHelp": "Toggle individual skills on or off for this cronjob. Disabled skills will be excluded from the task agent.",
       "noSkills": "No skills available.",
+      "attachedSkills": "Attached Skills",
+      "attachedSkillsHelp": "Agent skills whose SKILL.md will be injected into the task prompt when this cronjob fires. Useful for skills the cronjob always needs (e.g. nitter, wiki).",
+      "noAgentSkills": "No agent skills found.",
       "systemPromptOverride": "System Prompt Override",
       "systemPromptOverrideHelp": "When set, this completely replaces the default task agent system prompt.",
       "systemPromptPlaceholder": "You are a background task agent. Your task: ...\n\nLeave empty to use the default system prompt."
@@ -887,7 +890,8 @@
     "badges": {
       "customTools": "custom tools",
       "customSkills": "custom skills",
-      "customPrompt": "custom prompt"
+      "customPrompt": "custom prompt",
+      "attachedSkillTooltip": "Attached skill: {name}"
     }
   },
   "taskViewer": {

--- a/packages/web-frontend/app/pages/cronjobs.vue
+++ b/packages/web-frontend/app/pages/cronjobs.vue
@@ -94,8 +94,8 @@
               class="cursor-pointer"
               @click="openEditCronjob(cj)"
             >
-              <TableCell class="max-w-[200px] font-medium">
-                <div class="flex items-center gap-1.5">
+              <TableCell class="max-w-[260px] font-medium">
+                <div class="flex flex-wrap items-center gap-1.5">
                   <span class="truncate">{{ cj.name }}</span>
                   <Badge v-if="cj.toolsOverride" variant="outline" class="shrink-0 text-xs">
                     {{ $t('cronjobs.badges.customTools') }}
@@ -105,6 +105,15 @@
                   </Badge>
                   <Badge v-if="cj.systemPromptOverride" variant="outline" class="shrink-0 text-xs">
                     {{ $t('cronjobs.badges.customPrompt') }}
+                  </Badge>
+                  <Badge
+                    v-for="skill in cj.attachedSkills || []"
+                    :key="`attached-${skill}`"
+                    variant="secondary"
+                    class="shrink-0 text-xs font-normal"
+                    :title="$t('cronjobs.badges.attachedSkillTooltip', { name: skill })"
+                  >
+                    📎 {{ skill }}
                   </Badge>
                 </div>
               </TableCell>
@@ -235,7 +244,7 @@ function openEditCronjob(cj: Cronjob) {
   cronjobDialog.open = true
 }
 
-async function handleCronjobSubmit(form: { name: string; prompt: string; schedule: string; actionType?: 'task' | 'injection'; provider?: string; toolsOverride?: string | null; skillsOverride?: string | null; systemPromptOverride?: string | null }) {
+async function handleCronjobSubmit(form: { name: string; prompt: string; schedule: string; actionType?: 'task' | 'injection'; provider?: string; toolsOverride?: string | null; skillsOverride?: string | null; systemPromptOverride?: string | null; attachedSkills?: string[] | null }) {
   cronjobDialog.loading = true
 
   if (cronjobDialog.mode === 'create') {


### PR DESCRIPTION
## Problem

Cronjobs that depend on a specific skill (`nitter`, `reddit`, `wiki`, …) currently have to spend the first tool call of every run on `read_file` to load the skill's `SKILL.md`. That costs a round-trip on every fire and makes the skill context non-deterministic — a cronjob can silently "forget" to load the skill if the prompt wording drifts.

## Change

Cronjobs now accept an optional `attachedSkills: string[]`. When a cronjob fires as a `task`, the runner reads `SKILL.md` from `<DATA_DIR>/skills_agent/<name>/` for each entry and injects the content verbatim into the task system prompt under an `<attached_skills>` block, ahead of the base prompt.

- **Data model**: new `attached_skills TEXT` column on `scheduled_tasks` (JSON array), with a non-destructive `ALTER TABLE` migration. `ScheduledTask.attachedSkills: string[] | null`.
- **Task runner**: `renderAttachedSkillsBlock()` builds the block. Missing `SKILL.md` → `console.warn` and skip, never throws. Skill names containing path separators or `..` are rejected.
- **Task scheduler**: forwards `scheduledTask.attachedSkills` into `TaskOverrides` when firing a cronjob.
- **Agent tools**: `create_cronjob` and `edit_cronjob` accept `attached_skills: string[]` (deduped, trimmed, empty strings dropped). On `edit_cronjob`, `[]` clears the list; omitting the field leaves it unchanged. `list_cronjobs` and `get_cronjob` now show the attached skills.
- **REST API**: `POST /api/cronjobs` and `PUT /api/cronjobs/:id` accept and validate `attachedSkills` (array of strings, `null` clears).
- **Backward compatibility**: existing cronjobs without `attachedSkills` are unaffected — the block is only rendered when the list is non-empty.

## Testing

- New `packages/core/src/cronjob-tools.test.ts` (6 tests) covering create/edit persistence, normalization, clear-via-`[]`, and unchanged-on-omit.
- Extended `packages/core/src/task-runner.test.ts` (4 new tests) covering:
  - `<attached_skills>` block is injected before the base prompt with correct content,
  - missing `SKILL.md` warns and does not abort,
  - empty/null `attachedSkills` injects nothing,
  - path-traversal skill names are rejected.
- `npx vitest run packages/core` → 767 tests pass (up from 757). The 35 pre-existing `packages/web-backend/src/app.test.ts` auth/401 failures reproduce identically on `upstream/main` and are unrelated.