### PR TITLE
fix(tasks): prevent tasks from running past max duration

### DIFF
--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -704,6 +704,126 @@ describe('TaskRunner', () => {
     })
   })
 
+  describe('maxDurationMinutes enforcement across pause/resume', () => {
+    // Mocks an agent that asks a question on first prompt() and completes on
+    // the second (resume) prompt() — only after a configurable delay so the
+    // resumed run is observably long.
+    function mockPauseThenSlowComplete(resumeDelayMs: number) {
+      return async () => {
+        const { Agent } = await import('@mariozechner/pi-agent-core')
+        const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+        let callCount = 0
+        let resumeAbort: (() => void) | null = null
+        MockAgent.mockImplementationOnce(() => {
+          let subscribeFn: ((event: unknown) => void) | null = null
+          const messages: unknown[] = []
+          return {
+            subscribe: vi.fn((fn: (event: unknown) => void) => {
+              subscribeFn = fn
+              return () => { subscribeFn = null }
+            }),
+            prompt: vi.fn(async () => {
+              callCount++
+              if (callCount === 1) {
+                messages.push({
+                  role: 'assistant',
+                  content: [{ type: 'text', text: 'STATUS: question\nSUMMARY: ?' }],
+                })
+                return
+              }
+              // Resume call: block until either the delay elapses or abort()
+              // is invoked (which is what the max-duration timer triggers).
+              await new Promise<void>((resolve) => {
+                const t = setTimeout(resolve, resumeDelayMs)
+                resumeAbort = () => { clearTimeout(t); resolve() }
+              })
+              if (subscribeFn) {
+                subscribeFn({
+                  type: 'message_end',
+                  message: {
+                    role: 'assistant',
+                    content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: done' }],
+                    provider: 'test-provider',
+                    model: 'test-model',
+                    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+                  },
+                })
+              }
+              messages.push({
+                role: 'assistant',
+                content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: done' }],
+              })
+            }),
+            abort: vi.fn(() => { if (resumeAbort) resumeAbort() }),
+            state: { get messages() { return messages } },
+          }
+        })
+      }
+    }
+
+    it('aborts a resumed task whose original maxDuration deadline has already passed', async () => {
+      await mockPauseThenSlowComplete(60_000)()
+
+      const task = store.create({
+        name: 'Long-paused Task',
+        prompt: 'work',
+        triggerType: 'agent',
+        maxDurationMinutes: 1, // 1 minute budget
+      })
+
+      await runner.startTask(task, mockProvider)
+      await new Promise(resolve => setTimeout(resolve, 50))
+      expect(runner.isPaused(task.id)).toBe(true)
+
+      // Pretend the original task started 2 minutes ago — the 1-minute
+      // budget has already been blown while the task sat paused.
+      const longAgo = new Date(Date.now() - 2 * 60 * 1000)
+        .toISOString().replace('T', ' ').slice(0, 19)
+      store.update(task.id, { startedAt: longAgo })
+
+      const ok = await runner.resumeTask(task.id, 'go')
+      expect(ok).toBe(true)
+
+      // Resume must NOT leave the task running indefinitely — it should
+      // abort synchronously because the deadline already passed.
+      await new Promise(resolve => setTimeout(resolve, 50))
+      expect(runner.isRunning(task.id)).toBe(false)
+      const updated = store.getById(task.id)!
+      expect(updated.status).toBe('failed')
+      expect(updated.errorMessage).toBe('Max duration exceeded')
+    })
+
+    it('cleanupStalePausedTasks aborts paused tasks that exceeded maxDurationMinutes', async () => {
+      await mockPauseThenSlowComplete(60_000)()
+
+      const task = store.create({
+        name: 'Paused past deadline',
+        prompt: 'work',
+        triggerType: 'agent',
+        maxDurationMinutes: 1,
+      })
+
+      await runner.startTask(task, mockProvider)
+      await new Promise(resolve => setTimeout(resolve, 50))
+      expect(runner.isPaused(task.id)).toBe(true)
+
+      // Backdate startedAt past the 1-minute budget. pausedAt is fresh,
+      // so the 24h pause cap does NOT apply — only the maxDuration check
+      // should trigger cleanup.
+      const longAgo = new Date(Date.now() - 5 * 60 * 1000)
+        .toISOString().replace('T', ' ').slice(0, 19)
+      store.update(task.id, { startedAt: longAgo })
+
+      const cleaned = runner.cleanupStalePausedTasks()
+      expect(cleaned).toBe(1)
+      expect(runner.isPaused(task.id)).toBe(false)
+
+      const updated = store.getById(task.id)!
+      expect(updated.status).toBe('failed')
+      expect(updated.errorMessage).toBe('Max duration exceeded')
+    })
+  })
+
   describe('server restart recovery', () => {
     it('marks paused tasks as failed on recovery', async () => {
       // Manually insert a paused task in DB (simulating a task left from a previous server session)

--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -793,6 +793,65 @@ describe('TaskRunner', () => {
       expect(updated.errorMessage).toBe('Max duration exceeded')
     })
 
+    it('aborts a hung task that has no maxDurationMinutes via the runner-wide watchdog default', async () => {
+      // Build a runner whose default kicks in for tasks without their own
+      // limit (mirrors heartbeat/consolidation/cronjob tasks in production).
+      const watchdogRunner = new TaskRunner({
+        db,
+        buildModel: () => ({} as ReturnType<TaskRunnerOptions['buildModel']>),
+        getApiKey: async () => 'test-key',
+        tools: [],
+        memoryDir: undefined,
+        onTaskComplete: () => { /* ignore */ },
+        sessionManager,
+        defaultMaxDurationMinutes: 1, // 1-minute fallback
+      })
+
+      const { Agent } = await import('@mariozechner/pi-agent-core')
+      const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+      let resolvePrompt: (() => void) | null = null
+      MockAgent.mockImplementationOnce(() => ({
+        subscribe: vi.fn(() => () => {}),
+        // Hang forever — no error, no return — simulating a dead provider.
+        prompt: vi.fn(() => new Promise<void>((resolve) => { resolvePrompt = resolve })),
+        abort: vi.fn(() => { if (resolvePrompt) resolvePrompt() }),
+        state: { messages: [] },
+      }))
+
+      const task = store.create({
+        name: 'Heartbeat-like Task',
+        prompt: 'work',
+        triggerType: 'heartbeat',
+        // Intentionally no maxDurationMinutes — mirrors heartbeat/cron paths.
+      })
+
+      await watchdogRunner.startTask(task, mockProvider)
+      expect(watchdogRunner.isRunning(task.id)).toBe(true)
+
+      // Backdate startedAt so the watchdog deadline is already past, then
+      // re-arm by aborting via the same code path the timer would use.
+      const longAgo = new Date(Date.now() - 5 * 60 * 1000)
+        .toISOString().replace('T', ' ').slice(0, 19)
+      store.update(task.id, { startedAt: longAgo })
+
+      // Sanity-check the helper directly: re-invoking scheduling with a
+      // past-deadline task must abort synchronously.
+      const internal = watchdogRunner as unknown as {
+        scheduleMaxDurationTimeout: (rt: { taskId: string; timeoutTimer: unknown; startedAtMs: number }, t: { id: string; maxDurationMinutes: number | null; startedAt: string | null }) => void
+        runningTasks: Map<string, { taskId: string; timeoutTimer: unknown; startedAtMs: number }>
+      }
+      const rt = internal.runningTasks.get(task.id)!
+      const refreshed = store.getById(task.id)!
+      internal.scheduleMaxDurationTimeout(rt, refreshed)
+
+      const updated = store.getById(task.id)!
+      expect(updated.status).toBe('failed')
+      expect(updated.errorMessage).toBe('Max duration exceeded')
+      expect(watchdogRunner.isRunning(task.id)).toBe(false)
+
+      watchdogRunner.dispose()
+    })
+
     it('cleanupStalePausedTasks aborts paused tasks that exceeded maxDurationMinutes', async () => {
       await mockPauseThenSlowComplete(60_000)()
 

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -437,11 +437,14 @@ export class TaskRunner {
         startedAtMs: Date.now(),
       }
 
+      this.runningTasks.set(taskId, runningTask)
+
       // Set up max duration timeout
-      if (task.maxDurationMinutes && task.maxDurationMinutes > 0) {
-        runningTask.timeoutTimer = setTimeout(() => {
-          this.abortTask(taskId, 'Max duration exceeded')
-        }, task.maxDurationMinutes * 60 * 1000)
+      this.scheduleMaxDurationTimeout(runningTask, task)
+      // If already past the deadline, scheduleMaxDurationTimeout aborted the
+      // task synchronously — bail out before subscribing/running anything.
+      if (!this.runningTasks.has(taskId)) {
+        return taskId
       }
 
       // Set up periodic status updates
@@ -451,8 +454,6 @@ export class TaskRunner {
           this.emitStatusUpdate(runningTask, task)
         }, statusIntervalMinutes * 60 * 1000)
       }
-
-      this.runningTasks.set(taskId, runningTask)
 
       // Update task as started
       const now = new Date().toISOString().replace('T', ' ').slice(0, 19)
@@ -1064,6 +1065,48 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
   }
 
   /**
+   * Schedule the max-duration timeout for a running task.
+   *
+   * The deadline is anchored on `task.startedAt` (the original wall-clock
+   * start), NOT on the in-memory `startedAtMs`. This way the limit also
+   * survives pause/resume cycles: if a task pauses on a question and is
+   * resumed later, the remaining budget is computed against the original
+   * start, not refreshed from zero.
+   *
+   * If the deadline has already passed (e.g. a task is resumed long after
+   * `maxDurationMinutes` would have fired), the task is aborted synchronously
+   * and no timer is registered.
+   */
+  private scheduleMaxDurationTimeout(
+    runningTask: RunningTask,
+    task: { id: string; maxDurationMinutes: number | null; startedAt: string | null },
+  ): void {
+    if (runningTask.timeoutTimer) {
+      clearTimeout(runningTask.timeoutTimer)
+      runningTask.timeoutTimer = null
+    }
+
+    const maxMinutes = task.maxDurationMinutes
+    if (!maxMinutes || maxMinutes <= 0) return
+
+    const startedAtMs = task.startedAt
+      ? new Date(task.startedAt.replace(' ', 'T') + 'Z').getTime()
+      : runningTask.startedAtMs
+    const deadline = startedAtMs + maxMinutes * 60 * 1000
+    const remaining = deadline - Date.now()
+
+    if (remaining <= 0) {
+      // Already past the deadline (e.g. resumed long after the limit).
+      this.abortTask(runningTask.taskId, 'Max duration exceeded')
+      return
+    }
+
+    runningTask.timeoutTimer = setTimeout(() => {
+      this.abortTask(runningTask.taskId, 'Max duration exceeded')
+    }, remaining)
+  }
+
+  /**
    * Clean up a running task's resources
    */
   private cleanupRunningTask(taskId: string): void {
@@ -1143,6 +1186,15 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
     }
 
     this.runningTasks.set(taskId, runningTask)
+
+    // Re-arm the max-duration timeout against the original startedAt so
+    // resumed tasks cannot run past their original budget. If the deadline
+    // has already passed, this aborts synchronously and the task is no longer
+    // in the runningTasks map.
+    this.scheduleMaxDurationTimeout(runningTask, task)
+    if (!this.runningTasks.has(taskId)) {
+      return true
+    }
 
     // Subscribe to events for the resumed task
     const unsubscribe = agent.subscribe((event: AgentEvent) => {
@@ -1288,43 +1340,65 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
   }
 
   /**
-   * Clean up paused tasks that have been waiting for >24 hours
+   * Clean up paused tasks that have exceeded their time budget.
+   *
+   * Two independent limits apply, whichever is reached first:
+   *  1. `MAX_PAUSE_DURATION_MS` (24h) — hard cap on how long a task may sit
+   *     paused waiting for a user response, regardless of `maxDurationMinutes`.
+   *  2. `task.maxDurationMinutes` measured from `task.startedAt` — a paused
+   *     task must not silently outlive its configured max duration. Without
+   *     this check a task with `maxDurationMinutes=60` could remain paused
+   *     for up to 24h, and on resume run on with no remaining budget.
    */
   cleanupStalePausedTasks(): number {
     let cleanedCount = 0
     const now = Date.now()
 
     for (const [taskId, pausedTask] of this.pausedTasks) {
-      if (now - pausedTask.pausedAt >= MAX_PAUSE_DURATION_MS) {
-        // Free the agent from memory
-        pausedTask.agent.abort()
-        this.pausedTasks.delete(taskId)
+      const task = this.store.getById(taskId)
+      const pausedTooLong = now - pausedTask.pausedAt >= MAX_PAUSE_DURATION_MS
 
-        // Mark as failed in DB
-        const nowStr = new Date().toISOString().replace('T', ' ').slice(0, 19)
-        this.store.update(taskId, {
-          status: 'failed',
-          resultStatus: 'failed',
-          resultSummary: 'timeout — no response received',
-          errorMessage: 'timeout — no response received',
-          completedAt: nowStr,
-          promptTokens: pausedTask.promptTokens,
-          completionTokens: pausedTask.completionTokens,
-          estimatedCost: pausedTask.estimatedCost,
-          toolCallCount: pausedTask.toolCallCount,
-        })
-
-        // Notify via injection
-        const task = this.store.getById(taskId)
-        if (task) {
-          const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
-          const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
-          const injection = formatTaskInjection(task, durationMinutes)
-          this.notifyTaskComplete(taskId, injection, "failed", "timeout — no response received")
-        }
-
-        cleanedCount++
+      let maxDurationExceeded = false
+      if (task?.maxDurationMinutes && task.maxDurationMinutes > 0 && task.startedAt) {
+        const startedAtMs = new Date(task.startedAt.replace(' ', 'T') + 'Z').getTime()
+        const deadline = startedAtMs + task.maxDurationMinutes * 60 * 1000
+        maxDurationExceeded = now >= deadline
       }
+
+      if (!pausedTooLong && !maxDurationExceeded) continue
+
+      const reason = maxDurationExceeded
+        ? 'Max duration exceeded'
+        : 'timeout — no response received'
+
+      // Free the agent from memory
+      pausedTask.agent.abort()
+      this.pausedTasks.delete(taskId)
+
+      // Mark as failed in DB
+      const nowStr = new Date().toISOString().replace('T', ' ').slice(0, 19)
+      this.store.update(taskId, {
+        status: 'failed',
+        resultStatus: 'failed',
+        resultSummary: reason,
+        errorMessage: reason,
+        completedAt: nowStr,
+        promptTokens: pausedTask.promptTokens,
+        completionTokens: pausedTask.completionTokens,
+        estimatedCost: pausedTask.estimatedCost,
+        toolCallCount: pausedTask.toolCallCount,
+      })
+
+      // Notify via injection
+      const updated = this.store.getById(taskId)
+      if (updated) {
+        const startedAt = updated.startedAt ? new Date(updated.startedAt).getTime() : Date.now()
+        const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
+        const injection = formatTaskInjection(updated, durationMinutes)
+        this.notifyTaskComplete(taskId, injection, 'failed', reason)
+      }
+
+      cleanedCount++
     }
 
     return cleanedCount

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -76,6 +76,20 @@ export interface TaskRunnerOptions {
    * `sessions` table with the correct `type` and `parent_session_id`.
    */
   sessionManager: SessionManager
+  /**
+   * Watchdog fallback applied when `task.maxDurationMinutes` is null.
+   *
+   * Many internal task creators (agent heartbeat, memory consolidation,
+   * cronjobs, scheduled tasks) never set `maxDurationMinutes`, so without
+   * a fallback a task whose LLM call hangs silently (no error, no return)
+   * would sit at status='running' indefinitely. This option puts a hard
+   * upper bound on those runs.
+   *
+   * Set to a positive number to enable; leave undefined for legacy "no
+   * limit" behavior. The web-backend wires this to `tasks.maxDurationMinutes`
+   * from settings.
+   */
+  defaultMaxDurationMinutes?: number
 }
 
 /**
@@ -1086,8 +1100,15 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       runningTask.timeoutTimer = null
     }
 
-    const maxMinutes = task.maxDurationMinutes
-    if (!maxMinutes || maxMinutes <= 0) return
+    // Per-task limit takes precedence; fall back to the runner-wide default
+    // so internal callers (heartbeat, consolidation, cronjobs) that never set
+    // maxDurationMinutes still get a watchdog and cannot hang forever.
+    const maxMinutes = (task.maxDurationMinutes && task.maxDurationMinutes > 0)
+      ? task.maxDurationMinutes
+      : (this.options.defaultMaxDurationMinutes && this.options.defaultMaxDurationMinutes > 0
+          ? this.options.defaultMaxDurationMinutes
+          : 0)
+    if (maxMinutes <= 0) return
 
     const startedAtMs = task.startedAt
       ? new Date(task.startedAt.replace(' ', 'T') + 'Z').getTime()
@@ -1358,10 +1379,18 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       const task = this.store.getById(taskId)
       const pausedTooLong = now - pausedTask.pausedAt >= MAX_PAUSE_DURATION_MS
 
+      // Same fallback as scheduleMaxDurationTimeout: per-task limit, or the
+      // runner-wide default if the task has none.
+      const effectiveMaxMinutes = (task?.maxDurationMinutes && task.maxDurationMinutes > 0)
+        ? task.maxDurationMinutes
+        : (this.options.defaultMaxDurationMinutes && this.options.defaultMaxDurationMinutes > 0
+            ? this.options.defaultMaxDurationMinutes
+            : 0)
+
       let maxDurationExceeded = false
-      if (task?.maxDurationMinutes && task.maxDurationMinutes > 0 && task.startedAt) {
+      if (effectiveMaxMinutes > 0 && task?.startedAt) {
         const startedAtMs = new Date(task.startedAt.replace(' ', 'T') + 'Z').getTime()
-        const deadline = startedAtMs + task.maxDurationMinutes * 60 * 1000
+        const deadline = startedAtMs + effectiveMaxMinutes * 60 * 1000
         maxDurationExceeded = now >= deadline
       }
 

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -557,6 +557,11 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
       statusUpdateIntervalMinutes: taskSettings.statusUpdateIntervalMinutes,
       getProviderById: (id: string) => resolveProvider(id),
       taskEventBus,
+      // Watchdog fallback for tasks that never set maxDurationMinutes
+      // (heartbeat, consolidation, cronjobs, scheduled tasks). Without
+      // this a hung LLM call would leave the row at status='running'
+      // forever. Per-task limits still take precedence when set.
+      defaultMaxDurationMinutes: taskSettings.maxDurationMinutes,
     },
     scheduler: {
       getDefaultProvider: getTaskDefaultProvider,


### PR DESCRIPTION
This PR fixes 2 issues with tasks and max duration:

- The max-duration deadline is now anchored on the original task start and survives pause/resume cycles. Resumed tasks past their deadline abort immediately, paused tasks past their deadline are cleaned up alongside the existing 24h pause cap.
- A runner-wide watchdog default (sourced from the configured task max duration in settings) now applies to any task that doesn't set its own limit, so heartbeat/cron/consolidation tasks can no longer hang forever. Per-task limits still take precedence.

