### PR TITLE
feat(tasks): add provider and date range filters

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -473,6 +473,14 @@ export function initDatabase(dbPath?: string): Database {
     db.exec("ALTER TABLE tasks ADD COLUMN is_default_model INTEGER")
   }
 
+  // Provider/model task filters can otherwise fall back to a full task scan
+  // when the date range is wide or cleared.
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_tasks_provider_model_created_at ON tasks(provider, model, created_at);
+    CREATE INDEX IF NOT EXISTS idx_tasks_model_created_at ON tasks(model, created_at);
+    CREATE INDEX IF NOT EXISTS idx_tasks_is_default_model_created_at ON tasks(is_default_model, created_at);
+  `)
+
   // Migration: add last_activity, session_user, and token columns to sessions table
   const sessionCols = db.prepare("PRAGMA table_info(sessions)").all() as { name: string }[]
   if (!sessionCols.find(c => c.name === 'last_activity')) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,8 +190,18 @@ export type { AgentRuntimeBoundary, AgentRuntimeOptions, AgentRuntimePiAgentAcce
 export type { AgentRuntimeStateSnapshot } from './agent-runtime-types.js'
 export { ProviderManager } from './provider-manager.js'
 export type { OperatingMode, ProviderManagerEvents } from './provider-manager.js'
-export { TaskStore, initTasksTable } from './task-store.js'
-export type { Task, TaskStatus, TaskTriggerType, TaskResultStatus, CreateTaskInput, UpdateTaskInput, TaskListFilters } from './task-store.js'
+export { TaskStore, initTasksTable, buildTaskFilterClause } from './task-store.js'
+export type {
+  Task,
+  TaskStatus,
+  TaskTriggerType,
+  TaskResultStatus,
+  CreateTaskInput,
+  UpdateTaskInput,
+  TaskListFilters,
+  TaskFilterClause,
+  TaskFilterClauseOptions,
+} from './task-store.js'
 export { TaskRunner, formatTaskInjection } from './task-runner.js'
 export type { TaskRunnerOptions, TaskOverrides } from './task-runner.js'
 export { createTaskRuntime } from './task-runtime.js'

--- a/packages/core/src/task-store.test.ts
+++ b/packages/core/src/task-store.test.ts
@@ -161,6 +161,44 @@ describe('TaskStore', () => {
       expect(agentTasks[0].name).toBe('Agent Task')
     })
 
+    it('filters by default-provider flag and provider/model', () => {
+      store.create({
+        name: 'Default Task',
+        prompt: 'p1',
+        triggerType: 'agent',
+        provider: 'OpenAI',
+        model: 'gpt-4o',
+        isDefaultModel: true,
+      })
+      store.create({
+        name: 'Pinned Task',
+        prompt: 'p2',
+        triggerType: 'agent',
+        provider: 'Anthropic',
+        model: 'claude-sonnet-4-5',
+        isDefaultModel: false,
+      })
+
+      const defaultTasks = store.list({ isDefaultModel: true })
+      expect(defaultTasks).toHaveLength(1)
+      expect(defaultTasks[0].name).toBe('Default Task')
+
+      const providerModelTasks = store.list({ provider: 'Anthropic', model: 'claude-sonnet-4-5' })
+      expect(providerModelTasks).toHaveLength(1)
+      expect(providerModelTasks[0].name).toBe('Pinned Task')
+    })
+
+    it('filters by created date range', () => {
+      const oldTask = store.create({ name: 'Old Task', prompt: 'p1', triggerType: 'agent' })
+      const recentTask = store.create({ name: 'Recent Task', prompt: 'p2', triggerType: 'agent' })
+      db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2024-01-01 10:00:00', oldTask.id)
+      db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2024-01-03 10:00:00', recentTask.id)
+
+      const tasks = store.list({ createdFrom: '2024-01-02 00:00:00', createdTo: '2024-01-03 23:59:59' })
+      expect(tasks).toHaveLength(1)
+      expect(tasks[0].name).toBe('Recent Task')
+    })
+
     it('supports limit and offset', () => {
       for (let i = 0; i < 5; i++) {
         store.create({ name: `Task ${i}`, prompt: `p${i}`, triggerType: 'agent' })

--- a/packages/core/src/task-store.test.ts
+++ b/packages/core/src/task-store.test.ts
@@ -364,5 +364,14 @@ describe('TaskStore', () => {
       expect(colNames).toContain('completed_at')
       expect(colNames).toContain('session_id')
     })
+
+    it('indexes task provider filters', () => {
+      const indexes = db.prepare('PRAGMA index_list(tasks)').all() as { name: string }[]
+      const indexNames = indexes.map(index => index.name)
+
+      expect(indexNames).toContain('idx_tasks_provider_model_created_at')
+      expect(indexNames).toContain('idx_tasks_model_created_at')
+      expect(indexNames).toContain('idx_tasks_is_default_model_created_at')
+    })
   })
 })

--- a/packages/core/src/task-store.test.ts
+++ b/packages/core/src/task-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { initDatabase } from './database.js'
-import { TaskStore } from './task-store.js'
+import { buildTaskFilterClause, TaskStore } from './task-store.js'
 import type { Database } from './database.js'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -197,6 +197,17 @@ describe('TaskStore', () => {
       const tasks = store.list({ createdFrom: '2024-01-02 00:00:00', createdTo: '2024-01-03 23:59:59' })
       expect(tasks).toHaveLength(1)
       expect(tasks[0].name).toBe('Recent Task')
+    })
+
+    it('keeps created date filters sargable for indexes', () => {
+      const clause = buildTaskFilterClause({
+        createdFrom: '2024-01-02 00:00:00',
+        createdTo: '2024-01-03 23:59:59',
+      })
+
+      expect(clause.sql).toContain('created_at >= ?')
+      expect(clause.sql).toContain('created_at <= ?')
+      expect(clause.sql).not.toContain('datetime(created_at)')
     })
 
     it('supports limit and offset', () => {

--- a/packages/core/src/task-store.ts
+++ b/packages/core/src/task-store.ts
@@ -118,11 +118,11 @@ export function buildTaskFilterClause(
     params.push(filters.model)
   }
   if (filters?.createdFrom) {
-    sql += ' AND datetime(created_at) >= datetime(?)'
+    sql += ' AND created_at >= ?'
     params.push(filters.createdFrom)
   }
   if (filters?.createdTo) {
-    sql += ' AND datetime(created_at) <= datetime(?)'
+    sql += ' AND created_at <= ?'
     params.push(filters.createdTo)
   }
 

--- a/packages/core/src/task-store.ts
+++ b/packages/core/src/task-store.ts
@@ -71,6 +71,11 @@ export interface UpdateTaskInput {
 export interface TaskListFilters {
   status?: TaskStatus
   triggerType?: TaskTriggerType
+  provider?: string
+  model?: string
+  isDefaultModel?: boolean
+  createdFrom?: string
+  createdTo?: string
   limit?: number
   offset?: number
 }
@@ -220,6 +225,26 @@ export class TaskStore {
     if (filters?.triggerType) {
       sql += ' AND trigger_type = ?'
       params.push(filters.triggerType)
+    }
+    if (filters?.isDefaultModel !== undefined) {
+      sql += ' AND is_default_model = ?'
+      params.push(filters.isDefaultModel ? 1 : 0)
+    }
+    if (filters?.provider) {
+      sql += ' AND provider = ?'
+      params.push(filters.provider)
+    }
+    if (filters?.model) {
+      sql += ' AND model = ?'
+      params.push(filters.model)
+    }
+    if (filters?.createdFrom) {
+      sql += ' AND datetime(created_at) >= datetime(?)'
+      params.push(filters.createdFrom)
+    }
+    if (filters?.createdTo) {
+      sql += ' AND datetime(created_at) <= datetime(?)'
+      params.push(filters.createdTo)
     }
 
     sql += ' ORDER BY created_at DESC'

--- a/packages/core/src/task-store.ts
+++ b/packages/core/src/task-store.ts
@@ -80,6 +80,55 @@ export interface TaskListFilters {
   offset?: number
 }
 
+export interface TaskFilterClauseOptions {
+  includeProviderModel?: boolean
+}
+
+export interface TaskFilterClause {
+  sql: string
+  params: unknown[]
+}
+
+export function buildTaskFilterClause(
+  filters?: TaskListFilters,
+  options: TaskFilterClauseOptions = {},
+): TaskFilterClause {
+  const includeProviderModel = options.includeProviderModel ?? true
+  let sql = ''
+  const params: unknown[] = []
+
+  if (filters?.status) {
+    sql += ' AND status = ?'
+    params.push(filters.status)
+  }
+  if (filters?.triggerType) {
+    sql += ' AND trigger_type = ?'
+    params.push(filters.triggerType)
+  }
+  if (includeProviderModel && filters?.isDefaultModel !== undefined) {
+    sql += ' AND is_default_model = ?'
+    params.push(filters.isDefaultModel ? 1 : 0)
+  }
+  if (includeProviderModel && filters?.provider) {
+    sql += ' AND provider = ?'
+    params.push(filters.provider)
+  }
+  if (includeProviderModel && filters?.model) {
+    sql += ' AND model = ?'
+    params.push(filters.model)
+  }
+  if (filters?.createdFrom) {
+    sql += ' AND datetime(created_at) >= datetime(?)'
+    params.push(filters.createdFrom)
+  }
+  if (filters?.createdTo) {
+    sql += ' AND datetime(created_at) <= datetime(?)'
+    params.push(filters.createdTo)
+  }
+
+  return { sql, params }
+}
+
 // Raw row from SQLite
 interface TaskRow {
   id: string
@@ -216,36 +265,9 @@ export class TaskStore {
    */
   list(filters?: TaskListFilters): Task[] {
     let sql = 'SELECT * FROM tasks WHERE 1=1'
-    const params: unknown[] = []
-
-    if (filters?.status) {
-      sql += ' AND status = ?'
-      params.push(filters.status)
-    }
-    if (filters?.triggerType) {
-      sql += ' AND trigger_type = ?'
-      params.push(filters.triggerType)
-    }
-    if (filters?.isDefaultModel !== undefined) {
-      sql += ' AND is_default_model = ?'
-      params.push(filters.isDefaultModel ? 1 : 0)
-    }
-    if (filters?.provider) {
-      sql += ' AND provider = ?'
-      params.push(filters.provider)
-    }
-    if (filters?.model) {
-      sql += ' AND model = ?'
-      params.push(filters.model)
-    }
-    if (filters?.createdFrom) {
-      sql += ' AND datetime(created_at) >= datetime(?)'
-      params.push(filters.createdFrom)
-    }
-    if (filters?.createdTo) {
-      sql += ' AND datetime(created_at) <= datetime(?)'
-      params.push(filters.createdTo)
-    }
+    const filterClause = buildTaskFilterClause(filters)
+    sql += filterClause.sql
+    const params = filterClause.params
 
     sql += ' ORDER BY created_at DESC'
 

--- a/packages/core/src/task-store.ts
+++ b/packages/core/src/task-store.ts
@@ -215,6 +215,9 @@ export function initTasksTable(db: Database): void {
     CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
     CREATE INDEX IF NOT EXISTS idx_tasks_trigger_type ON tasks(trigger_type);
     CREATE INDEX IF NOT EXISTS idx_tasks_created_at ON tasks(created_at);
+    CREATE INDEX IF NOT EXISTS idx_tasks_provider_model_created_at ON tasks(provider, model, created_at);
+    CREATE INDEX IF NOT EXISTS idx_tasks_model_created_at ON tasks(model, created_at);
+    CREATE INDEX IF NOT EXISTS idx_tasks_is_default_model_created_at ON tasks(is_default_model, created_at);
     CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id);
   `)
 }

--- a/packages/web-backend/src/api/modules/tasks/controller.ts
+++ b/packages/web-backend/src/api/modules/tasks/controller.ts
@@ -29,7 +29,7 @@ export function createTasksController(service: TasksService): TasksController {
           return
         }
 
-        const { tasks, total } = service.listTasks(parsedQuery.value)
+        const { tasks, total, providerOptions } = service.listTasks(parsedQuery.value)
 
         res.json(
           mapTasksListResponse({
@@ -37,6 +37,7 @@ export function createTasksController(service: TasksService): TasksController {
             page: parsedQuery.value.page,
             limit: parsedQuery.value.limit,
             total,
+            providerOptions,
           }),
         )
       } catch (err) {

--- a/packages/web-backend/src/api/modules/tasks/mapper.ts
+++ b/packages/web-backend/src/api/modules/tasks/mapper.ts
@@ -1,4 +1,5 @@
 import type { Task } from '@openagent/core'
+import type { TaskProviderFilterOption } from './service.js'
 import type { TaskTimelineEvent } from './types.js'
 
 export function mapTasksListResponse(input: {
@@ -6,6 +7,7 @@ export function mapTasksListResponse(input: {
   page: number
   limit: number
   total: number
+  providerOptions?: TaskProviderFilterOption[]
 }) {
   return {
     tasks: input.tasks,
@@ -15,6 +17,7 @@ export function mapTasksListResponse(input: {
       total: input.total,
       totalPages: Math.ceil(input.total / input.limit),
     },
+    providerOptions: input.providerOptions ?? [],
   }
 }
 

--- a/packages/web-backend/src/api/modules/tasks/route.test.ts
+++ b/packages/web-backend/src/api/modules/tasks/route.test.ts
@@ -120,6 +120,12 @@ describe('tasks route module', () => {
       model: 'gpt-5.4',
       isDefaultModel: false,
     })
+    const explicitDefaultProviderTask = createTask({
+      name: 'Explicit default provider task',
+      provider: 'ChatGPT Plus',
+      model: 'gpt-5.4-mini',
+      isDefaultModel: false,
+    })
     const outsideRangeTask = createTask({
       name: 'Outside task',
       provider: 'Old Provider',
@@ -129,6 +135,7 @@ describe('tasks route module', () => {
 
     db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2026-04-14 23:00:00', defaultTask.id)
     db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2026-04-09 23:00:00', explicitTask.id)
+    db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2026-04-14 23:30:00', explicitDefaultProviderTask.id)
     db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2026-03-31 23:00:00', outsideRangeTask.id)
 
     const res = await fetch(`${baseUrl}/api/tasks?created_from=2026-04-01&created_to=2026-04-28`, {
@@ -140,11 +147,13 @@ describe('tasks route module', () => {
     }
 
     expect(res.status).toBe(200)
-    expect(body.providerOptions).toContainEqual({
+    expect(body.providerOptions.filter(option =>
+      option.provider === 'ChatGPT Plus' && option.model === 'gpt-5.4-mini',
+    )).toEqual([{
       provider: 'ChatGPT Plus',
       model: 'gpt-5.4-mini',
       isDefaultModel: true,
-    })
+    }])
     expect(body.providerOptions).toContainEqual({
       provider: 'OpenAI GPT-5.4',
       model: 'gpt-5.4',

--- a/packages/web-backend/src/api/modules/tasks/route.test.ts
+++ b/packages/web-backend/src/api/modules/tasks/route.test.ts
@@ -53,13 +53,24 @@ function authHeaders() {
   return { Authorization: `Bearer ${token}` }
 }
 
-function createTask(input?: Partial<{ name: string; prompt: string; triggerType: Task['triggerType']; sessionId: string }>) {
+function createTask(input?: Partial<{
+  name: string
+  prompt: string
+  triggerType: Task['triggerType']
+  sessionId: string
+  provider: string
+  model: string
+  isDefaultModel: boolean
+}>) {
   const store = new TaskStore(db)
   return store.create({
     name: input?.name ?? 'Task',
     prompt: input?.prompt ?? 'Do something',
     triggerType: input?.triggerType ?? 'user',
     sessionId: input?.sessionId,
+    provider: input?.provider,
+    model: input?.model,
+    isDefaultModel: input?.isDefaultModel,
   })
 }
 
@@ -94,6 +105,56 @@ describe('tasks route module', () => {
       totalPages: 1,
     })
     expect(body.tasks[0]?.id).not.toBe(runningTask.id)
+  })
+
+  it('returns provider filter options from historical task rows in the selected date range', async () => {
+    const defaultTask = createTask({
+      name: 'Default task',
+      provider: 'ChatGPT Plus',
+      model: 'gpt-5.4-mini',
+      isDefaultModel: true,
+    })
+    const explicitTask = createTask({
+      name: 'Explicit task',
+      provider: 'OpenAI GPT-5.4',
+      model: 'gpt-5.4',
+      isDefaultModel: false,
+    })
+    const outsideRangeTask = createTask({
+      name: 'Outside task',
+      provider: 'Old Provider',
+      model: 'old-model',
+      isDefaultModel: false,
+    })
+
+    db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2026-04-14 23:00:00', defaultTask.id)
+    db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2026-04-09 23:00:00', explicitTask.id)
+    db.prepare('UPDATE tasks SET created_at = ? WHERE id = ?').run('2026-03-31 23:00:00', outsideRangeTask.id)
+
+    const res = await fetch(`${baseUrl}/api/tasks?created_from=2026-04-01&created_to=2026-04-28`, {
+      headers: authHeaders(),
+    })
+
+    const body = await res.json() as {
+      providerOptions: Array<{ provider: string | null; model: string | null; isDefaultModel: boolean | null }>
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.providerOptions).toContainEqual({
+      provider: 'ChatGPT Plus',
+      model: 'gpt-5.4-mini',
+      isDefaultModel: true,
+    })
+    expect(body.providerOptions).toContainEqual({
+      provider: 'OpenAI GPT-5.4',
+      model: 'gpt-5.4',
+      isDefaultModel: false,
+    })
+    expect(body.providerOptions).not.toContainEqual({
+      provider: 'Old Provider',
+      model: 'old-model',
+      isDefaultModel: false,
+    })
   })
 
   it('returns 400 for invalid filters', async () => {

--- a/packages/web-backend/src/api/modules/tasks/route.test.ts
+++ b/packages/web-backend/src/api/modules/tasks/route.test.ts
@@ -188,6 +188,17 @@ describe('tasks route module', () => {
     expect(body.error).toContain('created_to must be greater than or equal to created_from')
   })
 
+  it('returns 400 when a created date is not a real calendar date', async () => {
+    const res = await fetch(`${baseUrl}/api/tasks?created_from=2026-04-31`, {
+      headers: authHeaders(),
+    })
+
+    const body = await res.json() as { error: string }
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain('Invalid created_from filter')
+  })
+
   it('returns task details and 404 for missing task', async () => {
     const task = createTask({ name: 'Detail task' })
 

--- a/packages/web-backend/src/api/modules/tasks/route.test.ts
+++ b/packages/web-backend/src/api/modules/tasks/route.test.ts
@@ -177,6 +177,17 @@ describe('tasks route module', () => {
     expect(body.error).toContain('Invalid status filter')
   })
 
+  it('returns 400 when the created date range is inverted', async () => {
+    const res = await fetch(`${baseUrl}/api/tasks?created_from=2026-04-28&created_to=2026-04-01`, {
+      headers: authHeaders(),
+    })
+
+    const body = await res.json() as { error: string }
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain('created_to must be greater than or equal to created_from')
+  })
+
   it('returns task details and 404 for missing task', async () => {
     const task = createTask({ name: 'Detail task' })
 

--- a/packages/web-backend/src/api/modules/tasks/schema.ts
+++ b/packages/web-backend/src/api/modules/tasks/schema.ts
@@ -1,7 +1,7 @@
 import type { TaskStatus, TaskTriggerType } from '@openagent/core'
 
 const VALID_STATUSES: TaskStatus[] = ['running', 'paused', 'completed', 'failed']
-const VALID_TRIGGER_TYPES: TaskTriggerType[] = ['user', 'agent', 'cronjob', 'heartbeat']
+const VALID_TRIGGER_TYPES: TaskTriggerType[] = ['user', 'agent', 'cronjob', 'heartbeat', 'consolidation']
 
 export interface ListTasksQuery {
   page: number

--- a/packages/web-backend/src/api/modules/tasks/schema.ts
+++ b/packages/web-backend/src/api/modules/tasks/schema.ts
@@ -100,6 +100,10 @@ export function parseListTasksQuery(query: Record<string, unknown>): ParseResult
     return { ok: false, error: 'Invalid created_to filter. Must be a date or ISO date-time.' }
   }
 
+  if (createdFrom && createdTo && createdTo < createdFrom) {
+    return { ok: false, error: 'Invalid date range. created_to must be greater than or equal to created_from.' }
+  }
+
   return {
     ok: true,
     value: {

--- a/packages/web-backend/src/api/modules/tasks/schema.ts
+++ b/packages/web-backend/src/api/modules/tasks/schema.ts
@@ -1,7 +1,7 @@
 import type { TaskStatus, TaskTriggerType } from '@openagent/core'
 
 const VALID_STATUSES: TaskStatus[] = ['running', 'paused', 'completed', 'failed']
-const VALID_TRIGGER_TYPES: TaskTriggerType[] = ['user', 'agent', 'cronjob', 'heartbeat']
+const VALID_TRIGGER_TYPES: TaskTriggerType[] = ['user', 'agent', 'cronjob', 'heartbeat', 'consolidation']
 
 export interface ListTasksQuery {
   page: number
@@ -9,6 +9,11 @@ export interface ListTasksQuery {
   offset: number
   status?: TaskStatus
   triggerType?: TaskTriggerType
+  provider?: string
+  model?: string
+  isDefaultModel?: boolean
+  createdFrom?: string
+  createdTo?: string
 }
 
 interface ParseSuccess<T> {
@@ -33,6 +38,23 @@ function toOptionalString(value: unknown): string | undefined {
   return undefined
 }
 
+function normalizeDateBoundary(value: string, boundary: 'start' | 'end'): string | null | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const dateOnlyMatch = /^(\d{4}-\d{2}-\d{2})$/.exec(trimmed)
+  if (dateOnlyMatch) {
+    return `${dateOnlyMatch[1]} ${boundary === 'start' ? '00:00:00' : '23:59:59'}`
+  }
+
+  const date = new Date(trimmed)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString().replace('T', ' ').slice(0, 19)
+}
+
 export function parseListTasksQuery(query: Record<string, unknown>): ParseResult<ListTasksQuery> {
   const page = Math.max(1, Number.parseInt(toOptionalString(query.page) ?? '', 10) || 1)
   const limit = Math.min(100, Math.max(1, Number.parseInt(toOptionalString(query.limit) ?? '', 10) || 20))
@@ -40,6 +62,11 @@ export function parseListTasksQuery(query: Record<string, unknown>): ParseResult
 
   const statusParam = toOptionalString(query.status)
   const triggerTypeParam = toOptionalString(query.trigger_type)
+  const providerParam = toOptionalString(query.provider)?.trim()
+  const modelParam = toOptionalString(query.model)?.trim()
+  const isDefaultModelParam = toOptionalString(query.is_default_model)
+  const createdFromParam = toOptionalString(query.created_from)
+  const createdToParam = toOptionalString(query.created_to)
 
   if (statusParam && !VALID_STATUSES.includes(statusParam as TaskStatus)) {
     return {
@@ -55,6 +82,24 @@ export function parseListTasksQuery(query: Record<string, unknown>): ParseResult
     }
   }
 
+  let isDefaultModel: boolean | undefined
+  if (isDefaultModelParam) {
+    if (isDefaultModelParam !== 'true' && isDefaultModelParam !== 'false') {
+      return { ok: false, error: 'Invalid is_default_model filter. Must be true or false.' }
+    }
+    isDefaultModel = isDefaultModelParam === 'true'
+  }
+
+  const createdFrom = createdFromParam ? normalizeDateBoundary(createdFromParam, 'start') : undefined
+  if (createdFrom === null) {
+    return { ok: false, error: 'Invalid created_from filter. Must be a date or ISO date-time.' }
+  }
+
+  const createdTo = createdToParam ? normalizeDateBoundary(createdToParam, 'end') : undefined
+  if (createdTo === null) {
+    return { ok: false, error: 'Invalid created_to filter. Must be a date or ISO date-time.' }
+  }
+
   return {
     ok: true,
     value: {
@@ -63,6 +108,11 @@ export function parseListTasksQuery(query: Record<string, unknown>): ParseResult
       offset,
       status: statusParam as TaskStatus | undefined,
       triggerType: triggerTypeParam as TaskTriggerType | undefined,
+      provider: providerParam || undefined,
+      model: modelParam || undefined,
+      isDefaultModel,
+      createdFrom,
+      createdTo,
     },
   }
 }

--- a/packages/web-backend/src/api/modules/tasks/schema.ts
+++ b/packages/web-backend/src/api/modules/tasks/schema.ts
@@ -38,13 +38,28 @@ function toOptionalString(value: unknown): string | undefined {
   return undefined
 }
 
+function isValidDateOnly(year: number, month: number, day: number): boolean {
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return date.getUTCFullYear() === year
+    && date.getUTCMonth() === month - 1
+    && date.getUTCDate() === day
+}
+
 function normalizeDateBoundary(value: string, boundary: 'start' | 'end'): string | null | undefined {
   const trimmed = value.trim()
   if (!trimmed) return undefined
 
-  const dateOnlyMatch = /^(\d{4}-\d{2}-\d{2})$/.exec(trimmed)
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed)
   if (dateOnlyMatch) {
-    return `${dateOnlyMatch[1]} ${boundary === 'start' ? '00:00:00' : '23:59:59'}`
+    const [, yearRaw, monthRaw, dayRaw] = dateOnlyMatch
+    const year = Number(yearRaw)
+    const month = Number(monthRaw)
+    const day = Number(dayRaw)
+    if (!isValidDateOnly(year, month, day)) {
+      return null
+    }
+
+    return `${yearRaw}-${monthRaw}-${dayRaw} ${boundary === 'start' ? '00:00:00' : '23:59:59'}`
   }
 
   const date = new Date(trimmed)

--- a/packages/web-backend/src/api/modules/tasks/schema.ts
+++ b/packages/web-backend/src/api/modules/tasks/schema.ts
@@ -9,6 +9,11 @@ export interface ListTasksQuery {
   offset: number
   status?: TaskStatus
   triggerType?: TaskTriggerType
+  provider?: string
+  model?: string
+  isDefaultModel?: boolean
+  createdFrom?: string
+  createdTo?: string
 }
 
 interface ParseSuccess<T> {
@@ -33,6 +38,23 @@ function toOptionalString(value: unknown): string | undefined {
   return undefined
 }
 
+function normalizeDateBoundary(value: string, boundary: 'start' | 'end'): string | null | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const dateOnlyMatch = /^(\d{4}-\d{2}-\d{2})$/.exec(trimmed)
+  if (dateOnlyMatch) {
+    return `${dateOnlyMatch[1]} ${boundary === 'start' ? '00:00:00' : '23:59:59'}`
+  }
+
+  const date = new Date(trimmed)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString().replace('T', ' ').slice(0, 19)
+}
+
 export function parseListTasksQuery(query: Record<string, unknown>): ParseResult<ListTasksQuery> {
   const page = Math.max(1, Number.parseInt(toOptionalString(query.page) ?? '', 10) || 1)
   const limit = Math.min(100, Math.max(1, Number.parseInt(toOptionalString(query.limit) ?? '', 10) || 20))
@@ -40,6 +62,11 @@ export function parseListTasksQuery(query: Record<string, unknown>): ParseResult
 
   const statusParam = toOptionalString(query.status)
   const triggerTypeParam = toOptionalString(query.trigger_type)
+  const providerParam = toOptionalString(query.provider)?.trim()
+  const modelParam = toOptionalString(query.model)?.trim()
+  const isDefaultModelParam = toOptionalString(query.is_default_model)
+  const createdFromParam = toOptionalString(query.created_from)
+  const createdToParam = toOptionalString(query.created_to)
 
   if (statusParam && !VALID_STATUSES.includes(statusParam as TaskStatus)) {
     return {
@@ -55,6 +82,24 @@ export function parseListTasksQuery(query: Record<string, unknown>): ParseResult
     }
   }
 
+  let isDefaultModel: boolean | undefined
+  if (isDefaultModelParam) {
+    if (isDefaultModelParam !== 'true' && isDefaultModelParam !== 'false') {
+      return { ok: false, error: 'Invalid is_default_model filter. Must be true or false.' }
+    }
+    isDefaultModel = isDefaultModelParam === 'true'
+  }
+
+  const createdFrom = createdFromParam ? normalizeDateBoundary(createdFromParam, 'start') : undefined
+  if (createdFrom === null) {
+    return { ok: false, error: 'Invalid created_from filter. Must be a date or ISO date-time.' }
+  }
+
+  const createdTo = createdToParam ? normalizeDateBoundary(createdToParam, 'end') : undefined
+  if (createdTo === null) {
+    return { ok: false, error: 'Invalid created_to filter. Must be a date or ISO date-time.' }
+  }
+
   return {
     ok: true,
     value: {
@@ -63,6 +108,11 @@ export function parseListTasksQuery(query: Record<string, unknown>): ParseResult
       offset,
       status: statusParam as TaskStatus | undefined,
       triggerType: triggerTypeParam as TaskTriggerType | undefined,
+      provider: providerParam || undefined,
+      model: modelParam || undefined,
+      isDefaultModel,
+      createdFrom,
+      createdTo,
     },
   }
 }

--- a/packages/web-backend/src/api/modules/tasks/service.ts
+++ b/packages/web-backend/src/api/modules/tasks/service.ts
@@ -1,4 +1,4 @@
-import { TaskStore, getToolCalls, resolveProviderModelInput } from '@openagent/core'
+import { TaskStore, buildTaskFilterClause, getToolCalls, resolveProviderModelInput } from '@openagent/core'
 import type {
   Database,
   ProviderConfig,
@@ -111,45 +111,11 @@ export class TasksService {
       ? runtime.list(listFilters)
       : this.store.list(listFilters)
 
-    let countSql = 'SELECT COUNT(*) as count FROM tasks WHERE 1=1'
-    const countParams: unknown[] = []
-
-    if (input.status) {
-      countSql += ' AND status = ?'
-      countParams.push(input.status)
-    }
-
-    if (input.triggerType) {
-      countSql += ' AND trigger_type = ?'
-      countParams.push(input.triggerType)
-    }
-
-    if (input.isDefaultModel !== undefined) {
-      countSql += ' AND is_default_model = ?'
-      countParams.push(input.isDefaultModel ? 1 : 0)
-    }
-
-    if (input.provider) {
-      countSql += ' AND provider = ?'
-      countParams.push(input.provider)
-    }
-
-    if (input.model) {
-      countSql += ' AND model = ?'
-      countParams.push(input.model)
-    }
-
-    if (input.createdFrom) {
-      countSql += ' AND datetime(created_at) >= datetime(?)'
-      countParams.push(input.createdFrom)
-    }
-
-    if (input.createdTo) {
-      countSql += ' AND datetime(created_at) <= datetime(?)'
-      countParams.push(input.createdTo)
-    }
-
-    const total = (this.options.db.prepare(countSql).get(...countParams) as { count: number }).count
+    const countFilterClause = buildTaskFilterClause(input)
+    const countSql = `SELECT COUNT(*) as count FROM tasks WHERE 1=1${countFilterClause.sql}`
+    const total = (
+      this.options.db.prepare(countSql).get(...countFilterClause.params) as { count: number }
+    ).count
     const providerOptions = this.listProviderFilterOptions(input)
 
     return { tasks, total, providerOptions }
@@ -158,39 +124,20 @@ export class TasksService {
   private listProviderFilterOptions(input: ListTasksInput): TaskProviderFilterOption[] {
     // Provider choices must come from historical task rows for the current
     // non-provider filters (especially date range), not from today's provider
-    // configuration. Intentionally ignore input.provider/model here so the
-    // dropdown still shows sibling options while one provider is selected.
+    // configuration. Intentionally ignore input.provider/model/isDefaultModel
+    // here so the dropdown still shows sibling options while one provider is
+    // selected.
     let sql = `
       SELECT provider, model, is_default_model
       FROM tasks
       WHERE 1=1
         AND (provider IS NOT NULL OR model IS NOT NULL OR is_default_model = 1)
     `
-    const params: unknown[] = []
-
-    if (input.status) {
-      sql += ' AND status = ?'
-      params.push(input.status)
-    }
-
-    if (input.triggerType) {
-      sql += ' AND trigger_type = ?'
-      params.push(input.triggerType)
-    }
-
-    if (input.createdFrom) {
-      sql += ' AND datetime(created_at) >= datetime(?)'
-      params.push(input.createdFrom)
-    }
-
-    if (input.createdTo) {
-      sql += ' AND datetime(created_at) <= datetime(?)'
-      params.push(input.createdTo)
-    }
-
+    const filterClause = buildTaskFilterClause(input, { includeProviderModel: false })
+    sql += filterClause.sql
     sql += ' GROUP BY provider, model, is_default_model ORDER BY lower(provider), lower(model)'
 
-    const rows = this.options.db.prepare(sql).all(...params) as Array<{
+    const rows = this.options.db.prepare(sql).all(...filterClause.params) as Array<{
       provider: string | null
       model: string | null
       is_default_model: number | null

--- a/packages/web-backend/src/api/modules/tasks/service.ts
+++ b/packages/web-backend/src/api/modules/tasks/service.ts
@@ -30,8 +30,19 @@ export interface TasksServiceOptions {
 export interface ListTasksInput {
   status?: TaskStatus
   triggerType?: TaskTriggerType
+  provider?: string
+  model?: string
+  isDefaultModel?: boolean
+  createdFrom?: string
+  createdTo?: string
   limit: number
   offset: number
+}
+
+export interface TaskProviderFilterOption {
+  provider: string | null
+  model: string | null
+  isDefaultModel: boolean | null
 }
 
 export class TaskNotFoundError extends Error {
@@ -82,21 +93,23 @@ export class TasksService {
     return this.options.getTaskRuntime?.() ?? null
   }
 
-  listTasks(input: ListTasksInput): { tasks: Task[]; total: number } {
+  listTasks(input: ListTasksInput): { tasks: Task[]; total: number; providerOptions: TaskProviderFilterOption[] } {
+    const listFilters = {
+      status: input.status,
+      triggerType: input.triggerType,
+      provider: input.provider,
+      model: input.model,
+      isDefaultModel: input.isDefaultModel,
+      createdFrom: input.createdFrom,
+      createdTo: input.createdTo,
+      limit: input.limit,
+      offset: input.offset,
+    }
+
     const runtime = this.getRuntime()
     const tasks = runtime
-      ? runtime.list({
-          status: input.status,
-          triggerType: input.triggerType,
-          limit: input.limit,
-          offset: input.offset,
-        })
-      : this.store.list({
-          status: input.status,
-          triggerType: input.triggerType,
-          limit: input.limit,
-          offset: input.offset,
-        })
+      ? runtime.list(listFilters)
+      : this.store.list(listFilters)
 
     let countSql = 'SELECT COUNT(*) as count FROM tasks WHERE 1=1'
     const countParams: unknown[] = []
@@ -111,9 +124,86 @@ export class TasksService {
       countParams.push(input.triggerType)
     }
 
-    const total = (this.options.db.prepare(countSql).get(...countParams) as { count: number }).count
+    if (input.isDefaultModel !== undefined) {
+      countSql += ' AND is_default_model = ?'
+      countParams.push(input.isDefaultModel ? 1 : 0)
+    }
 
-    return { tasks, total }
+    if (input.provider) {
+      countSql += ' AND provider = ?'
+      countParams.push(input.provider)
+    }
+
+    if (input.model) {
+      countSql += ' AND model = ?'
+      countParams.push(input.model)
+    }
+
+    if (input.createdFrom) {
+      countSql += ' AND datetime(created_at) >= datetime(?)'
+      countParams.push(input.createdFrom)
+    }
+
+    if (input.createdTo) {
+      countSql += ' AND datetime(created_at) <= datetime(?)'
+      countParams.push(input.createdTo)
+    }
+
+    const total = (this.options.db.prepare(countSql).get(...countParams) as { count: number }).count
+    const providerOptions = this.listProviderFilterOptions(input)
+
+    return { tasks, total, providerOptions }
+  }
+
+  private listProviderFilterOptions(input: ListTasksInput): TaskProviderFilterOption[] {
+    // Provider choices must come from historical task rows for the current
+    // non-provider filters (especially date range), not from today's provider
+    // configuration. Intentionally ignore input.provider/model here so the
+    // dropdown still shows sibling options while one provider is selected.
+    let sql = `
+      SELECT provider, model, is_default_model
+      FROM tasks
+      WHERE 1=1
+        AND (provider IS NOT NULL OR model IS NOT NULL OR is_default_model = 1)
+    `
+    const params: unknown[] = []
+
+    if (input.status) {
+      sql += ' AND status = ?'
+      params.push(input.status)
+    }
+
+    if (input.triggerType) {
+      sql += ' AND trigger_type = ?'
+      params.push(input.triggerType)
+    }
+
+    if (input.createdFrom) {
+      sql += ' AND datetime(created_at) >= datetime(?)'
+      params.push(input.createdFrom)
+    }
+
+    if (input.createdTo) {
+      sql += ' AND datetime(created_at) <= datetime(?)'
+      params.push(input.createdTo)
+    }
+
+    sql += ' GROUP BY provider, model, is_default_model ORDER BY lower(provider), lower(model)'
+
+    const rows = this.options.db.prepare(sql).all(...params) as Array<{
+      provider: string | null
+      model: string | null
+      is_default_model: number | null
+    }>
+
+    return rows.map(row => ({
+      provider: row.provider,
+      model: row.model,
+      isDefaultModel:
+        row.is_default_model === null || row.is_default_model === undefined
+          ? null
+          : row.is_default_model === 1,
+    }))
   }
 
   getTaskById(id: string): Task | null {

--- a/packages/web-backend/src/api/modules/tasks/service.ts
+++ b/packages/web-backend/src/api/modules/tasks/service.ts
@@ -128,14 +128,14 @@ export class TasksService {
     // here so the dropdown still shows sibling options while one provider is
     // selected.
     let sql = `
-      SELECT provider, model, is_default_model
+      SELECT provider, model, MAX(is_default_model) AS is_default_model
       FROM tasks
       WHERE 1=1
         AND (provider IS NOT NULL OR model IS NOT NULL OR is_default_model = 1)
     `
     const filterClause = buildTaskFilterClause(input, { includeProviderModel: false })
     sql += filterClause.sql
-    sql += ' GROUP BY provider, model, is_default_model ORDER BY lower(provider), lower(model)'
+    sql += ' GROUP BY provider, model ORDER BY lower(provider), lower(model)'
 
     const rows = this.options.db.prepare(sql).all(...filterClause.params) as Array<{
       provider: string | null

--- a/packages/web-frontend/app/api/tasks.ts
+++ b/packages/web-frontend/app/api/tasks.ts
@@ -28,6 +28,12 @@ export interface Task {
   sessionId: string | null
 }
 
+export interface TaskProviderFilterOption {
+  provider: string | null
+  model: string | null
+  isDefaultModel: boolean | null
+}
+
 export interface TasksResponse {
   tasks: Task[]
   pagination: {
@@ -36,6 +42,7 @@ export interface TasksResponse {
     total: number
     totalPages: number
   }
+  providerOptions?: TaskProviderFilterOption[]
 }
 
 export interface TaskResponse {
@@ -88,6 +95,11 @@ export interface ListTasksParams {
   limit?: number
   status?: string
   triggerType?: string
+  provider?: string
+  model?: string
+  isDefaultModel?: boolean
+  createdFrom?: string
+  createdTo?: string
 }
 
 export function useTasksApi() {
@@ -100,6 +112,11 @@ export function useTasksApi() {
     if (params.limit !== undefined) query.set('limit', String(params.limit))
     if (params.status) query.set('status', params.status)
     if (params.triggerType) query.set('trigger_type', params.triggerType)
+    if (params.provider) query.set('provider', params.provider)
+    if (params.model) query.set('model', params.model)
+    if (params.isDefaultModel !== undefined) query.set('is_default_model', String(params.isDefaultModel))
+    if (params.createdFrom) query.set('created_from', params.createdFrom)
+    if (params.createdTo) query.set('created_to', params.createdTo)
 
     const suffix = query.toString()
     return apiFetch<TasksResponse>(`/api/tasks${suffix ? `?${suffix}` : ''}`)

--- a/packages/web-frontend/app/features/tasks/components/TasksWorkspace.vue
+++ b/packages/web-frontend/app/features/tasks/components/TasksWorkspace.vue
@@ -12,8 +12,8 @@
 
     <!-- Filter toolbar -->
     <div class="flex-shrink-0 border-b border-border px-5 py-3">
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <div class="flex flex-1 items-center gap-2">
+      <div class="flex flex-col gap-2 lg:flex-row lg:items-center">
+        <div class="flex flex-1 flex-wrap items-center gap-2">
           <Select v-model="filters.status" @update:model-value="onFilterChange">
             <SelectTrigger class="w-full sm:w-[160px]">
               <SelectValue />
@@ -40,6 +40,47 @@
               <SelectItem value="consolidation">{{ $t('tasks.trigger.consolidation') }}</SelectItem>
             </SelectContent>
           </Select>
+
+          <Select v-model="filters.providerFilter" @update:model-value="onFilterChange">
+            <SelectTrigger class="w-full sm:w-[240px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">{{ $t('tasks.filters.allProviders') }}</SelectItem>
+              <SelectItem v-if="hasDefaultProviderFilter" :value="TASK_DEFAULT_PROVIDER_FILTER">
+                {{ $t('tasks.filters.defaultProvider') }}
+              </SelectItem>
+              <SelectItem
+                v-for="option in providerModelFilterOptions"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-muted-foreground">{{ $t('tasks.filters.fromDate') }}</span>
+            <Input
+              v-model="filters.createdFrom"
+              type="date"
+              class="w-[145px]"
+              :aria-label="$t('tasks.filters.fromDate')"
+              @change="onFilterChange"
+            />
+          </div>
+
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-muted-foreground">{{ $t('tasks.filters.toDate') }}</span>
+            <Input
+              v-model="filters.createdTo"
+              type="date"
+              class="w-[145px]"
+              :aria-label="$t('tasks.filters.toDate')"
+              @change="onFilterChange"
+            />
+          </div>
         </div>
 
         <Button variant="outline" :disabled="loading" class="gap-2" @click="loadTasks(pagination.page)">
@@ -242,7 +283,11 @@
 <script setup lang="ts">
 import type { Task } from '~/api/tasks'
 import TaskEventsViewer from '~/features/tasks/components/TaskEventsViewer.vue'
-import { useTasksList } from '~/features/tasks/composables/useTasksList'
+import {
+  TASK_DEFAULT_PROVIDER_FILTER,
+  encodeTaskProviderModelFilter,
+  useTasksList,
+} from '~/features/tasks/composables/useTasksList'
 
 const { locale, t } = useI18n()
 const { formatNumber, formatCurrency } = useFormat()
@@ -270,6 +315,7 @@ function onTaskRestarted(newTaskId: string) {
 
 const {
   tasks,
+  providerOptions,
   sortedTasks,
   loading,
   error,
@@ -283,6 +329,28 @@ const {
   startPolling,
   stopPolling,
 } = useTasksList()
+
+const hasDefaultProviderFilter = computed(() =>
+  providerOptions.value.some(option => option.isDefaultModel === true),
+)
+
+const providerModelFilterOptions = computed(() => {
+  const seen = new Set<string>()
+
+  return providerOptions.value
+    .filter((option): option is { provider: string; model: string; isDefaultModel: boolean | null } =>
+      Boolean(option.provider && option.model),
+    )
+    .map((option) => ({
+      value: encodeTaskProviderModelFilter(option.provider, option.model),
+      label: `${option.provider} (${option.model})`,
+    }))
+    .filter((option) => {
+      if (seen.has(option.value)) return false
+      seen.add(option.value)
+      return true
+    })
+})
 
 const killDialog = reactive({
   open: false,

--- a/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
+++ b/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
@@ -1,6 +1,6 @@
 import type { Task, TaskProviderFilterOption } from '~/api/tasks'
 import { useTasksApi } from '~/api/tasks'
-import { createDefaultTaskDateRange } from '../utils/dateFilters'
+import { createDefaultTaskDateRange, formatTaskCreatedAtBoundary } from '../utils/dateFilters'
 
 export const TASK_DEFAULT_PROVIDER_FILTER = '__default__'
 
@@ -84,8 +84,8 @@ export function useTasksList() {
         status: filters.status || undefined,
         triggerType: filters.triggerType || undefined,
         ...providerFilter,
-        createdFrom: filters.createdFrom || undefined,
-        createdTo: filters.createdTo || undefined,
+        createdFrom: formatTaskCreatedAtBoundary(filters.createdFrom, 'start'),
+        createdTo: formatTaskCreatedAtBoundary(filters.createdTo, 'end'),
       })
 
       providerOptions.value = data.providerOptions ?? []

--- a/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
+++ b/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
@@ -90,7 +90,7 @@ export function useTasksList() {
 
       providerOptions.value = data.providerOptions ?? []
 
-      if (allowProviderReset && filters.providerFilter && !isProviderFilterAvailable(filters.providerFilter)) {
+      if (!silent && allowProviderReset && filters.providerFilter && !isProviderFilterAvailable(filters.providerFilter)) {
         filters.providerFilter = ''
         await loadTasks(1, { silent, allowProviderReset: false })
         return

--- a/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
+++ b/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
@@ -1,27 +1,8 @@
 import type { Task, TaskProviderFilterOption } from '~/api/tasks'
 import { useTasksApi } from '~/api/tasks'
+import { createDefaultTaskDateRange } from '../utils/dateFilters'
 
 export const TASK_DEFAULT_PROVIDER_FILTER = '__default__'
-
-const DEFAULT_DATE_RANGE_DAYS = 3
-
-function formatDateInputValue(date: Date): string {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function createDefaultDateRange() {
-  const to = new Date()
-  const from = new Date(to)
-  from.setDate(to.getDate() - (DEFAULT_DATE_RANGE_DAYS - 1))
-
-  return {
-    createdFrom: formatDateInputValue(from),
-    createdTo: formatDateInputValue(to),
-  }
-}
 
 export function encodeTaskProviderModelFilter(provider: string, model: string): string {
   return `${encodeURIComponent(provider)}|${encodeURIComponent(model)}`
@@ -51,7 +32,7 @@ export function useTasksList() {
     totalPages: 0,
   })
 
-  const defaultDateRange = createDefaultDateRange()
+  const defaultDateRange = createDefaultTaskDateRange()
   const filters = reactive({
     status: '' as string,
     triggerType: '' as string,

--- a/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
+++ b/packages/web-frontend/app/features/tasks/composables/useTasksList.ts
@@ -1,10 +1,47 @@
-import type { Task } from '~/api/tasks'
+import type { Task, TaskProviderFilterOption } from '~/api/tasks'
 import { useTasksApi } from '~/api/tasks'
+
+export const TASK_DEFAULT_PROVIDER_FILTER = '__default__'
+
+const DEFAULT_DATE_RANGE_DAYS = 3
+
+function formatDateInputValue(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function createDefaultDateRange() {
+  const to = new Date()
+  const from = new Date(to)
+  from.setDate(to.getDate() - (DEFAULT_DATE_RANGE_DAYS - 1))
+
+  return {
+    createdFrom: formatDateInputValue(from),
+    createdTo: formatDateInputValue(to),
+  }
+}
+
+export function encodeTaskProviderModelFilter(provider: string, model: string): string {
+  return `${encodeURIComponent(provider)}|${encodeURIComponent(model)}`
+}
+
+function decodeTaskProviderModelFilter(value: string): { provider: string; model: string } | null {
+  const [provider, model] = value.split('|')
+  if (!provider || !model) return null
+
+  return {
+    provider: decodeURIComponent(provider),
+    model: decodeURIComponent(model),
+  }
+}
 
 export function useTasksList() {
   const tasksApi = useTasksApi()
 
   const tasks = ref<Task[]>([])
+  const providerOptions = ref<TaskProviderFilterOption[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
   const pagination = ref({
@@ -14,9 +51,13 @@ export function useTasksList() {
     totalPages: 0,
   })
 
+  const defaultDateRange = createDefaultDateRange()
   const filters = reactive({
     status: '' as string,
     triggerType: '' as string,
+    providerFilter: '' as string,
+    createdFrom: defaultDateRange.createdFrom,
+    createdTo: defaultDateRange.createdTo,
   })
 
   const sortField = ref<string>('createdAt')
@@ -28,19 +69,51 @@ export function useTasksList() {
     tasks.value.some(task => task.status === 'running'),
   )
 
-  async function loadTasks(page: number = 1, { silent = false }: { silent?: boolean } = {}) {
+  function isProviderFilterAvailable(value: string): boolean {
+    if (!value) return true
+    if (value === TASK_DEFAULT_PROVIDER_FILTER) {
+      return providerOptions.value.some(option => option.isDefaultModel === true)
+    }
+
+    const decoded = decodeTaskProviderModelFilter(value)
+    if (!decoded) return false
+
+    return providerOptions.value.some(option =>
+      option.provider === decoded.provider && option.model === decoded.model,
+    )
+  }
+
+  async function loadTasks(
+    page: number = 1,
+    { silent = false, allowProviderReset = true }: { silent?: boolean; allowProviderReset?: boolean } = {},
+  ) {
     if (!silent) {
       loading.value = true
     }
     error.value = null
 
     try {
+      const providerFilter = filters.providerFilter === TASK_DEFAULT_PROVIDER_FILTER
+        ? { isDefaultModel: true }
+        : decodeTaskProviderModelFilter(filters.providerFilter) ?? {}
+
       const data = await tasksApi.listTasks({
         page,
         limit: pagination.value.limit,
         status: filters.status || undefined,
         triggerType: filters.triggerType || undefined,
+        ...providerFilter,
+        createdFrom: filters.createdFrom || undefined,
+        createdTo: filters.createdTo || undefined,
       })
+
+      providerOptions.value = data.providerOptions ?? []
+
+      if (allowProviderReset && filters.providerFilter && !isProviderFilterAvailable(filters.providerFilter)) {
+        filters.providerFilter = ''
+        await loadTasks(1, { silent, allowProviderReset: false })
+        return
+      }
 
       tasks.value = data.tasks
       pagination.value = data.pagination
@@ -114,6 +187,7 @@ export function useTasksList() {
 
   return {
     tasks,
+    providerOptions,
     sortedTasks,
     loading,
     error,

--- a/packages/web-frontend/app/features/tasks/utils/dateFilters.test.ts
+++ b/packages/web-frontend/app/features/tasks/utils/dateFilters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createDefaultTaskDateRange, formatDateInputValue } from './dateFilters'
+import { createDefaultTaskDateRange, formatDateInputValue, formatTaskCreatedAtBoundary } from './dateFilters'
 
 describe('task date filters', () => {
   it('keeps date input labels on the local calendar day', () => {
@@ -13,4 +13,15 @@ describe('task date filters', () => {
     })
   })
 
+  it('converts picked local dates to UTC instants for API filters', () => {
+    expect(formatTaskCreatedAtBoundary('2026-03-28', 'start'))
+      .toBe(new Date(2026, 2, 28, 0, 0, 0).toISOString())
+    expect(formatTaskCreatedAtBoundary('2026-03-28', 'end'))
+      .toBe(new Date(2026, 2, 28, 23, 59, 59).toISOString())
+  })
+
+  it('leaves non-date-only values for backend validation', () => {
+    expect(formatTaskCreatedAtBoundary('not-a-date', 'start')).toBe('not-a-date')
+    expect(formatTaskCreatedAtBoundary('', 'start')).toBeUndefined()
+  })
 })

--- a/packages/web-frontend/app/features/tasks/utils/dateFilters.test.ts
+++ b/packages/web-frontend/app/features/tasks/utils/dateFilters.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { createDefaultTaskDateRange, formatDateInputValue } from './dateFilters'
+
+describe('task date filters', () => {
+  it('keeps date input labels on the local calendar day', () => {
+    expect(formatDateInputValue(new Date(2026, 2, 28, 15, 30, 0))).toBe('2026-03-28')
+  })
+
+  it('creates the default three-day date input range', () => {
+    expect(createDefaultTaskDateRange(new Date(2026, 2, 28, 15, 30, 0))).toEqual({
+      createdFrom: '2026-03-26',
+      createdTo: '2026-03-28',
+    })
+  })
+
+})

--- a/packages/web-frontend/app/features/tasks/utils/dateFilters.ts
+++ b/packages/web-frontend/app/features/tasks/utils/dateFilters.ts
@@ -1,0 +1,19 @@
+export const TASK_DEFAULT_DATE_RANGE_DAYS = 3
+
+export function formatDateInputValue(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function createDefaultTaskDateRange(to: Date = new Date()) {
+  const from = new Date(to)
+  from.setDate(to.getDate() - (TASK_DEFAULT_DATE_RANGE_DAYS - 1))
+
+  return {
+    createdFrom: formatDateInputValue(from),
+    createdTo: formatDateInputValue(to),
+  }
+}
+

--- a/packages/web-frontend/app/features/tasks/utils/dateFilters.ts
+++ b/packages/web-frontend/app/features/tasks/utils/dateFilters.ts
@@ -1,5 +1,7 @@
 export const TASK_DEFAULT_DATE_RANGE_DAYS = 3
 
+export type DateBoundary = 'start' | 'end'
+
 export function formatDateInputValue(date: Date): string {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0')
@@ -15,5 +17,29 @@ export function createDefaultTaskDateRange(to: Date = new Date()) {
     createdFrom: formatDateInputValue(from),
     createdTo: formatDateInputValue(to),
   }
+}
+
+/**
+ * Convert an <input type="date"> value into the UTC instant that represents
+ * the selected local-day boundary. The backend stores task timestamps in UTC,
+ * so sending date-only values would make it interpret the user's local date as
+ * a UTC day and shift the bucket for non-UTC timezones.
+ */
+export function formatTaskCreatedAtBoundary(value: string, boundary: DateBoundary): string | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed)
+  if (!match) return trimmed
+
+  const [, yearRaw, monthRaw, dayRaw] = match
+  const year = Number(yearRaw)
+  const month = Number(monthRaw)
+  const day = Number(dayRaw)
+  const localBoundary = boundary === 'start'
+    ? new Date(year, month - 1, day, 0, 0, 0)
+    : new Date(year, month - 1, day, 23, 59, 59)
+
+  return localBoundary.toISOString()
 }
 

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -823,7 +823,11 @@
     "killSuccess": "Aufgabe erfolgreich beendet.",
     "filters": {
       "allStatuses": "Alle Status",
-      "allTriggers": "Alle Auslöser"
+      "allTriggers": "Alle Auslöser",
+      "allProviders": "Alle Provider",
+      "defaultProvider": "Standard",
+      "fromDate": "Von",
+      "toDate": "Bis"
     },
     "columns": {
       "name": "Name",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -823,7 +823,11 @@
     "killSuccess": "Task killed successfully.",
     "filters": {
       "allStatuses": "All statuses",
-      "allTriggers": "All triggers"
+      "allTriggers": "All triggers",
+      "allProviders": "All providers",
+      "defaultProvider": "Default",
+      "fromDate": "From",
+      "toDate": "To"
     },
     "columns": {
       "name": "Name",


### PR DESCRIPTION
Adds task filtering by provider/model and date range. Provider options are derived dynamically from historical task rows in the selected time range, so renamed or removed providers remain filterable.