### PR TITLE
fix(settings): prevent double-encryption of braveSearchApiKey

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,7 +89,7 @@ export {
   PROVIDER_TYPE_MODEL_OVERRIDES,
 } from './provider-config.js'
 export type { ProviderConfig, ProviderModelConfig, ProvidersFile, ProviderType, ProviderTypePreset, AuthMethod, AvailableModel, OAuthCredentialsStored, TokenPriceTable } from './provider-config.js'
-export { encrypt, decrypt, maskApiKey } from './encryption.js'
+export { encrypt, decrypt, isEncrypted, maskApiKey } from './encryption.js'
 export {
   logTokenUsage,
   logToolCall,

--- a/packages/core/src/web-tools.ts
+++ b/packages/core/src/web-tools.ts
@@ -358,7 +358,8 @@ export async function searchSearXNG(
  * Encrypt a Brave Search API key for storage in settings.json.
  */
 export function encryptBraveApiKey(apiKey: string): string {
-  return encrypt(apiKey)
+  if (!apiKey) return ''
+  return isEncrypted(apiKey) ? apiKey : encrypt(apiKey)
 }
 
 /**

--- a/packages/web-backend/src/routes/skills.ts
+++ b/packages/web-backend/src/routes/skills.ts
@@ -14,6 +14,7 @@ import {
   ensureConfigTemplates,
   getConfigDir,
   encrypt,
+  isEncrypted,
   maskApiKey,
   listAgentSkills,
 } from '@openagent/core'
@@ -250,7 +251,8 @@ export function createSkillsRouter(options: SkillsRouterOptions = {}): Router {
       // Encrypt and store braveSearchApiKey — write into builtinTools.webSearch
       // so createBuiltinWebTools() picks it up, plus top-level for API response
       if (body.braveSearchApiKey !== undefined) {
-        const encrypted = body.braveSearchApiKey ? encrypt(body.braveSearchApiKey) : ''
+        const raw = body.braveSearchApiKey
+        const encrypted = raw ? (isEncrypted(raw) ? raw : encrypt(raw)) : ''
         settings.braveSearchApiKey = encrypted
         if (!settings.builtinTools) settings.builtinTools = {}
         if (!settings.builtinTools.webSearch) settings.builtinTools.webSearch = { enabled: true, provider: 'duckduckgo' }


### PR DESCRIPTION
## Problem

When the skills settings endpoint (`PATCH /api/skills/builtin`) saves `braveSearchApiKey`, it calls `encrypt()` unconditionally. The `GET` side masks the key for display, but if the frontend ever round-trips an already-encrypted value back (e.g. a workflow that loads settings and re-saves other fields without touching the masked key, or a client that reads the raw ciphertext from settings.json), the value gets encrypted a second time. `decrypt()` only unwraps one layer, so the Brave Search tool ends up with a still-ciphertext string and gets rejected with HTTP 401.

## Change

- Export the existing `isEncrypted(value)` helper from `packages/core/src/index.ts` (it was already defined in `encryption.ts` but not re-exported).
- `web-tools.ts::encryptBraveApiKey()` now short-circuits: empty input → empty string, already-encrypted → pass through unchanged, plaintext → `encrypt()`.
- `web-backend/src/routes/skills.ts` applies the same guard at the skills-settings write path for `body.braveSearchApiKey`.

Net: re-saving an unchanged encrypted value is now idempotent. No migration needed; once written through the new path, the value is always singly encrypted.

## Testing

- `npm run lint` — clean.
- `npm run lint:boundaries` — clean.
- `npm run baseline:unit` — 856/856 passed (45 files).
- `npm run baseline:api` — 137 passed / 35 failed; the 35 failures are identical to the current `upstream/main` baseline (pre-existing auth-setup failures in `app.test.ts`, unrelated to this change).
- `npm run build` in `packages/core` and `packages/web-backend` — both compile clean.

Rebased cleanly on current `upstream/main`; only a single commit on top.
