### PR TITLE
fix(tts): chunk long texts for Deepgram to bypass 2000-char limit

### DIFF
--- a/docs/settings/text-to-speech.md
+++ b/docs/settings/text-to-speech.md
@@ -109,13 +109,35 @@ A text field + play button at the bottom of each provider block. Enter any text,
 
 Output container format used for the synthesized audio in the web chat.
 
-| Value  | Notes                |
-|--------|----------------------|
-| `mp3`  | Universal default.   |
-| `wav`  | Uncompressed, large. |
-| `opus` | Small.               |
-| `flac` | Lossless.            |
+| Value  | Notes                                                                                                                                |
+|--------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `mp3`  | Universal default. Supports long-text chunking with Deepgram (see below).                                                            |
+| `wav`  | Uncompressed, large. Supports long-text chunking with Deepgram (PCM is concatenated and wrapped in a single WAV header).             |
+| `opus` | Small. Deepgram only — limited to 2000 characters per request (see below).                                                           |
+| `flac` | Lossless. Deepgram only — limited to 2000 characters per request (see below).                                                        |
 
 ```json
 { "tts": { "responseFormat": "mp3" } }
 ```
+
+### Deepgram long-text behavior
+
+Deepgram's `/v1/speak` endpoint rejects any single request longer than
+**2000 characters**. To make the “Read message aloud” button work for long
+assistant replies, Axiom transparently splits the input on sentence
+boundaries and synthesizes each chunk separately, then concatenates the
+result.
+
+Which formats this works for depends on whether the audio container can be
+safely concatenated byte-for-byte:
+
+- **`mp3`** — frame-aligned; chunked output is concatenated directly.
+- **`wav`** — Deepgram returns headerless PCM (`linear16`); chunks are
+  concatenated as raw samples and wrapped in a single WAV header.
+- **`opus`** and **`flac`** — use page/frame containers that **do not**
+  survive naive concatenation. Inputs **≤ 2000 characters** still work
+  normally; longer inputs are rejected with an actionable error asking you
+  to switch to `mp3` or `wav` in **Settings → Text-to-Speech**.
+
+The OpenAI and Mistral providers don't have this 2000-character limit and
+are unaffected.

--- a/packages/core/src/tts.test.ts
+++ b/packages/core/src/tts.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the config layer so loadTtsSettings / loadTtsDeepgramApiKey work
+// without touching the real on-disk settings.json. We override the return
+// values per test via `loadConfigMock.mockReturnValueOnce(...)` below.
+vi.mock('./config.js', () => ({
+  ensureConfigTemplates: vi.fn(),
+  loadConfig: vi.fn(),
+}))
+
+// Mock Deepgram so we can assert chunk count and avoid real HTTP.
+vi.mock('./deepgram.js', async () => {
+  const actual = await vi.importActual<typeof import('./deepgram.js')>('./deepgram.js')
+  return {
+    ...actual,
+    decryptDeepgramApiKey: vi.fn((s: string) => s),
+    synthesizeDeepgram: vi.fn(async (text: string) => Buffer.from(`audio:${text.length}`)),
+  }
+})
+
+// Provider config isn't exercised by the Deepgram path (it uses its own
+// `tts.deepgramApiKey`), but `synthesizeTts` imports the module eagerly so
+// we stub the loader to a no-op file.
+vi.mock('./provider-config.js', async () => {
+  const actual = await vi.importActual<typeof import('./provider-config.js')>('./provider-config.js')
+  return {
+    ...actual,
+    loadProvidersDecrypted: vi.fn(() => ({ providers: [] })),
+    getApiKeyForProvider: vi.fn(async () => 'test-key'),
+  }
+})
+
+import { loadConfig } from './config.js'
+import { synthesizeDeepgram } from './deepgram.js'
+import { synthesizeTts } from './tts.js'
+import type { TtsResponseFormat } from './contracts/settings.js'
+
+const loadConfigMock = vi.mocked(loadConfig)
+const synthesizeDeepgramMock = vi.mocked(synthesizeDeepgram)
+
+function settingsFor(responseFormat: TtsResponseFormat) {
+  return {
+    tts: {
+      enabled: true,
+      provider: 'deepgram',
+      providerId: '',
+      responseFormat,
+      deepgramModel: 'aura-2-thalia-en',
+      deepgramApiKey: 'dg_test',
+    },
+  }
+}
+
+function mockSettings(responseFormat: TtsResponseFormat) {
+  // `synthesizeTts` calls loadConfig twice: once via loadTtsSettings and
+  // once via loadTtsDeepgramApiKey. Return the same payload both times.
+  loadConfigMock.mockImplementation(() => settingsFor(responseFormat) as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  synthesizeDeepgramMock.mockImplementation(async (text: string) => Buffer.from(`audio:${text.length}`))
+})
+
+describe('synthesizeTts (Deepgram chunking)', () => {
+  it('does not reject 2000-char opus input even though the chunker would split it', async () => {
+    mockSettings('opus')
+    const text = 'a'.repeat(2000)
+    await expect(synthesizeTts(text)).resolves.toMatchObject({ extension: 'ogg' })
+    // 2000 chars > 1900 chunk limit, so the chunker produced multiple
+    // pieces — but Deepgram's hard cap is 2000, so the rejection must
+    // not fire.
+    expect(synthesizeDeepgramMock).toHaveBeenCalled()
+  })
+
+  it('does not reject 1901-char flac input (boundary just past chunk limit)', async () => {
+    mockSettings('flac')
+    const text = 'a'.repeat(1901)
+    await expect(synthesizeTts(text)).resolves.toMatchObject({ extension: 'flac' })
+    expect(synthesizeDeepgramMock).toHaveBeenCalled()
+  })
+
+  it('rejects opus input strictly longer than 2000 chars', async () => {
+    mockSettings('opus')
+    const text = 'a'.repeat(2001)
+    await expect(synthesizeTts(text)).rejects.toThrow(/2001 chars \(>2000\)/)
+    expect(synthesizeDeepgramMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects flac input strictly longer than 2000 chars with an actionable message', async () => {
+    mockSettings('flac')
+    const text = 'a'.repeat(5000)
+    await expect(synthesizeTts(text)).rejects.toThrow(/`mp3` and `wav`/)
+    expect(synthesizeDeepgramMock).not.toHaveBeenCalled()
+  })
+
+  it('chunks long mp3 input across multiple Deepgram calls and concatenates the audio', async () => {
+    mockSettings('mp3')
+    // Build a multi-sentence text well above 2000 chars so the chunker
+    // splits on sentence boundaries rather than the hard slice path.
+    const sentence = `${'word '.repeat(80).trim()}. `
+    const text = sentence.repeat(8) // ~3300 chars
+    const result = await synthesizeTts(text)
+    expect(synthesizeDeepgramMock.mock.calls.length).toBeGreaterThan(1)
+    expect(result.extension).toBe('mp3')
+    // Each call returns Buffer.from(`audio:${chunk.length}`); the result
+    // is the concatenation of all chunks' audio.
+    const expectedLen = synthesizeDeepgramMock.mock.calls
+      .map(([chunk]) => Buffer.byteLength(`audio:${(chunk as string).length}`))
+      .reduce((a, b) => a + b, 0)
+    expect(result.audio.length).toBe(expectedLen)
+  })
+
+  it('chunks long wav input and wraps the concatenated PCM in a WAV header', async () => {
+    mockSettings('wav')
+    const sentence = `${'word '.repeat(80).trim()}. `
+    const text = sentence.repeat(8)
+    const result = await synthesizeTts(text)
+    expect(synthesizeDeepgramMock.mock.calls.length).toBeGreaterThan(1)
+    expect(result.contentType).toBe('audio/wav')
+    expect(result.extension).toBe('wav')
+    // RIFF/WAVE magic — proves we wrapped the concatenated PCM rather
+    // than handing back raw bytes.
+    expect(result.audio.slice(0, 4).toString()).toBe('RIFF')
+    expect(result.audio.slice(8, 12).toString()).toBe('WAVE')
+  })
+
+  it('passes short opus input through unchanged (single Deepgram call, no rejection)', async () => {
+    mockSettings('opus')
+    const text = 'short hello'
+    await expect(synthesizeTts(text)).resolves.toMatchObject({ contentType: 'audio/opus' })
+    expect(synthesizeDeepgramMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/tts.test.ts
+++ b/packages/core/src/tts.test.ts
@@ -63,21 +63,40 @@ beforeEach(() => {
 })
 
 describe('synthesizeTts (Deepgram chunking)', () => {
-  it('does not reject 2000-char opus input even though the chunker would split it', async () => {
+  it('sends 2000-char opus input in a single Deepgram call (no concat-unsafe chunking)', async () => {
     mockSettings('opus')
     const text = 'a'.repeat(2000)
     await expect(synthesizeTts(text)).resolves.toMatchObject({ extension: 'ogg' })
-    // 2000 chars > 1900 chunk limit, so the chunker produced multiple
-    // pieces — but Deepgram's hard cap is 2000, so the rejection must
-    // not fire.
-    expect(synthesizeDeepgramMock).toHaveBeenCalled()
+    // opus pages don't survive naive Buffer.concat(), so even though the
+    // internal chunker (1900-char limit) would split this, we must call
+    // Deepgram exactly once for inputs ≤2000 chars.
+    expect(synthesizeDeepgramMock).toHaveBeenCalledTimes(1)
   })
 
-  it('does not reject 1901-char flac input (boundary just past chunk limit)', async () => {
+  it('sends 1901-char flac input in a single Deepgram call (boundary just past chunk limit)', async () => {
     mockSettings('flac')
     const text = 'a'.repeat(1901)
     await expect(synthesizeTts(text)).resolves.toMatchObject({ extension: 'flac' })
-    expect(synthesizeDeepgramMock).toHaveBeenCalled()
+    expect(synthesizeDeepgramMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('never chunks opus/flac at or below the Deepgram hard limit (regression)', async () => {
+    // Same multi-sentence text that *does* split for mp3/wav. Proves
+    // opus/flac follow the single-call path purely on encoding, not
+    // length.
+    const sentence = `${'word '.repeat(76).trim()}. `
+    const text = sentence.repeat(5) // > 1900 chunk limit but ≤ 2000
+    expect(text.length).toBeGreaterThan(1900)
+    expect(text.length).toBeLessThanOrEqual(2000)
+
+    mockSettings('opus')
+    await synthesizeTts(text)
+    expect(synthesizeDeepgramMock).toHaveBeenCalledTimes(1)
+
+    synthesizeDeepgramMock.mockClear()
+    mockSettings('flac')
+    await synthesizeTts(text)
+    expect(synthesizeDeepgramMock).toHaveBeenCalledTimes(1)
   })
 
   it('rejects opus input strictly longer than 2000 chars', async () => {

--- a/packages/core/src/tts.ts
+++ b/packages/core/src/tts.ts
@@ -41,6 +41,62 @@ const DEEPGRAM_LINEAR16_CHANNELS = 1
 const DEEPGRAM_LINEAR16_BITS_PER_SAMPLE = 16
 
 /**
+ * Deepgram's `/v1/speak` rejects payloads >2000 chars. We split longer
+ * texts into chunks and synthesize each separately so the user-facing
+ * “Read message aloud” button works for long assistant replies. Kept a
+ * touch under the hard limit to leave headroom for whitespace tweaks.
+ */
+const DEEPGRAM_TTS_CHUNK_LIMIT = 1900
+
+/**
+ * Split `text` into chunks of at most `maxLen` characters, preferring
+ * paragraph → sentence → word boundaries before falling back to a hard
+ * slice. The goal is to keep prosody intact across chunks: cutting at
+ * `. ` / `! ` / `? ` / `\n\n` produces audibly smoother joins than
+ * mid-sentence splits.
+ */
+export function chunkTextForDeepgram(text: string, maxLen = DEEPGRAM_TTS_CHUNK_LIMIT): string[] {
+  const trimmed = text.trim()
+  if (trimmed.length <= maxLen) return [trimmed]
+
+  // First pass: split on sentence-ish boundaries while keeping the
+  // delimiter attached to the preceding piece (so the synthesized audio
+  // still ends on the punctuation).
+  const pieces = trimmed.split(/(?<=[.!?\n])\s+/)
+
+  const chunks: string[] = []
+  let current = ''
+  const flush = () => {
+    if (current.trim()) chunks.push(current.trim())
+    current = ''
+  }
+
+  for (const piece of pieces) {
+    if (piece.length > maxLen) {
+      // A single “sentence” that's still too long — fall back to a
+      // word-boundary slice so we don't chop a word in half.
+      flush()
+      let remaining = piece
+      while (remaining.length > maxLen) {
+        const slice = remaining.slice(0, maxLen)
+        const lastSpace = slice.lastIndexOf(' ')
+        const cut = lastSpace > maxLen * 0.5 ? lastSpace : maxLen
+        chunks.push(slice.slice(0, cut).trim())
+        remaining = remaining.slice(cut).trim()
+      }
+      if (remaining) current = remaining
+      continue
+    }
+    if (current.length + piece.length + 1 > maxLen) {
+      flush()
+    }
+    current = current ? `${current} ${piece}` : piece
+  }
+  flush()
+  return chunks
+}
+
+/**
  * Wrap raw little-endian PCM samples in a 44-byte canonical WAV/RIFF header
  * so generic players (Telegram's audio player, browsers, ffmpeg, ...) can
  * decode it. Used to bridge Deepgram's headerless `linear16` output to the
@@ -323,10 +379,29 @@ async function synthesizeDeepgramWrapped(
   // `linear16` (raw PCM) which we wrap in a WAV header below so the user
   // gets a playable file.
   const deepgramEncoding = DEEPGRAM_FORMAT_MAP[settings.responseFormat]
-  const raw = await synthesizeDeepgram(text, apiKey, {
-    model: options.voice || settings.deepgramModel,
-    encoding: deepgramEncoding,
-  })
+  const model = options.voice || settings.deepgramModel
+
+  // Deepgram caps `/v1/speak` at 2000 chars per call. Split longer texts
+  // and concatenate the audio. Safe for `mp3` (frame-aligned) and
+  // `linear16` (raw PCM — just bytes); `opus`/`flac` use page/frame
+  // containers that don't survive naive concatenation, so we refuse those
+  // explicitly with an actionable error rather than producing a corrupt
+  // file.
+  const chunks = chunkTextForDeepgram(text)
+  if (chunks.length > 1 && (deepgramEncoding === 'opus' || deepgramEncoding === 'flac')) {
+    throw new Error(
+      `Deepgram TTS: text is ${text.length} chars (>2000). Long-text chunking is only supported for `
+      + `\`mp3\` and \`wav\` — switch “Response format” in Settings → Text-to-Speech.`,
+    )
+  }
+
+  const parts: Buffer[] = []
+  for (const chunk of chunks) {
+    parts.push(
+      await synthesizeDeepgram(chunk, apiKey, { model, encoding: deepgramEncoding }),
+    )
+  }
+  const raw = parts.length === 1 ? parts[0]! : Buffer.concat(parts)
 
   if (settings.responseFormat === 'wav') {
     const wav = wrapPcmInWav(

--- a/packages/core/src/tts.ts
+++ b/packages/core/src/tts.ts
@@ -396,7 +396,15 @@ async function synthesizeDeepgramWrapped(
       + `\`mp3\` and \`wav\` — switch “Response format” in Settings → Text-to-Speech.`,
     )
   }
-  const chunks = chunkTextForDeepgram(text)
+
+  // `opus` and `flac` use container/page/frame structures that don't
+  // survive naive `Buffer.concat()`. For those encodings, only chunk
+  // when the response format is concatenation-safe — otherwise send the
+  // whole (≤2000-char) text in a single Deepgram call.
+  const supportsChunkConcatenation = deepgramEncoding === 'mp3' || deepgramEncoding === 'linear16'
+  const chunks = supportsChunkConcatenation
+    ? chunkTextForDeepgram(text)
+    : [text.trim()]
 
   const parts: Buffer[] = []
   for (const chunk of chunks) {

--- a/packages/core/src/tts.ts
+++ b/packages/core/src/tts.ts
@@ -48,6 +48,9 @@ const DEEPGRAM_LINEAR16_BITS_PER_SAMPLE = 16
  */
 const DEEPGRAM_TTS_CHUNK_LIMIT = 1900
 
+/** Deepgram's documented hard cap on `/v1/speak` input length. */
+const DEEPGRAM_TTS_HARD_LIMIT = 2000
+
 /**
  * Split `text` into chunks of at most `maxLen` characters, preferring
  * paragraph → sentence → word boundaries before falling back to a hard
@@ -55,13 +58,13 @@ const DEEPGRAM_TTS_CHUNK_LIMIT = 1900
  * `. ` / `! ` / `? ` / `\n\n` produces audibly smoother joins than
  * mid-sentence splits.
  */
-export function chunkTextForDeepgram(text: string, maxLen = DEEPGRAM_TTS_CHUNK_LIMIT): string[] {
+function chunkTextForDeepgram(text: string, maxLen = DEEPGRAM_TTS_CHUNK_LIMIT): string[] {
   const trimmed = text.trim()
   if (trimmed.length <= maxLen) return [trimmed]
 
-  // First pass: split on sentence-ish boundaries while keeping the
-  // delimiter attached to the preceding piece (so the synthesized audio
-  // still ends on the punctuation).
+  // Split on sentence-ish boundaries while keeping the delimiter attached
+  // to the preceding piece, so the synthesized audio still ends on the
+  // punctuation.
   const pieces = trimmed.split(/(?<=[.!?\n])\s+/)
 
   const chunks: string[] = []
@@ -73,7 +76,7 @@ export function chunkTextForDeepgram(text: string, maxLen = DEEPGRAM_TTS_CHUNK_L
 
   for (const piece of pieces) {
     if (piece.length > maxLen) {
-      // A single “sentence” that's still too long — fall back to a
+      // A single “sentence” still longer than `maxLen` — fall back to a
       // word-boundary slice so we don't chop a word in half.
       flush()
       let remaining = piece
@@ -375,25 +378,25 @@ async function synthesizeDeepgramWrapped(
     throw new Error('Deepgram TTS: API key is not configured. Set it in Settings \u2192 Text-to-Speech.')
   }
 
-  // Map the unified `responseFormat` to Deepgram's `encoding`. `wav` becomes
-  // `linear16` (raw PCM) which we wrap in a WAV header below so the user
-  // gets a playable file.
   const deepgramEncoding = DEEPGRAM_FORMAT_MAP[settings.responseFormat]
   const model = options.voice || settings.deepgramModel
 
-  // Deepgram caps `/v1/speak` at 2000 chars per call. Split longer texts
-  // and concatenate the audio. Safe for `mp3` (frame-aligned) and
-  // `linear16` (raw PCM — just bytes); `opus`/`flac` use page/frame
-  // containers that don't survive naive concatenation, so we refuse those
-  // explicitly with an actionable error rather than producing a corrupt
-  // file.
-  const chunks = chunkTextForDeepgram(text)
-  if (chunks.length > 1 && (deepgramEncoding === 'opus' || deepgramEncoding === 'flac')) {
+  // Deepgram caps `/v1/speak` at 2000 chars per call. For longer texts we
+  // split the input and concatenate the audio. Safe for `mp3` (frame-
+  // aligned) and `linear16` (raw PCM — just bytes); `opus`/`flac` use
+  // page/frame containers that don't survive naive concatenation, so we
+  // refuse only when the input actually exceeds the per-call limit and
+  // would therefore require multiple Deepgram calls. Inputs at or below
+  // 2000 chars stay valid for every format even if our internal chunker
+  // (which works under the limit for prosody headroom) would split them.
+  const inputLength = text.length
+  if (inputLength > DEEPGRAM_TTS_HARD_LIMIT && (deepgramEncoding === 'opus' || deepgramEncoding === 'flac')) {
     throw new Error(
-      `Deepgram TTS: text is ${text.length} chars (>2000). Long-text chunking is only supported for `
+      `Deepgram TTS: text is ${inputLength} chars (>${DEEPGRAM_TTS_HARD_LIMIT}). Long-text chunking is only supported for `
       + `\`mp3\` and \`wav\` — switch “Response format” in Settings → Text-to-Speech.`,
     )
   }
+  const chunks = chunkTextForDeepgram(text)
 
   const parts: Buffer[] = []
   for (const chunk of chunks) {

--- a/packages/web-frontend/app/composables/useTts.ts
+++ b/packages/web-frontend/app/composables/useTts.ts
@@ -84,13 +84,12 @@ export function useTts() {
    * If the same index is already playing, stop it (toggle behavior).
    */
   async function play(text: string, messageIndex: number) {
-    // Toggle off if already playing this message
+    // Toggle behavior: clicking the speaker on an already-playing message stops it.
     if (playingIndex.value === messageIndex) {
       stop()
       return
     }
 
-    // Stop any existing playback
     stop()
     error.value = null
 

--- a/packages/web-frontend/app/composables/useTts.ts
+++ b/packages/web-frontend/app/composables/useTts.ts
@@ -27,6 +27,14 @@ export function useTts() {
   const mistralVoices = useState<MistralVoice[]>('tts_mistral_voices', () => [])
   /** Whether voices are loading */
   const voicesLoading = useState<boolean>('tts_voices_loading', () => false)
+  /**
+   * Last playback error (server message or network failure). Cleared on
+   * each new `play()` call. Surfaced inline in the chat so a failed
+   * “Read aloud” click doesn't look like a dead button — the most common
+   * Deepgram failure mode (text >2000 chars) used to disappear into the
+   * console.
+   */
+  const error = useState<string | null>('tts_error', () => null)
 
   /** Fetch TTS settings from the server */
   async function fetchTtsSettings(): Promise<void> {
@@ -66,6 +74,11 @@ export function useTts() {
     loading.value = false
   }
 
+  /** Clear the last error banner (e.g. when the user dismisses it). */
+  function clearError() {
+    error.value = null
+  }
+
   /**
    * Play TTS for the given text.
    * If the same index is already playing, stop it (toggle behavior).
@@ -79,6 +92,7 @@ export function useTts() {
 
     // Stop any existing playback
     stop()
+    error.value = null
 
     if (!text.trim()) return
 
@@ -117,7 +131,9 @@ export function useTts() {
       await audioElement.play()
       loading.value = false
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
       console.error('TTS playback failed:', err)
+      error.value = message
       stop()
     }
   }
@@ -129,9 +145,11 @@ export function useTts() {
     ttsSettings,
     mistralVoices,
     voicesLoading,
+    error,
     fetchTtsSettings,
     fetchMistralVoices,
     play,
     stop,
+    clearError,
   }
 }

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -82,6 +82,8 @@
     "ttsPlay": "Vorlesen",
     "ttsStop": "Vorlesen stoppen",
     "ttsLoading": "Sprache wird generiert...",
+    "ttsErrorTitle": "Vorlesen fehlgeschlagen",
+    "ttsErrorDismiss": "Schließen",
     "micTooltip": "Gedrückt halten zum Aufnehmen",
     "thinkingLevelTooltip": "Denk-Level für den nächsten Zug (gilt global für den Haupt-Agent)",
     "thinkingLevelSaved": "Denk-Level aktualisiert",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -81,6 +81,8 @@
     },
     "ttsPlay": "Read aloud",
     "ttsStop": "Stop reading",
+    "ttsErrorTitle": "Read aloud failed",
+    "ttsErrorDismiss": "Dismiss",
     "ttsLoading": "Generating speech...",
     "micTooltip": "Hold to record",
     "thinkingLevelTooltip": "Thinking level for the next turn (applies to the main agent globally)",

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -335,6 +335,20 @@
       </button>
     </Transition>
 
+    <Transition enter-active-class="transition duration-200 ease-out" enter-from-class="translate-y-2 opacity-0" enter-to-class="translate-y-0 opacity-100" leave-active-class="transition duration-150 ease-in" leave-from-class="translate-y-0 opacity-100" leave-to-class="translate-y-2 opacity-0">
+      <div v-if="ttsError" class="absolute bottom-24 left-1/2 z-10 w-[min(92%,32rem)] -translate-x-1/2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive shadow-md">
+        <div class="flex items-start gap-2">
+          <div class="flex-1">
+            <div class="font-medium">{{ $t('chat.ttsErrorTitle') }}</div>
+            <div class="mt-0.5 break-words text-destructive/90">{{ ttsError }}</div>
+          </div>
+          <button type="button" class="shrink-0 rounded p-0.5 text-destructive/70 hover:text-destructive" :title="$t('chat.ttsErrorDismiss')" @click="clearTtsError">
+            <AppIcon name="x" size="sm" />
+          </button>
+        </div>
+      </div>
+    </Transition>
+
     <div class="shrink-0 border-t border-border bg-background p-3">
       <form class="flex flex-col gap-2" @submit.prevent="handleSend">
         <!-- Pending files row -->
@@ -622,7 +636,7 @@ function formatTokenCount(count: number): string {
   return String(count)
 }
 const { messages, connectionStatus, isStreaming, connect, disconnect, sendMessage, newSession, stopTask } = useChat()
-const { playingIndex: ttsPlayingIndex, loading: ttsLoading, ttsEnabled, fetchTtsSettings, play: ttsPlay, stop: ttsStop } = useTts()
+const { playingIndex: ttsPlayingIndex, loading: ttsLoading, ttsEnabled, error: ttsError, fetchTtsSettings, play: ttsPlay, stop: ttsStop, clearError: clearTtsError } = useTts()
 const { recording: sttRecording, transcribing: sttTranscribing, error: sttError, sttEnabled, fetchSttSettings, startRecording: sttStartRecording, stopAndTranscribe: sttStopAndTranscribe, cleanup: sttCleanup } = useStt()
 
 function handleTtsPlay(content: string, index: number) {


### PR DESCRIPTION
Deepgram's /v1/speak endpoint hard-rejects payloads larger than 2000 characters, causing the 'Read aloud' button to silently fail on any longer assistant message.

Add chunkTextForDeepgram() which splits at sentence/word boundaries (lookbehind on [.!?\n]) and falls back to word- then hard-splits for pathological inputs. synthesizeDeepgramWrapped() now iterates chunks, synthesizes each, and concatenates the resulting Buffers:

- mp3  → Buffer.concat() (MP3 frames are self-contained, concat is safe)
- wav  → chunks requested as linear16 (raw PCM), concatenated, then a single WAV header is prepended at the end
- opus / flac → explicit error with actionable message (container headers per-chunk make naive concat produce corrupt files)

The low-level synthesizeDeepgram() retains its strict 2000-char guard so existing tests are unaffected.