### PR TITLE
fix(providers): remove google-antigravity provider

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -349,7 +349,7 @@ LLM provider catalog. UI-managed via the [Providers page](../web-ui/providers); 
 | `id`                     | `string`                                        | Stable, unique within the file. Used everywhere as `providerId`.                              |
 | `name`                   | `string`                                        | Display name in the UI.                                                                        |
 | `type`                   | `string`                                        | Wire protocol, e.g. `"openai-completions"`, `"anthropic-messages"`.                            |
-| `providerType`           | `string`                                        | Logical class — `"openai"`, `"anthropic"`, `"mistral"`, `"openrouter"`, `"deepseek"`, `"kimi"`, `"minimax"`, `"ollama"`, `"openai-codex"`, `"github-copilot"`, `"google-antigravity"`, `"anthropic-oauth"`, etc. |
+| `providerType`           | `string`                                        | Logical class — `"openai"`, `"anthropic"`, `"mistral"`, `"openrouter"`, `"deepseek"`, `"kimi"`, `"minimax"`, `"ollama"`, `"openai-codex"`, `"github-copilot"`, `"google-gemini-cli"`, `"anthropic-oauth"`, etc. |
 | `provider`               | `string`                                        | pi-ai provider key.                                                                            |
 | `baseUrl`                | `string`                                        | API base URL.                                                                                  |
 | `apiKey`                 | `string` (**encrypted**)                        | Encrypted with `ENCRYPTION_KEY` (`packages/core/src/encryption.ts`). Use the UI to write.      |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -349,7 +349,7 @@ LLM provider catalog. UI-managed via the [Providers page](../web-ui/providers); 
 | `id`                     | `string`                                        | Stable, unique within the file. Used everywhere as `providerId`.                              |
 | `name`                   | `string`                                        | Display name in the UI.                                                                        |
 | `type`                   | `string`                                        | Wire protocol, e.g. `"openai-completions"`, `"anthropic-messages"`.                            |
-| `providerType`           | `string`                                        | Logical class — `"openai"`, `"anthropic"`, `"mistral"`, `"openrouter"`, `"deepseek"`, `"kimi"`, `"minimax"`, `"ollama"`, `"google"`, `"openai-codex"`, `"github-copilot"`, `"google-gemini-cli"`, `"anthropic-oauth"`, etc. |
+| `providerType`           | `string`                                        | Logical class — `"openai"`, `"anthropic"`, `"mistral"`, `"openrouter"`, `"deepseek"`, `"kimi"`, `"minimax"`, `"ollama"`, `"google"`, `"openai-codex"`, `"github-copilot"`, `"anthropic-oauth"`, etc. |
 | `provider`               | `string`                                        | pi-ai provider key.                                                                            |
 | `baseUrl`                | `string`                                        | API base URL.                                                                                  |
 | `apiKey`                 | `string` (**encrypted**)                        | Encrypted with `ENCRYPTION_KEY` (`packages/core/src/encryption.ts`). Use the UI to write.      |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -349,7 +349,7 @@ LLM provider catalog. UI-managed via the [Providers page](../web-ui/providers); 
 | `id`                     | `string`                                        | Stable, unique within the file. Used everywhere as `providerId`.                              |
 | `name`                   | `string`                                        | Display name in the UI.                                                                        |
 | `type`                   | `string`                                        | Wire protocol, e.g. `"openai-completions"`, `"anthropic-messages"`.                            |
-| `providerType`           | `string`                                        | Logical class — `"openai"`, `"anthropic"`, `"mistral"`, `"openrouter"`, `"deepseek"`, `"kimi"`, `"minimax"`, `"ollama"`, `"openai-codex"`, `"github-copilot"`, `"google-gemini-cli"`, `"anthropic-oauth"`, etc. |
+| `providerType`           | `string`                                        | Logical class — `"openai"`, `"anthropic"`, `"mistral"`, `"openrouter"`, `"deepseek"`, `"kimi"`, `"minimax"`, `"ollama"`, `"google"`, `"openai-codex"`, `"github-copilot"`, `"google-gemini-cli"`, `"anthropic-oauth"`, etc. |
 | `provider`               | `string`                                        | pi-ai provider key.                                                                            |
 | `baseUrl`                | `string`                                        | API base URL.                                                                                  |
 | `apiKey`                 | `string` (**encrypted**)                        | Encrypted with `ENCRYPTION_KEY` (`packages/core/src/encryption.ts`). Use the UI to write.      |

--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -105,7 +105,7 @@ The dialog keeps connection details first, then model selection, then advanced h
 | Field                  | Notes                                                                                                |
 |------------------------|------------------------------------------------------------------------------------------------------|
 | **Name**               | Free text, your label for this provider — appears in the table, in `<task_injection>` blocks, on the Dashboard. |
-| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, Google Gemini CLI, …). |
+| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, Google Gemini, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, Google Gemini CLI, …). |
 | **Base URL**           | Shown directly after Type when the preset has an editable URL (Ollama, generic OpenAI-compatible, …). |
 | **API Key**            | Shown after Base URL for API-key providers. Required for most hosted presets, optional for local/custom providers that do not need auth. |
 | **Enabled Models**     | Model selector or model-id entry for this provider. The exact control depends on the provider type. |

--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -105,7 +105,7 @@ The dialog keeps connection details first, then model selection, then advanced h
 | Field                  | Notes                                                                                                |
 |------------------------|------------------------------------------------------------------------------------------------------|
 | **Name**               | Free text, your label for this provider — appears in the table, in `<task_injection>` blocks, on the Dashboard. |
-| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, Google Gemini, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, Google Gemini CLI, …). |
+| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, Google Gemini, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, GitHub Copilot, …). |
 | **Base URL**           | Shown directly after Type when the preset has an editable URL (Ollama, generic OpenAI-compatible, …). |
 | **API Key**            | Shown after Base URL for API-key providers. Required for most hosted presets, optional for local/custom providers that do not need auth. |
 | **Enabled Models**     | Model selector or model-id entry for this provider. The exact control depends on the provider type. |

--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -105,7 +105,7 @@ The dialog keeps connection details first, then model selection, then advanced h
 | Field                  | Notes                                                                                                |
 |------------------------|------------------------------------------------------------------------------------------------------|
 | **Name**               | Free text, your label for this provider — appears in the table, in `<task_injection>` blocks, on the Dashboard. |
-| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, Google Antigravity Free, …). |
+| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, Google Gemini CLI, …). |
 | **Base URL**           | Shown directly after Type when the preset has an editable URL (Ollama, generic OpenAI-compatible, …). |
 | **API Key**            | Shown after Base URL for API-key providers. Required for most hosted presets, optional for local/custom providers that do not need auth. |
 | **Enabled Models**     | Model selector or model-id entry for this provider. The exact control depends on the provider type. |

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -21,7 +21,7 @@ export type ProviderType =
   | 'openai' | 'anthropic' | 'mistral' | 'ollama' | 'openrouter' | 'deepseek' | 'kimi' | 'minimax' | 'zai' | 'opencode-go' | 'openai-compatible' | 'google'
   // Legacy aliases kept for migration
   | 'ollama-local' | 'ollama-cloud'
-  | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'anthropic-oauth'
+  | 'openai-codex' | 'github-copilot' | 'anthropic-oauth'
 
 export type AuthMethod = 'api-key' | 'oauth'
 export type TextVerbosity = 'low' | 'medium' | 'high'
@@ -247,18 +247,6 @@ export const PROVIDER_TYPE_PRESETS: Record<ProviderType, ProviderTypePreset> = {
     piAiProvider: 'github-copilot',
     authMethod: 'oauth',
     oauthProviderId: 'github-copilot',
-  },
-  'google-gemini-cli': {
-    type: 'google-gemini-cli',
-    label: 'Google Gemini CLI',
-    apiType: 'google-gemini-cli',
-    providerName: 'google-gemini-cli',
-    baseUrl: '',
-    requiresApiKey: false,
-    urlEditable: false,
-    piAiProvider: 'google-gemini-cli',
-    authMethod: 'oauth',
-    oauthProviderId: 'google-gemini-cli',
   },
   'anthropic-oauth': {
     type: 'anthropic-oauth',

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -21,7 +21,7 @@ export type ProviderType =
   | 'openai' | 'anthropic' | 'mistral' | 'ollama' | 'openrouter' | 'deepseek' | 'kimi' | 'minimax' | 'zai' | 'opencode-go' | 'openai-compatible'
   // Legacy aliases kept for migration
   | 'ollama-local' | 'ollama-cloud'
-  | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'google-antigravity' | 'anthropic-oauth'
+  | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'anthropic-oauth'
 
 export type AuthMethod = 'api-key' | 'oauth'
 export type TextVerbosity = 'low' | 'medium' | 'high'
@@ -247,18 +247,6 @@ export const PROVIDER_TYPE_PRESETS: Record<ProviderType, ProviderTypePreset> = {
     piAiProvider: 'google-gemini-cli',
     authMethod: 'oauth',
     oauthProviderId: 'google-gemini-cli',
-  },
-  'google-antigravity': {
-    type: 'google-antigravity',
-    label: 'Google Antigravity',
-    apiType: 'google-gemini-cli',
-    providerName: 'google-antigravity',
-    baseUrl: '',
-    requiresApiKey: false,
-    urlEditable: false,
-    piAiProvider: 'google-antigravity',
-    authMethod: 'oauth',
-    oauthProviderId: 'google-antigravity',
   },
   'anthropic-oauth': {
     type: 'anthropic-oauth',

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -18,7 +18,7 @@ const CLAUDE_CODE_VERSION = '2.1.96'
  * Supported provider types with presets
  */
 export type ProviderType =
-  | 'openai' | 'anthropic' | 'mistral' | 'ollama' | 'openrouter' | 'deepseek' | 'kimi' | 'minimax' | 'zai' | 'opencode-go' | 'openai-compatible'
+  | 'openai' | 'anthropic' | 'mistral' | 'ollama' | 'openrouter' | 'deepseek' | 'kimi' | 'minimax' | 'zai' | 'opencode-go' | 'openai-compatible' | 'google'
   // Legacy aliases kept for migration
   | 'ollama-local' | 'ollama-cloud'
   | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'anthropic-oauth'
@@ -208,6 +208,18 @@ export const PROVIDER_TYPE_PRESETS: Record<ProviderType, ProviderTypePreset> = {
     requiresApiKey: false,
     urlEditable: true,
     piAiProvider: null,
+    authMethod: 'api-key',
+  },
+
+  google: {
+    type: 'google',
+    label: 'Google Gemini',
+    apiType: 'google-generative-ai',
+    providerName: 'google',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+    requiresApiKey: true,
+    urlEditable: false,
+    piAiProvider: 'google',
     authMethod: 'api-key',
   },
 


### PR DESCRIPTION
## Problem
pi-ai 0.72.0 removed `google-antigravity` as an OAuth provider, and `google-gemini-cli` — which was the previous replacement — does not exist in pi-ai either. The three built-in OAuth providers in pi-ai 0.72.0 are exactly: `anthropic`, `openai-codex`, `github-copilot`. Any call to `getOAuthApiKey('google-antigravity', ...)` or `getOAuthApiKey('google-gemini-cli', ...)` throws `Unknown OAuth provider`, crashing the health monitor's fallback-swap path.

Additionally there was no API-key-based Google/Gemini preset at all.

## Changes
- Remove `'google-antigravity'` from `ProviderType` and `PROVIDER_TYPE_PRESETS`
- Remove `'google-gemini-cli'` OAuth preset (provider does not exist in pi-ai 0.72.0)
- Add `'google'` API-key preset — targets `google-generative-ai` API (`GEMINI_API_KEY`), model catalog resolved via pi-ai's built-in `google` provider
- Update docs to reflect the correct provider landscape

## Testing
- `npm test` → all 62 test files / 1102 tests pass
- `npm run build --workspace=packages/core` → clean