### PR TITLE
fix(tasks): add missing 'consolidation' to valid trigger_type filter

### DIFF
--- a/packages/web-backend/src/api/modules/tasks/schema.ts
+++ b/packages/web-backend/src/api/modules/tasks/schema.ts
@@ -1,7 +1,7 @@
 import type { TaskStatus, TaskTriggerType } from '@openagent/core'
 
 const VALID_STATUSES: TaskStatus[] = ['running', 'paused', 'completed', 'failed']
-const VALID_TRIGGER_TYPES: TaskTriggerType[] = ['user', 'agent', 'cronjob', 'heartbeat']
+const VALID_TRIGGER_TYPES: TaskTriggerType[] = ['user', 'agent', 'cronjob', 'heartbeat', 'consolidation']
 
 export interface ListTasksQuery {
   page: number


### PR DESCRIPTION
## Problem

Filtering tasks by trigger type `consolidation` returned a 400 error:

```
Invalid trigger_type filter. Must be one of: user, agent, cronjob, heartbeat
```

## Root cause

`VALID_TRIGGER_TYPES` in `packages/web-backend/src/api/modules/tasks/schema.ts` was missing `'consolidation'`, even though:
- `TaskTriggerType` in core already includes it
- The SQLite `CHECK` constraint already allows it
- The frontend filter dropdown already shows the option

One-line sync fix.

## Testing

- `npm run lint` — 0 errors
- `npm run baseline:unit` — 856/856 passing