### PR TITLE
fix(build): install devDependencies when NODE_ENV=production

### DIFF
--- a/.github/workflows/ci-guardrails.yml
+++ b/.github/workflows/ci-guardrails.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --include=dev
 
       - name: Lint boundaries
         run: npm run lint:boundaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ COPY packages/telegram/package.json packages/telegram/
 COPY packages/web-backend/package.json packages/web-backend/
 COPY packages/web-frontend/package.json packages/web-frontend/
 
-# Install dependencies
-RUN npm ci
+# Install dependencies (include devDependencies for TypeScript type declarations)
+RUN npm ci --include=dev
 
 # Copy source code
 COPY . .

--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -780,7 +780,7 @@ describe('TaskRunner', () => {
 
       // The PiAgent should have been created with only read_file
       expect(capturedOptions).toBeTruthy()
-      const passedTools = capturedOptions.initialState.tools
+      const passedTools = capturedOptions!.initialState.tools
       expect(passedTools).toHaveLength(1)
       expect(passedTools[0].name).toBe('read_file')
 
@@ -845,7 +845,7 @@ describe('TaskRunner', () => {
 
       // The PiAgent should have been created with the custom system prompt
       expect(capturedOptions).toBeTruthy()
-      expect(capturedOptions.initialState.systemPrompt).toBe(customPrompt)
+      expect(capturedOptions!.initialState.systemPrompt).toBe(customPrompt)
 
       const updated = store.getById(task.id)!
       expect(updated.status).toBe('completed')
@@ -887,8 +887,8 @@ describe('TaskRunner', () => {
       await new Promise(resolve => setTimeout(resolve, 100))
 
       // Should use default prompt (contains "background task agent")
-      expect(capturedOptions.initialState.systemPrompt).toContain('background task agent')
-      expect(capturedOptions.initialState.systemPrompt).toContain('Do work')
+      expect(capturedOptions!.initialState.systemPrompt).toContain('background task agent')
+      expect(capturedOptions!.initialState.systemPrompt).toContain('Do work')
     })
 
     it('handles invalid toolsOverride JSON gracefully', async () => {


### PR DESCRIPTION
## Problem

The container sets `NODE_ENV=production`, which causes `npm ci` to skip all `devDependencies`. This includes all `@types/*` packages, breaking the TypeScript build with dozens of `TS7016` errors (`express`, `bcrypt`, `ws`, `multer`, `jsonwebtoken`, `better-sqlite3`, `adm-zip`, `js-yaml`).

Additionally, 4 `TS18047` strict-null errors in `task-runner.test.ts` where `capturedOptions` was accessed without a null check after `toBeTruthy()`.

## Changes

- **`Dockerfile`**: `npm ci` → `npm ci --include=dev`
- **`.github/workflows/ci-guardrails.yml`**: same fix
- **`packages/core/src/task-runner.test.ts`**: added non-null assertions (`!`) at 4 affected lines (783, 848, 890, 891)

## Testing

`npm ci --include=dev && npm run build` — all workspaces build clean, no TS errors.