### PR TITLE
feat: add OpenAI WebSocket transport option with delta-updates

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -357,11 +357,38 @@ LLM provider catalog. UI-managed via the [Providers page](../web-ui/providers); 
 | `enabledModels`          | `string[]?`                                     | Model ids the user has enabled for this provider.                                              |
 | `degradedThresholdMs`    | `number?`                                       | Latency threshold for `healthy → degraded` transitions in [Health Monitor](../settings/health-monitor). |
 | `textVerbosity`          | `"low" \| "medium" \| "high"` (optional)          | Response verbosity for supported OpenAI Codex/Responses-style providers. Omit to use the provider default (pi-ai currently defaults Codex to `low`). Configure via [Providers UI](../web-ui/providers#add-edit-dialog). |
+| `transport`              | `"sse" \| "websocket" \| "websocket-cached" \| "auto"` (optional) | Wire-level streaming transport. **Only honoured by the OpenAI Codex / Responses apiType today** — silently ignored on every other provider type and dropped on persist. Omit (or set to `"sse"`) to use the default HTTP+SSE streaming. See [Transport modes](#transport-modes) below. |
 | `models`                 | `ProviderModelConfig[]?`                        | Per-model overrides — context window, max tokens, reasoning support, fixed temperature, custom cost. |
 | `status`                 | `"connected" \| "error" \| "untested"`          | Last-known result of an explicit "test connection" click.                                      |
 | `modelStatuses`          | `Record<modelId, status>`                       | Per-model variant of `status`.                                                                 |
 | `authMethod`             | `"apiKey" \| "oauth"`                           | Determines whether `apiKey` or `oauthCredentials` is used.                                     |
 | `oauthCredentials`       | `OAuthCredentialsStored?` (**encrypted**)       | `{ refresh, access, expires, extra }` — only present when `authMethod === "oauth"`.            |
+
+### Transport modes
+
+The `transport` field selects the wire protocol used to stream completions for
+providers that expose more than one. **In Axiom today this only applies to the
+OpenAI Codex / Responses apiType** (`providerType: "openai-codex"`); for every
+other provider type the value is dropped on save and the default SSE transport
+is used.
+
+| Value                | Behaviour                                                                                                                                                                              |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `"sse"` (default)    | Regular HTTP request per turn with Server-Sent Events streaming. The full conversation context is resent on every tool-call round.                                                     |
+| `"websocket"`        | Persistent WebSocket connection per session. No SSE fallback — connection errors surface as request errors.                                                                            |
+| `"websocket-cached"` | Persistent WebSocket connection that ships only **delta context items** per turn. The first turn primes the cache; subsequent turns reuse `previous_response_id` and send only what's new. Best fit for long agent sessions. |
+| `"auto"`             | Try WebSocket first; fall back to SSE on connection error.                                                                                                                             |
+
+Why `"websocket-cached"` matters for long sessions: with `"sse"` every tool-call
+round re-uploads the full transcript, which scales linearly with session length.
+`"websocket-cached"` instead keys off `sessionId` (Axiom already passes one per
+session), keeps the connection open, and the upstream API resolves the prior
+context from cache — only new items are sent.
+
+Reconfigure via [Providers UI](../web-ui/providers#add-edit-dialog) or by
+editing `providers.json` directly. Switching a provider away from a Codex-style
+`providerType` automatically strips an existing `transport` value, since it
+would otherwise be a silent no-op.
 
 ### Encryption
 

--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -112,6 +112,13 @@ The dialog keeps connection details first, then model selection, then advanced h
 | **Degraded Threshold** | Last field in the form. Latency in ms above which the provider is marked *Degraded* in health checks. Default `5000`. Lower = more sensitive. |
 | **Text verbosity**     | Shown for supported OpenAI Codex/Responses-style providers. `Default` leaves the value unset so pi-ai's provider default applies; `Low`, `Medium`, `High` override response verbosity. |
 
+The provider record also accepts an optional `transport` field (`sse` /
+`websocket` / `websocket-cached` / `auto`) for OpenAI Codex / Responses-style
+providers, but it is not yet surfaced as a dialog control. To enable a
+non-default transport today, set it via the providers HTTP API or by editing
+`providers.json` directly — see [Transport modes in `providers.json`](../reference/settings#transport-modes).
+| **Transport**          | Wire-level streaming protocol. Honoured today only by OpenAI Codex/Responses providers; ignored elsewhere. Defaults to `sse`. `websocket-cached` keeps a persistent WebSocket open and ships only delta context items per turn — noticeably faster on long agent sessions. See [`providers.json` → Transport modes](../reference/settings#transport-modes) for the full table. Currently configured by editing `providers.json` directly; UI control is planned. |
+
 ### API-key providers
 
 When you pick a type from the *API Key* group, the fields appear in this order:

--- a/packages/core/src/agent-runtime.ts
+++ b/packages/core/src/agent-runtime.ts
@@ -471,7 +471,12 @@ class PiAgentRuntime implements AgentRuntimeBoundary, AgentRuntimePiAgentAccess 
         tools,
         thinkingLevel: effectiveThinkingLevel,
       },
-      streamFn: buildStreamFn({ textVerbosity: this.providerConfig?.textVerbosity }),
+      streamFn: buildStreamFn({
+        textVerbosity: this.providerConfig?.textVerbosity,
+        transport: this.providerConfig?.transport,
+      }),
+      ...(this.providerConfig?.transport && this.providerConfig.transport !== 'sse'
+        && { transport: this.providerConfig.transport }),
       getApiKey: this.providerConfig?.authMethod === 'oauth'
         ? async () => {
             try {

--- a/packages/core/src/contracts/providers.ts
+++ b/packages/core/src/contracts/providers.ts
@@ -3,11 +3,6 @@ import type { ProviderType } from '../provider-config.js'
 export type ProviderStatusContract = 'connected' | 'error' | 'untested'
 export type ProviderAuthMethodContract = 'api-key' | 'oauth'
 export type ProviderTextVerbosityContract = 'low' | 'medium' | 'high'
-/**
- * Wire-level transport for providers that expose more than one. Mirrors
- * pi-ai's `Transport` union — see `ProviderTransport` in provider-config.ts
- * for semantics. `undefined` means "use the provider default" (`"sse"`).
- */
 export type ProviderTransportContract = 'sse' | 'websocket' | 'websocket-cached' | 'auto'
 
 export interface ProviderContract {

--- a/packages/core/src/contracts/providers.ts
+++ b/packages/core/src/contracts/providers.ts
@@ -3,6 +3,12 @@ import type { ProviderType } from '../provider-config.js'
 export type ProviderStatusContract = 'connected' | 'error' | 'untested'
 export type ProviderAuthMethodContract = 'api-key' | 'oauth'
 export type ProviderTextVerbosityContract = 'low' | 'medium' | 'high'
+/**
+ * Wire-level transport for providers that expose more than one. Mirrors
+ * pi-ai's `Transport` union — see `ProviderTransport` in provider-config.ts
+ * for semantics. `undefined` means "use the provider default" (`"sse"`).
+ */
+export type ProviderTransportContract = 'sse' | 'websocket' | 'websocket-cached' | 'auto'
 
 export interface ProviderContract {
   id: string
@@ -17,6 +23,7 @@ export interface ProviderContract {
   enabledModels?: string[]
   degradedThresholdMs?: number
   textVerbosity?: ProviderTextVerbosityContract
+  transport?: ProviderTransportContract
   status?: ProviderStatusContract
   modelStatuses?: Record<string, ProviderStatusContract>
   authMethod?: ProviderAuthMethodContract
@@ -120,6 +127,7 @@ export interface ProviderCreatePayloadContract {
   enabledModels?: string[]
   degradedThresholdMs?: number
   textVerbosity?: ProviderTextVerbosityContract | null
+  transport?: ProviderTransportContract | null
 }
 
 export interface ProviderUpdatePayloadContract {
@@ -131,6 +139,7 @@ export interface ProviderUpdatePayloadContract {
   enabledModels?: string[]
   degradedThresholdMs?: number
   textVerbosity?: ProviderTextVerbosityContract | null
+  transport?: ProviderTransportContract | null
 }
 
 export interface ProviderFallbackUpdatePayloadContract {
@@ -144,6 +153,7 @@ export interface ProviderOAuthLoginStartPayloadContract {
   defaultModel: string
   providerId?: string
   textVerbosity?: ProviderTextVerbosityContract | null
+  transport?: ProviderTransportContract | null
 }
 
 export interface ProviderOAuthCodePayloadContract {

--- a/packages/core/src/provider-config.test.ts
+++ b/packages/core/src/provider-config.test.ts
@@ -19,8 +19,10 @@ import {
   PROVIDER_TYPE_PRESETS,
   getConfiguredPriceTable,
   applyTextVerbosity,
+  applyTransport,
   buildStreamFn,
   presetSupportsTextVerbosity,
+  presetSupportsTransport,
 } from './provider-config.js'
 import { encrypt, decrypt, maskApiKey } from './encryption.js'
 import fs from 'node:fs'
@@ -285,6 +287,74 @@ describe('streamFn injection', () => {
     expect(opts).toBe(inputOpts) // identity — no spread when not needed
     expect(opts).not.toHaveProperty('textVerbosity')
   })
+
+  it('applyTransport returns opts unchanged when transport is undefined', () => {
+    const opts = { temperature: 0.7 }
+    expect(applyTransport(undefined, opts)).toBe(opts)
+  })
+
+  it('applyTransport returns opts unchanged when transport is the default "sse"', () => {
+    const opts = { temperature: 0.7 }
+    // "sse" matches pi-ai's default — the spread would be a no-op, so we keep
+    // identity for the common case to make the call site free of churn.
+    expect(applyTransport('sse', opts)).toBe(opts)
+  })
+
+  it('applyTransport merges non-default transports into opts', () => {
+    const opts = { temperature: 0.7 }
+    const merged = applyTransport('websocket-cached', opts)
+    expect(merged).toEqual({ temperature: 0.7, transport: 'websocket-cached' })
+    // does not mutate the input
+    expect(opts).toEqual({ temperature: 0.7 })
+  })
+
+  it('buildStreamFn forwards transport into streamSimple options when configured', async () => {
+    const fakeStream = vi.fn().mockResolvedValue({ ok: true })
+    const fn = buildStreamFn({ transport: 'websocket-cached' }, fakeStream as never)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fn({ id: 'm' } as any, { messages: [] } as any, { temperature: 0.5 } as any)
+    expect(fakeStream).toHaveBeenCalledTimes(1)
+    const [, , opts] = fakeStream.mock.calls[0]!
+    expect(opts).toEqual({ temperature: 0.5, transport: 'websocket-cached' })
+  })
+
+  it('buildStreamFn forwards both textVerbosity and transport when both configured', async () => {
+    const fakeStream = vi.fn().mockResolvedValue({ ok: true })
+    const fn = buildStreamFn(
+      { textVerbosity: 'medium', transport: 'websocket' },
+      fakeStream as never,
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fn({ id: 'm' } as any, { messages: [] } as any, { temperature: 0.5 } as any)
+    const [, , opts] = fakeStream.mock.calls[0]!
+    expect(opts).toEqual({
+      temperature: 0.5,
+      textVerbosity: 'medium',
+      transport: 'websocket',
+    })
+  })
+
+  it('buildStreamFn passes options through unchanged when transport is "sse" (default)', async () => {
+    const fakeStream = vi.fn().mockResolvedValue({ ok: true })
+    const fn = buildStreamFn({ transport: 'sse' }, fakeStream as never)
+    const inputOpts = { temperature: 0.5 }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await fn({ id: 'm' } as any, { messages: [] } as any, inputOpts as any)
+    const [, , opts] = fakeStream.mock.calls[0]!
+    expect(opts).toBe(inputOpts) // identity — no spread when not needed
+    expect(opts).not.toHaveProperty('transport')
+  })
+
+  it('presetSupportsTransport is true only for openai-codex-responses presets', () => {
+    // Only the OpenAI Codex / Responses apiType currently honours `transport`
+    // in pi-ai. Keeping this list explicit so a future provider gaining WS
+    // support fails this assertion and forces a deliberate update.
+    expect(presetSupportsTransport('openai-codex')).toBe(true)
+    expect(presetSupportsTransport('openai')).toBe(false)
+    expect(presetSupportsTransport('anthropic')).toBe(false)
+    expect(presetSupportsTransport('github-copilot')).toBe(false)
+    expect(presetSupportsTransport('ollama')).toBe(false)
+  })
 })
 
 describe('textVerbosity persistence guard', () => {
@@ -358,6 +428,136 @@ describe('textVerbosity persistence guard', () => {
     const provider = addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-a', defaultModel: 'gpt-4o' })
     const updated = updateProvider(provider.id, { textVerbosity: 'high' })
     expect(updated.textVerbosity).toBeUndefined()
+  })
+})
+
+describe('transport persistence guard', () => {
+  let tmpDir: string
+  const originalDataDir = process.env.DATA_DIR
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+    if (originalDataDir !== undefined) process.env.DATA_DIR = originalDataDir
+    else delete process.env.DATA_DIR
+  })
+
+  function setupEmpty(): void {
+    tmpDir = path.join(os.tmpdir(), `axiom-tr-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    const configDir = path.join(tmpDir, 'config')
+    fs.mkdirSync(configDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(configDir, 'providers.json'),
+      JSON.stringify({ providers: [] }, null, 2),
+      'utf-8',
+    )
+    process.env.DATA_DIR = tmpDir
+  }
+
+  it('addProvider persists transport on supported providerType (openai-codex)', () => {
+    setupEmpty()
+    const codex = addProvider({
+      name: 'codex-ws',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+      transport: 'websocket-cached',
+    })
+    expect(codex.transport).toBe('websocket-cached')
+  })
+
+  it('addProvider drops transport when preset does not support it', () => {
+    setupEmpty()
+    const provider = addProvider({
+      name: 'openai-noop',
+      providerType: 'openai',
+      apiKey: 'sk-1',
+      defaultModel: 'gpt-4o',
+      transport: 'websocket-cached',
+    })
+    expect(provider.transport).toBeUndefined()
+  })
+
+  it('addProvider drops transport when value is the default "sse"', () => {
+    setupEmpty()
+    const codex = addProvider({
+      name: 'codex-sse',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+      transport: 'sse',
+    })
+    // We never persist the no-op default — absence == "sse".
+    expect(codex.transport).toBeUndefined()
+  })
+
+  it('addProvider defaults transport to undefined (== sse) when not provided', () => {
+    setupEmpty()
+    const codex = addProvider({
+      name: 'codex-default',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+    })
+    expect(codex.transport).toBeUndefined()
+  })
+
+  it('updateProvider persists transport on supported provider', () => {
+    setupEmpty()
+    addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-a', defaultModel: 'gpt-4o' })
+    const codex = addProvider({
+      name: 'codex',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+    })
+    const updated = updateProvider(codex.id, { transport: 'websocket-cached' })
+    expect(updated.transport).toBe('websocket-cached')
+  })
+
+  it('updateProvider strips transport when switching to a non-supporting providerType', () => {
+    setupEmpty()
+    addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-a', defaultModel: 'gpt-4o' })
+    const codex = addProvider({
+      name: 'codex',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+      transport: 'websocket-cached',
+    })
+    expect(codex.transport).toBe('websocket-cached')
+
+    // Flip to a providerType that does not consume transport
+    const updated = updateProvider(codex.id, { providerType: 'openai' })
+    expect(updated.transport).toBeUndefined()
+  })
+
+  it('updateProvider clears transport when explicitly set to null', () => {
+    setupEmpty()
+    addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-a', defaultModel: 'gpt-4o' })
+    const codex = addProvider({
+      name: 'codex',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+      transport: 'websocket-cached',
+    })
+    expect(codex.transport).toBe('websocket-cached')
+    const updated = updateProvider(codex.id, { transport: null })
+    expect(updated.transport).toBeUndefined()
+  })
+
+  it('updateProvider clears transport when explicitly set to "sse" (the default)', () => {
+    setupEmpty()
+    addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-a', defaultModel: 'gpt-4o' })
+    const codex = addProvider({
+      name: 'codex',
+      providerType: 'openai-codex',
+      defaultModel: 'gpt-5-codex',
+      transport: 'websocket-cached',
+    })
+    const updated = updateProvider(codex.id, { transport: 'sse' })
+    expect(updated.transport).toBeUndefined()
+  })
+
+  it('updateProvider ignores transport on providers whose preset does not support it', () => {
+    setupEmpty()
+    const provider = addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-a', defaultModel: 'gpt-4o' })
+    const updated = updateProvider(provider.id, { transport: 'websocket-cached' })
+    expect(updated.transport).toBeUndefined()
   })
 })
 

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import type { Api, KnownProvider, Model } from '@mariozechner/pi-ai'
+import type { Api, KnownProvider, Model, Transport } from '@mariozechner/pi-ai'
 import { getModels as getPiAiModels, streamSimple } from '@mariozechner/pi-ai'
 import { getOAuthProvider, getOAuthApiKey } from '@mariozechner/pi-ai/oauth'
 import type { OAuthCredentials } from '@mariozechner/pi-ai/oauth'
@@ -25,6 +25,20 @@ export type ProviderType =
 
 export type AuthMethod = 'api-key' | 'oauth'
 export type TextVerbosity = 'low' | 'medium' | 'high'
+/**
+ * Wire-level transport for providers that support multiple transports. Mirrors
+ * pi-ai's `Transport` union. Only the `openai-codex-responses` apiType honours
+ * a non-`sse` value today; for every other provider the field is ignored
+ * downstream and is dropped on persist (see `presetSupportsTransport`).
+ *
+ * - `"sse"` (default): regular HTTP + Server-Sent Events streaming.
+ * - `"websocket"`: persistent WebSocket connection, no SSE fallback.
+ * - `"websocket-cached"`: persistent WebSocket connection that ships only
+ *   delta context items per turn (much smaller payloads on long sessions);
+ *   first turn primes the cache, subsequent turns reuse `previous_response_id`.
+ * - `"auto"`: try WebSocket first, fall back to SSE on connection error.
+ */
+export type ProviderTransport = Transport
 
 export interface ProviderTypePreset {
   type: ProviderType
@@ -352,6 +366,19 @@ export function presetSupportsTextVerbosity(providerType: ProviderType): boolean
 }
 
 /**
+ * Whether a provider type's pi-ai apiType actually consumes the `transport`
+ * stream option. Today only the OpenAI Codex / Responses API supports the
+ * WebSocket / cached-WebSocket transports; every other provider streams over
+ * SSE only and the value is silently ignored. We drop the field on persist
+ * for unsupported providers so it cannot accidentally diverge from runtime
+ * behaviour.
+ */
+export function presetSupportsTransport(providerType: ProviderType): boolean {
+  const preset = PROVIDER_TYPE_PRESETS[providerType]
+  return preset?.apiType === 'openai-codex-responses'
+}
+
+/**
  * Pure helper: merge the configured `textVerbosity` into a `streamSimple`
  * options object. Returns `opts` unchanged when the provider has no
  * verbosity override. Exported so tests can lock the contract without
@@ -366,20 +393,43 @@ export function applyTextVerbosity<T extends object | undefined>(
 }
 
 /**
+ * Pure helper: merge the configured `transport` into a `streamSimple` options
+ * object. Returns `opts` unchanged when the provider has no transport
+ * override or when the override is the default `"sse"`. Exported so tests can
+ * lock the contract without having to mock pi-ai's streamSimple.
+ *
+ * The default of `"sse"` is a no-op upstream (pi-ai also defaults to SSE), so
+ * we omit it from the spread to keep call paths identity-preserving when no
+ * change is requested.
+ */
+export function applyTransport<T extends object | undefined>(
+  transport: ProviderTransport | undefined,
+  opts: T,
+): T {
+  if (!transport || transport === 'sse') return opts
+  return { ...(opts ?? {}), transport } as T
+}
+
+/**
  * Build the `streamFn` callback that the agent loop hands to pi-agent-core.
- * Wraps `streamSimple` and forwards the provider's `textVerbosity` override
- * when one is configured. Centralising this keeps the cast in one place
- * and makes it impossible to forget the spread at a call site.
+ * Wraps `streamSimple` and forwards the provider's `textVerbosity` and
+ * `transport` overrides when configured. Centralising this keeps the cast
+ * in one place and makes it impossible to forget the spread at a call site.
+ *
+ * pi-agent-core also reads `transport` directly from its `Agent` constructor
+ * options and forwards it on every loop turn, so a configured non-`sse`
+ * transport flows through both code paths.
  *
  * The `streamSimple` argument is injectable purely for testing; production
  * call sites should omit it so the real pi-ai implementation is used.
  */
 export function buildStreamFn(
-  provider: Pick<ProviderConfig, 'textVerbosity'>,
+  provider: Pick<ProviderConfig, 'textVerbosity' | 'transport'>,
   streamImpl: typeof streamSimple = streamSimple,
 ): typeof streamSimple {
   return ((model, context, options) => {
-    const merged = applyTextVerbosity(provider.textVerbosity, options) as Parameters<typeof streamSimple>[2]
+    const withVerbosity = applyTextVerbosity(provider.textVerbosity, options)
+    const merged = applyTransport(provider.transport, withVerbosity) as Parameters<typeof streamSimple>[2]
     return streamImpl(model, context, merged)
   }) as typeof streamSimple
 }
@@ -470,6 +520,17 @@ export interface ProviderConfig {
    * to low).
    */
   textVerbosity?: TextVerbosity
+  /**
+   * Optional wire-level transport override. Currently only honoured by the
+   * OpenAI Codex / Responses apiType (other providers ignore it and the field
+   * is dropped on persist). Defaults to `"sse"` when unset.
+   *
+   * `"websocket-cached"` is the headline alternative: it keeps a persistent
+   * WebSocket connection and only ships delta context items per turn, which
+   * cuts per-round token overhead substantially on long agent sessions. See
+   * `presetSupportsTransport()` for the gating rule.
+   */
+  transport?: ProviderTransport
   models?: ProviderModelConfig[]
   status?: 'connected' | 'error' | 'untested'
   modelStatuses?: Record<string, 'connected' | 'error' | 'untested'>
@@ -712,6 +773,7 @@ export function addProvider(input: {
   enabledModels?: string[]
   degradedThresholdMs?: number
   textVerbosity?: TextVerbosity
+  transport?: ProviderTransport
 }): ProviderConfig {
   const preset = PROVIDER_TYPE_PRESETS[input.providerType]
   if (!preset) {
@@ -745,6 +807,8 @@ export function addProvider(input: {
     degradedThresholdMs: input.degradedThresholdMs ?? 5000,
     ...(input.textVerbosity && presetSupportsTextVerbosity(input.providerType)
       && { textVerbosity: input.textVerbosity }),
+    ...(input.transport && input.transport !== 'sse' && presetSupportsTransport(input.providerType)
+      && { transport: input.transport }),
     status: 'untested',
     authMethod: preset.authMethod,
   }
@@ -771,6 +835,7 @@ export function addOAuthProvider(input: {
   enabledModels?: string[]
   degradedThresholdMs?: number
   textVerbosity?: TextVerbosity
+  transport?: ProviderTransport
   oauthCredentials: OAuthCredentials
 }): ProviderConfig {
   const preset = PROVIDER_TYPE_PRESETS[input.providerType]
@@ -808,6 +873,8 @@ export function addOAuthProvider(input: {
     degradedThresholdMs: input.degradedThresholdMs ?? 5000,
     ...(input.textVerbosity && presetSupportsTextVerbosity(input.providerType)
       && { textVerbosity: input.textVerbosity }),
+    ...(input.transport && input.transport !== 'sse' && presetSupportsTransport(input.providerType)
+      && { transport: input.transport }),
     status: 'untested',
     authMethod: 'oauth',
     oauthCredentials: encryptOAuthCredentials(input.oauthCredentials),
@@ -836,6 +903,7 @@ export function updateProvider(id: string, input: {
   enabledModels?: string[]
   degradedThresholdMs?: number
   textVerbosity?: TextVerbosity | null
+  transport?: ProviderTransport | null
 }): ProviderConfig {
   const file = loadProviders()
   const index = file.providers.findIndex(p => p.id === id)
@@ -890,6 +958,20 @@ export function updateProvider(id: string, input: {
     // Provider type was switched to one that does not support textVerbosity
     // — strip the now-orphaned value so it does not silently persist.
     delete existing.textVerbosity
+  }
+  if (input.transport !== undefined) {
+    if (input.transport === null || input.transport === 'sse' || !presetSupportsTransport(existing.providerType)) {
+      // Caller explicitly cleared, asked for the SSE default, or switched to
+      // a provider type that does not consume `transport`. In all three
+      // cases we drop the field rather than persisting a no-op.
+      delete existing.transport
+    } else {
+      existing.transport = input.transport
+    }
+  } else if (existing.transport && !presetSupportsTransport(existing.providerType)) {
+    // Provider type was switched to one that does not support transport
+    // — strip the now-orphaned value so it does not silently persist.
+    delete existing.transport
   }
 
   // For providers with fixed URLs, always sync from preset

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -25,19 +25,6 @@ export type ProviderType =
 
 export type AuthMethod = 'api-key' | 'oauth'
 export type TextVerbosity = 'low' | 'medium' | 'high'
-/**
- * Wire-level transport for providers that support multiple transports. Mirrors
- * pi-ai's `Transport` union. Only the `openai-codex-responses` apiType honours
- * a non-`sse` value today; for every other provider the field is ignored
- * downstream and is dropped on persist (see `presetSupportsTransport`).
- *
- * - `"sse"` (default): regular HTTP + Server-Sent Events streaming.
- * - `"websocket"`: persistent WebSocket connection, no SSE fallback.
- * - `"websocket-cached"`: persistent WebSocket connection that ships only
- *   delta context items per turn (much smaller payloads on long sessions);
- *   first turn primes the cache, subsequent turns reuse `previous_response_id`.
- * - `"auto"`: try WebSocket first, fall back to SSE on connection error.
- */
 export type ProviderTransport = Transport
 
 export interface ProviderTypePreset {
@@ -514,22 +501,7 @@ export interface ProviderConfig {
   defaultModel: string
   enabledModels?: string[] // list of model IDs enabled for this provider
   degradedThresholdMs?: number
-  /**
-   * Optional OpenAI/Codex Responses text verbosity override. Undefined means
-   * "use the provider implementation default" (pi-ai currently defaults Codex
-   * to low).
-   */
   textVerbosity?: TextVerbosity
-  /**
-   * Optional wire-level transport override. Currently only honoured by the
-   * OpenAI Codex / Responses apiType (other providers ignore it and the field
-   * is dropped on persist). Defaults to `"sse"` when unset.
-   *
-   * `"websocket-cached"` is the headline alternative: it keeps a persistent
-   * WebSocket connection and only ships delta context items per turn, which
-   * cuts per-round token overhead substantially on long agent sessions. See
-   * `presetSupportsTransport()` for the gating rule.
-   */
   transport?: ProviderTransport
   models?: ProviderModelConfig[]
   status?: 'connected' | 'error' | 'untested'

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -458,6 +458,8 @@ export class TaskRunner {
           thinkingLevel: this.resolveBackgroundThinkingLevel(),
         },
         streamFn: buildStreamFn(provider),
+        ...(provider.transport && provider.transport !== 'sse'
+          && { transport: provider.transport }),
         getApiKey: () => apiKey,
       })
 
@@ -872,6 +874,8 @@ export class TaskRunner {
           thinkingLevel: this.resolveBackgroundThinkingLevel(),
         },
         streamFn: buildStreamFn(provider),
+        ...(provider.transport && provider.transport !== 'sse'
+          && { transport: provider.transport }),
         getApiKey: () => apiKey,
       })
 

--- a/packages/web-backend/src/api/modules/providers/schema.test.ts
+++ b/packages/web-backend/src/api/modules/providers/schema.test.ts
@@ -60,10 +60,42 @@ describe('providers schema', () => {
         defaultModel: 'gpt-4o-mini',
         providerId: undefined,
         textVerbosity: undefined,
+        transport: undefined,
       },
     })
 
     expect(parseOAuthCodePayload({})).toEqual({ ok: false, error: 'Code is required' })
+  })
+
+  it('parses transport field on create payload (sse / websocket / websocket-cached / auto / null)', () => {
+    const presets = PROVIDER_TYPE_PRESETS as unknown as typeof PROVIDER_TYPE_PRESETS
+    const base = { name: 'codex', providerType: 'openai-codex', defaultModel: 'gpt-5-codex' }
+
+    for (const value of ['sse', 'websocket', 'websocket-cached', 'auto'] as const) {
+      const result = parseProviderCreatePayload({ ...base, transport: value }, presets)
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.value.transport).toBe(value)
+    }
+
+    // null / empty string → explicit clear
+    const cleared = parseProviderCreatePayload({ ...base, transport: null }, presets)
+    expect(cleared.ok).toBe(true)
+    if (cleared.ok) expect(cleared.value.transport).toBeNull()
+
+    // unknown values are dropped (undefined), not echoed back unchecked
+    const garbage = parseProviderCreatePayload({ ...base, transport: 'http2' }, presets)
+    expect(garbage.ok).toBe(true)
+    if (garbage.ok) expect(garbage.value.transport).toBeUndefined()
+  })
+
+  it('parses transport field on update payload', () => {
+    const updated = parseProviderUpdatePayload({ transport: 'websocket-cached' })
+    expect(updated.ok).toBe(true)
+    if (updated.ok) expect(updated.value.transport).toBe('websocket-cached')
+
+    const cleared = parseProviderUpdatePayload({ transport: null })
+    expect(cleared.ok).toBe(true)
+    if (cleared.ok) expect(cleared.value.transport).toBeNull()
   })
 
   it('validates ollama probe payload and url format', () => {

--- a/packages/web-backend/src/api/modules/providers/schema.ts
+++ b/packages/web-backend/src/api/modules/providers/schema.ts
@@ -58,6 +58,16 @@ function normalizeTextVerbosity(value: unknown): 'low' | 'medium' | 'high' | nul
   return undefined
 }
 
+function normalizeTransport(
+  value: unknown,
+): 'sse' | 'websocket' | 'websocket-cached' | 'auto' | null | undefined {
+  if (value === null || value === '') return null
+  if (value === 'sse' || value === 'websocket' || value === 'websocket-cached' || value === 'auto') {
+    return value
+  }
+  return undefined
+}
+
 function isValidProviderType(providerType: string): boolean {
   return VALID_PROVIDER_TYPES.includes(providerType)
 }
@@ -134,6 +144,7 @@ export function parseOAuthLoginPayload(payload: unknown): ParseResult<ProviderOA
       defaultModel,
       providerId: asTrimmedString(body.providerId),
       textVerbosity: normalizeTextVerbosity(body.textVerbosity),
+      transport: normalizeTransport(body.transport),
     },
   }
 }
@@ -192,6 +203,7 @@ export function parseProviderCreatePayload(
       enabledModels: normalizeEnabledModels(body.enabledModels),
       degradedThresholdMs: normalizeDegradedThresholdMs(body.degradedThresholdMs),
       textVerbosity: normalizeTextVerbosity(body.textVerbosity),
+      transport: normalizeTransport(body.transport),
     },
   }
 }
@@ -218,6 +230,7 @@ export function parseProviderUpdatePayload(payload: unknown): ParseResult<Provid
       enabledModels: normalizeEnabledModels(body.enabledModels),
       degradedThresholdMs: normalizeDegradedThresholdMs(body.degradedThresholdMs),
       textVerbosity: normalizeTextVerbosity(body.textVerbosity),
+      transport: normalizeTransport(body.transport),
     },
   }
 }

--- a/packages/web-backend/src/api/modules/providers/service.ts
+++ b/packages/web-backend/src/api/modules/providers/service.ts
@@ -172,6 +172,7 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
       name: payload.name,
       defaultModel: payload.defaultModel,
       textVerbosity: payload.textVerbosity,
+      transport: payload.transport,
       createdAt: Date.now(),
       existingProviderId: payload.providerId,
     }
@@ -257,6 +258,7 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
             providerType: loginState.providerType as ProviderType,
             defaultModel: loginState.defaultModel,
             textVerbosity: loginState.textVerbosity ?? undefined,
+            transport: loginState.transport ?? undefined,
             oauthCredentials: loginState.credentials,
           })
           const afterActiveProvider = loadProviders().activeProvider ?? null
@@ -316,6 +318,7 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
         enabledModels: payload.enabledModels,
         degradedThresholdMs: payload.degradedThresholdMs,
         textVerbosity: payload.textVerbosity ?? undefined,
+        transport: payload.transport ?? undefined,
       })
 
       const afterActiveProvider = loadProviders().activeProvider ?? null
@@ -341,6 +344,7 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
         enabledModels: payload.enabledModels,
         degradedThresholdMs: payload.degradedThresholdMs,
         textVerbosity: payload.textVerbosity,
+        transport: payload.transport,
       })
 
       if (activeProvider === id) {

--- a/packages/web-backend/src/api/modules/providers/types.ts
+++ b/packages/web-backend/src/api/modules/providers/types.ts
@@ -19,6 +19,7 @@ export interface PendingOAuthLogin {
   name: string
   defaultModel: string
   textVerbosity?: 'low' | 'medium' | 'high' | null
+  transport?: 'sse' | 'websocket' | 'websocket-cached' | 'auto' | null
   authUrl?: string
   instructions?: string
   credentials?: OAuthCredentials


### PR DESCRIPTION
## Problem

Axiom's OpenAI Codex / Responses provider always streams over HTTP+SSE. Every tool-call round resends the full conversation context, which scales linearly with session length. For long agent loops this means substantial repeated upload cost and added latency.

pi-ai already implements WebSocket transports for the `openai-codex-responses` apiType (`websocket`, `websocket-cached`, `auto`), but Axiom never plumbs the option through, so the value can't be selected today.

## Change

Adds a `transport` field to `ProviderConfig` that mirrors pi-ai's `Transport` union (`"sse" | "websocket" | "websocket-cached" | "auto"`). When the configured provider's preset supports it (today: only the OpenAI Codex / Responses apiType, gated by the new `presetSupportsTransport()`), the value is forwarded to the runtime in two places:

- `buildStreamFn(provider)` merges it into the `streamSimple` options for every turn.
- `new PiAgent({ transport })` is set so pi-agent-core's loop config carries it on every iteration.

Behaviour is identical to today when `transport` is unset or `"sse"`. `"websocket-cached"` keeps a persistent WebSocket open and ships only delta context items per turn — much smaller payloads on long sessions, with the actual delta/cache logic owned by pi-ai.

The field is dropped on persist when the preset doesn't honour it (same pattern already used for `textVerbosity`), so users can't accidentally store a no-op.

## UI

A **Transport dropdown** is included in the Provider form dialog (commit `d3d878a`), visible for OpenAI Codex / Responses providers. Four options: SSE (default), WebSocket, WebSocket cached (delta-updates), Auto (WS with SSE fallback). i18n de + en complete.

## Testing

- `npx vitest run packages/core` — **865 / 865 passing**.
- `npx vitest run packages/web-backend/src/api/modules/providers` — 10 / 10 passing.
- `npm run build` — clean (full repo).
- `npm run lint` — same 8 pre-existing errors as `upstream/main`; nothing new.

## Docs

- `docs/reference/settings.md` — new `transport` row + "Transport modes" subsection.
- `docs/web-ui/providers.md` — Transport row updated to describe the dropdown.