### PR TITLE
fix(tasks): don't overwrite aborted task status after agent.prompt() resolves

### DIFF
--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -278,6 +278,139 @@ describe('TaskRunner', () => {
       expect(runner.isRunning(task.id)).toBe(false)
       expect(abortCalled).toBe(true)
     })
+
+    it('does not overwrite the failure status after the in-flight prompt() resolves post-abort', async () => {
+      // Regression: pi-agent-core's `prompt()` resolves normally on abort
+      // (it appends an empty "aborted" assistant message and returns)
+      // instead of rejecting. Without the `aborted` guard in `runTaskAsync`,
+      // the success branch would parse that empty message, default the
+      // status to "completed", and overwrite the row that `abortTask` just
+      // marked as failed — also emitting a second `onTaskComplete` with the
+      // wrong status.
+      const { Agent } = await import('@mariozechner/pi-agent-core')
+      const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+
+      const messages: unknown[] = []
+      let resolvePrompt: (() => void) | null = null
+      MockAgent.mockImplementationOnce(() => {
+        return {
+          subscribe: vi.fn(() => () => {}),
+          prompt: vi.fn(() => new Promise<void>((resolve) => {
+            resolvePrompt = resolve
+          })),
+          abort: vi.fn(() => {
+            // Mirror real pi-agent-core behavior: append an empty failure
+            // message with stopReason="aborted" and resolve the prompt.
+            messages.push({
+              role: 'assistant',
+              content: [{ type: 'text', text: '' }],
+              stopReason: 'aborted',
+              errorMessage: 'aborted',
+            })
+            if (resolvePrompt) {
+              const r = resolvePrompt
+              resolvePrompt = null
+              r()
+            }
+          }),
+          state: {
+            get messages() { return messages },
+          },
+        }
+      })
+
+      const task = store.create({
+        name: 'Timeout Task',
+        prompt: 'Long running task',
+        triggerType: 'agent',
+        maxDurationMinutes: 1,
+      })
+
+      await runner.startTask(task, mockProvider)
+      expect(runner.isRunning(task.id)).toBe(true)
+
+      runner.abortTask(task.id, 'Max duration exceeded')
+
+      // DB shows the timeout failure right after abortTask returns.
+      let updated = store.getById(task.id)!
+      expect(updated.status).toBe('failed')
+      expect(updated.errorMessage).toBe('Max duration exceeded')
+
+      // Let the runTaskAsync continuation fire (prompt() resolved during abort()).
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      // The row must STILL be the timeout failure — not overwritten.
+      updated = store.getById(task.id)!
+      expect(updated.status).toBe('failed')
+      expect(updated.resultStatus).toBe('failed')
+      expect(updated.errorMessage).toBe('Max duration exceeded')
+      expect(updated.resultSummary).toBe('Max duration exceeded')
+
+      // Exactly one completion notification, with the failure injection.
+      expect(onTaskCompleteCalls).toHaveLength(1)
+      expect(onTaskCompleteCalls[0].injection).toContain('status="failed"')
+      expect(onTaskCompleteCalls[0].injection).toContain('Max duration exceeded')
+    })
+
+    it('fires the timer after maxDurationMinutes and aborts the task', async () => {
+      // End-to-end check that the setTimeout wired up in startTask actually
+      // calls abortTask once `maxDurationMinutes` elapses.
+      const { Agent } = await import('@mariozechner/pi-agent-core')
+      const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+
+      const messages: unknown[] = []
+      let resolvePrompt: (() => void) | null = null
+      MockAgent.mockImplementationOnce(() => {
+        return {
+          subscribe: vi.fn(() => () => {}),
+          prompt: vi.fn(() => new Promise<void>((resolve) => {
+            resolvePrompt = resolve
+          })),
+          abort: vi.fn(() => {
+            messages.push({
+              role: 'assistant',
+              content: [{ type: 'text', text: '' }],
+              stopReason: 'aborted',
+              errorMessage: 'aborted',
+            })
+            if (resolvePrompt) {
+              const r = resolvePrompt
+              resolvePrompt = null
+              r()
+            }
+          }),
+          state: { get messages() { return messages } },
+        }
+      })
+
+      vi.useFakeTimers()
+      try {
+        const task = store.create({
+          name: 'Timer Task',
+          prompt: 'Long running task',
+          triggerType: 'agent',
+          maxDurationMinutes: 2,
+        })
+
+        await runner.startTask(task, mockProvider)
+        expect(runner.isRunning(task.id)).toBe(true)
+
+        // Advance just under the timeout — still running.
+        await vi.advanceTimersByTimeAsync(2 * 60 * 1000 - 1000)
+        expect(runner.isRunning(task.id)).toBe(true)
+        expect(store.getById(task.id)!.status).toBe('running')
+
+        // Cross the threshold — timer should fire and abort the task.
+        await vi.advanceTimersByTimeAsync(2000)
+
+        const updated = store.getById(task.id)!
+        expect(updated.status).toBe('failed')
+        expect(updated.errorMessage).toBe('Max duration exceeded')
+        expect(runner.isRunning(task.id)).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('formatTaskInjection', () => {

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -107,6 +107,14 @@ interface RunningTask {
   statusUpdateTimer: ReturnType<typeof setInterval> | null
   /** When the task started running (for status update runtime calc) */
   startedAtMs: number
+  /**
+   * Set to true by `abortTask` (e.g. via the max-duration timeout or the UI
+   * kill button) before signalling the agent. `runTaskAsync` checks this
+   * flag after `agent.prompt()` settles so it does not overwrite the
+   * already-finalized DB row (pi-agent-core resolves the prompt() promise
+   * normally on abort instead of rejecting).
+   */
+  aborted: boolean
 }
 
 interface PausedTask {
@@ -435,6 +443,7 @@ export class TaskRunner {
         toolCallTracker: new ToolCallTracker(),
         statusUpdateTimer: null,
         startedAtMs: Date.now(),
+        aborted: false,
       }
 
       // Set up max duration timeout
@@ -509,6 +518,17 @@ export class TaskRunner {
     try {
       // Prompt the task agent with the task — the system prompt already contains the full task description
       await agent.prompt('Begin working on the task described in your system prompt. Work autonomously and report your results when done.')
+
+      // If the task was aborted (max-duration timeout, UI kill button, loop
+      // detection, ...), `abortTask`/`handleLoopDetected` has already
+      // finalized the DB row and emitted the completion notification.
+      // Bail out so we don't overwrite that state with a spurious
+      // "completed" status derived from the empty aborted assistant
+      // message that pi-agent-core appends on abort.
+      if (runningTask.aborted) {
+        unsubscribe()
+        return
+      }
 
       // Task completed successfully
       unsubscribe()
@@ -611,6 +631,13 @@ export class TaskRunner {
     } catch (err) {
       // Task failed
       unsubscribe()
+
+      // Same guard as the success path: if the task was aborted, the row
+      // has already been finalized. Don't overwrite it.
+      if (runningTask.aborted) {
+        return
+      }
+
       this.cleanupRunningTask(taskId)
 
       const errorMessage = err instanceof Error ? err.message : String(err)
@@ -903,6 +930,9 @@ export class TaskRunner {
     const { taskId } = runningTask
     const reason = `Loop detected (${result.method}): ${result.details}`
 
+    // Mark aborted before signalling so `runTaskAsync` skips its post-prompt
+    // bookkeeping (see comment in `abortTask`).
+    runningTask.aborted = true
     // Abort the agent
     runningTask.agent.abort()
     this.cleanupRunningTask(taskId)
@@ -1024,6 +1054,13 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       return
     }
 
+    // Mark the task as aborted BEFORE signalling the agent so the
+    // `runTaskAsync` continuation can see it. pi-agent-core's `prompt()`
+    // resolves normally on abort instead of rejecting, which would
+    // otherwise cause the success branch in `runTaskAsync` to overwrite
+    // the failure status we are about to write below with a spurious
+    // "completed" derived from the empty aborted assistant message.
+    runningTask.aborted = true
     // Abort the agent
     runningTask.agent.abort()
     this.cleanupRunningTask(taskId)
@@ -1132,6 +1169,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       toolCallTracker: new ToolCallTracker(),
       statusUpdateTimer: null,
       startedAtMs: task.startedAt ? new Date(task.startedAt).getTime() : Date.now(),
+      aborted: false,
     }
 
     // Set up periodic status updates for resumed task


### PR DESCRIPTION
## Problem

Tasks that hit `maxDurationMinutes` (or were killed via the UI) were silently flipped back to `status="completed"` with an empty summary moments after being correctly aborted.

Root cause: pi-agent-core's `Agent.prompt()` resolves **normally** when aborted instead of rejecting — its internal `runWithLifecycle` catches the abort error, appends an empty assistant message with `stopReason="aborted"`, and returns. The `runTaskAsync` continuation then:

1. Runs the success branch
2. Pulls the (empty) last assistant message → `resultText = ""`
3. `parseTaskOutput("")` defaults `status` to `"completed"` (no `STATUS:` marker found)
4. Calls `store.update(taskId, { status: "completed", resultStatus: "completed", resultSummary: "", ... })` — **overwriting** the `status="failed" / errorMessage="Max duration exceeded"` row that `abortTask` had just written
5. Emits a second `onTaskComplete` notification with the wrong status

Same race exists for the UI kill button and for `handleLoopDetected`.

## Fix

Track an `aborted` flag on `RunningTask`. `abortTask` and `handleLoopDetected` set it **before** calling `agent.abort()`, and both branches of `runTaskAsync` short-circuit when the flag is set, preserving the failure row written by the aborter.

Files changed:
- `packages/core/src/task-runner.ts` — add `aborted` flag, set it in `abortTask`/`handleLoopDetected`, guard both branches of `runTaskAsync`
- `packages/core/src/task-runner.test.ts` — two new regression tests

## Testing

- Both new tests **fail without the fix** and **pass with the fix** (verified by reverting `task-runner.ts` only and rerunning the suite).
- Full `packages/core` suite still green: **800 / 800** tests pass.

```
✓ packages/core/src/task-runner.test.ts (32 tests) 3696ms
Test Files  42 passed (42)
     Tests  800 passed (800)
```

The two new cases:

1. `does not overwrite the failure status after the in-flight prompt() resolves post-abort` — mocks pi-agent-core's real abort behavior (resolves the prompt + appends empty `stopReason="aborted"` message), aborts via `abortTask`, then waits a tick and asserts the DB row is still `failed` with `Max duration exceeded` and that exactly one completion notification was emitted.
2. `fires the timer after maxDurationMinutes and aborts the task` — uses `vi.useFakeTimers()` to drive the real `setTimeout` wired up in `startTask`, confirming the timer actually fires after `maxDurationMinutes * 60 * 1000` ms and aborts the task end-to-end.
