### PR TITLE
fix: resolve failing tests

### DIFF
--- a/packages/web-backend/src/app.test.ts
+++ b/packages/web-backend/src/app.test.ts
@@ -23,6 +23,8 @@ let port: number
 let baseUrl: string
 let tempDataDir: string
 let previousDataDir: string | undefined
+let previousAdminUsername: string | undefined
+let previousAdminPassword: string | undefined
 const setTimeoutMinutes = vi.fn()
 const refreshSystemPrompt = vi.fn()
 const setThinkingLevel = vi.fn()
@@ -42,6 +44,15 @@ beforeAll(async () => {
   previousDataDir = process.env.DATA_DIR
   tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axiom-web-backend-'))
   process.env.DATA_DIR = tempDataDir
+
+  // Tests assume the default admin credentials (admin/admin) created by
+  // ensureAdminUser(). Snapshot and clear any inherited ADMIN_USERNAME /
+  // ADMIN_PASSWORD from the host environment so they don't leak into the
+  // bcrypt hash used during admin provisioning.
+  previousAdminUsername = process.env.ADMIN_USERNAME
+  previousAdminPassword = process.env.ADMIN_PASSWORD
+  delete process.env.ADMIN_USERNAME
+  delete process.env.ADMIN_PASSWORD
 
   db = initDatabase(':memory:')
   const mockAgentCore = {
@@ -99,6 +110,16 @@ afterAll(async () => {
     delete process.env.DATA_DIR
   } else {
     process.env.DATA_DIR = previousDataDir
+  }
+  if (previousAdminUsername === undefined) {
+    delete process.env.ADMIN_USERNAME
+  } else {
+    process.env.ADMIN_USERNAME = previousAdminUsername
+  }
+  if (previousAdminPassword === undefined) {
+    delete process.env.ADMIN_PASSWORD
+  } else {
+    process.env.ADMIN_PASSWORD = previousAdminPassword
   }
 })
 


### PR DESCRIPTION
## Summary

On a clean checkout of `upstream/main` (54b401b), `npm test` produces 35 failing tests, all in `packages/web-backend/src/app.test.ts`, when the host shell exports `ADMIN_USERNAME` / `ADMIN_PASSWORD` (which is normal in any real deployment env or sandboxed CI runner). On a pristine shell with no admin env vars set, all 1096 tests pass — so the production code is fine; only the test setup is leaky.

## Root cause

`packages/web-backend/src/auth.ts :: ensureAdminUser()` reads:

```ts
const username = process.env.ADMIN_USERNAME ?? 'admin'
const password = process.env.ADMIN_PASSWORD ?? 'admin'
```

`app.test.ts` calls `createApp({ db, ... })`, which calls `ensureAdminUser(db)`, then logs in with the hard-coded credentials `admin` / `admin`. If the host environment has `ADMIN_PASSWORD` set, the admin user is bcrypt-hashed with that value and the test login returns 401.

The test already isolates `process.env.DATA_DIR` in `beforeAll` / `afterAll`, but does not isolate `ADMIN_USERNAME` / `ADMIN_PASSWORD`.

I confirmed the diagnosis by hashing the seeded user and comparing against `'admin'`:

```
stored compare admin: false   # with ADMIN_PASSWORD=sd19)=SD in env
```

After `unset ADMIN_USERNAME ADMIN_PASSWORD`, the same test run goes from `35 failed | 1061 passed` to `1096 passed (62 files)`.

## Fix

Mirror the existing `DATA_DIR` isolation in `app.test.ts`: snapshot `ADMIN_USERNAME` / `ADMIN_PASSWORD` in `beforeAll`, `delete` them so `ensureAdminUser` falls back to its `'admin'` defaults, and restore them in `afterAll`. No production code, schema, or assertions are changed.

## Failing tests fixed (35)

All in `packages/web-backend/src/app.test.ts`, all variants of `expected 401 to be <2xx>`:

- API health monitoring: `GET /api/health`, `GET /api/health/history`
- auth flow: `POST /api/auth/login succeeds`, `POST /api/auth/refresh returns new tokens`, `POST /api/auth/refresh returns new tokens with user data`, `GET /api/auth/me returns current user`, `protected routes accept valid JWT`
- chat history API: `GET /api/chat/history returns paginated messages`
- logs API: `GET /api/logs` (5 variants), `GET /api/logs/:id` (2 variants), `GET /api/logs/tool-names`
- memory API: SOUL.md, daily memory files, HEARTBEAT.md, user profile, facts list/filter/update/delete (5 tests)
- settings API: read settings, update settings, legacy `healthMonitor.intervalMinutes`, `factExtraction` persistence, `agentHeartbeat` persistence, `telegram.enabled` persistence, live updates to agentCore (7 tests)
- providers API: `restarts health monitor when the active provider changes`
- users API: create/update/list/delete users, "does not allow deleting yourself"
- stats API: `GET /api/stats/usage` group_by, hourly grouping, `GET /api/stats/summary`
- upload API: `stores uploaded files with chat messages`

## Verification

```
$ ADMIN_USERNAME=admin ADMIN_PASSWORD='sd19)=SD' npm test
...
Test Files  62 passed (62)
     Tests  1096 passed (1096)
```

Tests now pass regardless of host env state.