### PR TITLE
fix(memory): make session-summary output format consistent

### DIFF
--- a/packages/core/src/agent-session-summary.test.ts
+++ b/packages/core/src/agent-session-summary.test.ts
@@ -169,9 +169,9 @@ describe('generateSessionSummary — open threads prompt', () => {
     expect(summary).toBe('Discussed Docker deployment options.')
   })
 
-  it('prompt instructs LLM to add ### Offene Fäden section for unresolved items', async () => {
+  it('prompt instructs LLM to add ### Open Threads section for unresolved items', async () => {
     mockCompleteSimple.mockResolvedValueOnce(
-      makeCompleteSimpleResponse('Discussed PR workflow.\n\n### Offene Fäden\n- PR for PDF upload not yet merged')
+      makeCompleteSimpleResponse('Discussed PR workflow.\n\n### Open Threads\n- PR for PDF upload not yet merged')
     )
 
     const agent = new AgentCore({
@@ -189,16 +189,21 @@ describe('generateSessionSummary — open threads prompt', () => {
       return mockCompleteSimple.mock.calls[0]
     })()
 
-    // The system prompt must mention "Offene Fäden"
-    expect(callOptions.systemPrompt).toContain('Offene Fäden')
+    // The system prompt must mention "Open Threads" (English, not the legacy German label)
+    expect(callOptions.systemPrompt).toContain('Open Threads')
+    expect(callOptions.systemPrompt).not.toContain('Offene Fäden')
     // The system prompt must explain what counts as open
     expect(callOptions.systemPrompt).toContain('unfinished tasks')
     // The system prompt must prohibit empty sections
     expect(callOptions.systemPrompt).toContain('empty')
+    // The system prompt must forbid leaking activity-log headings into the output
+    expect(callOptions.systemPrompt).toContain('# Activity Log')
+    // The system prompt must forbid horizontal rule separators
+    expect(callOptions.systemPrompt).toContain('---')
   })
 
   it('returns summary with open threads section when LLM includes it', async () => {
-    const llmOutput = 'Discussed PR for PDF upload extraction and open threads feature.\n\n### Offene Fäden\n- PR for PDF-upload-extraction started, result not yet confirmed\n- Open threads feature discussed, PR not yet started'
+    const llmOutput = 'Discussed PR for PDF upload extraction and open threads feature.\n\n### Open Threads\n- PR for PDF-upload-extraction started, result not yet confirmed\n- Open threads feature discussed, PR not yet started'
     mockCompleteSimple.mockResolvedValueOnce(makeCompleteSimpleResponse(llmOutput))
 
     const agent = new AgentCore({
@@ -214,7 +219,7 @@ describe('generateSessionSummary — open threads prompt', () => {
     }).generateSessionSummary('user1', 'User: Lets work on two things...\nAssistant: Sure.')
 
     expect(summary).toBe(llmOutput)
-    expect(summary).toContain('### Offene Fäden')
+    expect(summary).toContain('### Open Threads')
     expect(summary).toContain('PR for PDF-upload-extraction started')
   })
 
@@ -235,7 +240,7 @@ describe('generateSessionSummary — open threads prompt', () => {
     }).generateSessionSummary('user1', 'User: What does --build do?\nAssistant: It rebuilds images.')
 
     expect(summary).toBe(llmOutput)
-    expect(summary).not.toContain('### Offene Fäden')
+    expect(summary).not.toContain('### Open Threads')
   })
 
   it('returns "Empty session." when no conversation history is provided', async () => {
@@ -275,7 +280,7 @@ describe('generateSessionSummary — open threads prompt', () => {
 
   it('uses a single completeSimple call (no second call for open threads)', async () => {
     mockCompleteSimple.mockResolvedValue(
-      makeCompleteSimpleResponse('Activity log text.\n\n### Offene Fäden\n- Something open')
+      makeCompleteSimpleResponse('Activity log text.\n\n### Open Threads\n- Something open')
     )
 
     const agent = new AgentCore({
@@ -297,7 +302,7 @@ describe('generateSessionSummary — open threads prompt', () => {
   it('daily file entry contains both activity and open threads when present', async () => {
     // Use real appendToDailyFile logic by using a real SessionManager + fake summarizer
     // We verify by checking the summary text that gets written
-    const llmOutput = 'Reviewed PR structure and discussed open threads feature.\n\n### Offene Fäden\n- Open threads feature: PR not yet created'
+    const llmOutput = 'Reviewed PR structure and discussed open threads feature.\n\n### Open Threads\n- Open threads feature: PR not yet created'
     mockCompleteSimple.mockResolvedValueOnce(makeCompleteSimpleResponse(llmOutput))
 
     const agent = new AgentCore({
@@ -315,7 +320,7 @@ describe('generateSessionSummary — open threads prompt', () => {
     // The summary is written verbatim inside the ## HH:MM block in session-manager.ts
     // Verify the structure is correct for downstream use
     expect(summary).toMatch(/^Reviewed PR structure/)
-    expect(summary).toContain('\n\n### Offene Fäden\n')
+    expect(summary).toContain('\n\n### Open Threads\n')
     expect(summary).toContain('- Open threads feature: PR not yet created')
   })
 })

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -445,7 +445,7 @@ export class AgentCore {
   /**
    * Generate a summary of the current conversation using the LLM.
    * Returns a combined activity log entry that may include an optional
-   * "### Offene Fäden" (open threads) section when unresolved items exist.
+   * "### Open Threads" section when unresolved items exist.
    */
   private async generateSessionSummary(_userId: string, conversationHistory?: string): Promise<string> {
     // Always use DB conversation history (single source of truth).
@@ -493,11 +493,18 @@ export class AgentCore {
     try {
       // Session summary is a background job — use the background thinking level.
       const response = await completeSimple(summaryModel, {
-        systemPrompt: `You are writing a chronological activity log entry for this session. Your output will be stored in a daily file so the agent can recall what happened in past sessions (e.g. "yesterday at 14:30 we discussed X and you asked me to do Y").
+        systemPrompt: `You are writing a chronological activity log entry for this session. Your output will be stored in a daily file under a "## HH:MM" timestamp heading that the surrounding code adds automatically. Other sessions will read this entry to recall what happened (e.g. "yesterday at 14:30 we discussed X and you asked me to do Y").
 
-Your output has two parts:
+## Output format (strict)
 
-**Part 1 — Activity Log (always required)**
+- Start your output directly with the activity log content. Do NOT prepend any heading such as "Activity Log", "# Activity Log", "**Activity Log**", "**Part 1 — ...**", or any other variation. The "## HH:MM" heading is added by the code, not by you.
+- Do NOT use horizontal rule separators ("---", "***", "===") anywhere in your output. Use a single blank line as separator.
+- Your output has two parts in this exact order:
+  1. The activity log (always required, written as plain prose or bullets, no heading).
+  2. An optional "### Open Threads" section (only if there are genuinely unresolved items).
+
+## Activity log content (always required)
+
 - Write 2–5 sentences or bullet points. Max 200 words.
 - Describe what actually happened: topics discussed, questions answered, decisions made, tasks started or completed, PRs or files created.
 - If a background task completed or a task result was injected, mention its outcome (e.g. "PR #15 created for X", "wiki page updated").
@@ -505,15 +512,16 @@ Your output has two parts:
 - Do NOT filter for "memory-worthiness" — this is an activity log, not a memory promotion filter. Even a single answered question is worth one sentence.
 - Write "Empty session." ONLY if the transcript contains nothing but greetings or a bare connection with zero substantive content.
 
-**Part 2 — Open Threads (optional)**
-If and only if there are genuinely unresolved items, append the following section after the activity log (separated by a blank line):
+## Open Threads section (optional)
 
-### Offene Fäden
+If and only if there are genuinely unresolved items, append exactly the following section after the activity log (separated by a single blank line — no horizontal rule):
+
+### Open Threads
 - <concrete open item>
 - <concrete open item>
 
 Open items are: explicitly mentioned but unfinished tasks, background tasks started without a confirmed result, decisions that were deferred, or questions that were not answered.
-Do NOT add this section if everything discussed was resolved or if there is nothing left open. Never add an empty "### Offene Fäden" section.`,
+Do NOT add this section if everything discussed was resolved or if there is nothing left open. Never add an empty "### Open Threads" section.`,
         messages: [{
           role: 'user' as const,
           content: `Analyze the following session transcript and write an activity log entry:\n\n<transcript>\n${conversationHistory}\n</transcript>`,


### PR DESCRIPTION
The session-summary system prompt used "Part 1 / Part 2" framing as an internal structure marker, which models leaked into the actual output as headings like "# Activity Log", "**Activity Log**", or "**Part 1 — Activity Log**". Some models also injected horizontal-rule separators ("---") between the activity log and the open threads section. The result was inconsistent daily-file entries (the "## HH:MM" heading is already added by session-manager.ts, so any model-emitted heading is redundant noise).

Also rename the open-threads section header from the German "### Offene Fäden" to the English "### Open Threads". The internal prompt already used "Open Threads" as the conceptual name, so the German output header was an inconsistency from the start.