### PR TITLE
fix: move webSearch API keys into builtinTools.webSearch defaults

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -58,12 +58,15 @@ const TEMPLATES: Record<string, object> = {
       },
     },
     builtinTools: {
-      webSearch: { enabled: true, provider: 'duckduckgo' },
+      webSearch: {
+        enabled: true,
+        provider: 'duckduckgo',
+        braveSearchApiKey: '',
+        searxngUrl: '',
+        tavilyApiKey: '',
+      },
       webFetch: { enabled: true },
     },
-    braveSearchApiKey: '',
-    searxngUrl: '',
-    tavilyApiKey: '',
     tasks: {
       defaultProvider: '',
       maxDurationMinutes: 60,


### PR DESCRIPTION
## Problem
`braveSearchApiKey`, `searxngUrl`, and `tavilyApiKey` were seeded at the root level of the default `settings.json` template in `config.ts`. The canonical location per docs and runtime read/write logic is `builtinTools.webSearch`.

## Change
Moved all three keys into `builtinTools.webSearch` in the default config template. Removed the root-level entries. No changes to the legacy migration in `runtime-composition.ts` — existing installations with root-level keys are already handled there.

## Testing
- `packages/core` typecheck clean
- `packages/core` tests pass