### PR TITLE
feat: shared slash-command registry with Telegram menu

### DIFF
--- a/docs/guide/telegram.md
+++ b/docs/guide/telegram.md
@@ -75,6 +75,7 @@ to the input field) is populated automatically on bot startup via
 | `/tasks`    | Show running and recent background tasks (read-only).                       |
 | `/cronjobs` | Show configured cronjobs and their next run time. (alias `/cron`)           |
 | `/settings` | Show the active provider and model. (alias `/model`)                        |
+| `/thinking` | Show or set the global main-agent thinking level.                           |
 
 Everything else is treated as a normal message and forwarded to the agent.
 If the menu does not appear in your Telegram client, restart the chat or wait

--- a/docs/guide/telegram.md
+++ b/docs/guide/telegram.md
@@ -74,8 +74,15 @@ to the input field) is populated automatically on bot startup via
 | `/stop`     | Abort the current agent turn and clear queued messages. (alias `/kill`)     |
 | `/tasks`    | Show running and recent background tasks (read-only).                       |
 | `/cronjobs` | Show configured cronjobs and their next run time. (alias `/cron`)           |
-| `/settings` | Show the active provider and model. (alias `/model`)                        |
+| `/model`    | Show or switch the active provider and model. (alias `/provider`)           |
 | `/thinking` | Show or set the global main-agent thinking level.                           |
+
+On Telegram, `/model` (and its alias `/provider`) renders as an inline
+keyboard: provider picker → model picker → confirmation. The same message is
+edited in place between steps. Selecting a model writes `providers.json` and
+switches the active model for the next turn. The picker auto-expires after
+10 minutes if untouched, so scrolling back to an old picker and tapping a
+button will return an "expired" notice instead of switching models.
 
 Everything else is treated as a normal message and forwarded to the agent.
 If the menu does not appear in your Telegram client, restart the chat or wait

--- a/docs/guide/telegram.md
+++ b/docs/guide/telegram.md
@@ -60,15 +60,27 @@ From now on, anything you send to the bot is processed by the agent. Anyone else
 
 ## Bot commands
 
-The bot understands a handful of slash commands inside Telegram:
+The bot understands a handful of slash commands inside Telegram. They are
+shared with the web chat — same names, same descriptions — so muscle memory
+carries between surfaces. Telegram's native command menu (the `/` button next
+to the input field) is populated automatically on bot startup via
+`setMyCommands`, so you get autocomplete for every entry below.
 
-| Command  | What it does                                                               |
-|----------|----------------------------------------------------------------------------|
-| `/start` | Welcome message. Registers you as `pending` on first use.                  |
-| `/new`   | Summarize the current session, persist it, and start a fresh conversation. |
-| `/stop`  | Abort the current agent turn and clear queued messages. (alias `/kill`)    |
+| Command     | What it does                                                                |
+|-------------|-----------------------------------------------------------------------------|
+| `/start`    | Welcome message. Registers you as `pending` on first use.                   |
+| `/help`     | List all available slash commands.                                          |
+| `/new`      | Summarize the current session, persist it, and start a fresh conversation.  |
+| `/stop`     | Abort the current agent turn and clear queued messages. (alias `/kill`)     |
+| `/tasks`    | Show running and recent background tasks (read-only).                       |
+| `/cronjobs` | Show configured cronjobs and their next run time. (alias `/cron`)           |
+| `/settings` | Show the active provider and model. (alias `/model`)                        |
 
 Everything else is treated as a normal message and forwarded to the agent.
+If the menu does not appear in your Telegram client, restart the chat or wait
+a minute — Telegram caches the command list per device. Failures during
+`setMyCommands` are non-fatal: typing a slash command still works, the menu
+just stays empty until the next successful start.
 
 ## Voice messages
 

--- a/docs/guide/telegram.md
+++ b/docs/guide/telegram.md
@@ -76,6 +76,7 @@ to the input field) is populated automatically on bot startup via
 | `/cronjobs` | Show configured cronjobs and their next run time. (alias `/cron`)           |
 | `/model`    | Show or switch the active provider and model. (alias `/provider`)           |
 | `/thinking` | Show or set the global main-agent thinking level.                           |
+| `/tts`      | Toggle automatic Telegram voice replies. (alias `/voice`)                   |
 
 On Telegram, `/model` (and its alias `/provider`) renders as an inline
 keyboard: provider picker → model picker → confirmation. The same message is
@@ -95,7 +96,7 @@ just stays empty until the next successful start.
 Axiom can transcribe incoming Telegram voice messages and optionally reply with synthesized speech. Configuration lives in two places:
 
 - **Speech-to-Text** — pick a provider and model under [Settings → Speech-to-Text](../settings/speech-to-text). Voice messages sent to the bot are transcribed and forwarded to the agent as text.
-- **Text-to-Speech (optional)** — pick a provider and voice under [Settings → Text-to-Speech](../settings/text-to-speech), then enable [Send voice reply](../settings/telegram#send-voice-reply) on the Telegram settings page. Each agent reply is then also synthesized and uploaded as a voice/audio message.
+- **Text-to-Speech (optional)** — pick a provider and voice under [Settings → Text-to-Speech](../settings/text-to-speech), then enable [Send voice reply](../settings/telegram#send-voice-reply) on the Telegram settings page or run `/tts` (alias `/voice`) directly in the Telegram chat. Each agent reply is then also synthesized and uploaded as a voice/audio message. `/tts on`, `/tts off`, and `/tts status` are also accepted; the toggle persists to `telegram.json` and is independent of the global TTS settings.
 
 If TTS synthesis fails for a given reply, the text reply is still delivered — voice is best-effort.
 

--- a/docs/web-ui/chat.md
+++ b/docs/web-ui/chat.md
@@ -101,6 +101,27 @@ Pending files appear as chips above the composer. Click `×` on a chip to remove
 
 Where attachments end up on the backend, how long they're kept, and the upload limit live in [Settings → Agent → Upload retention](../settings/agent#upload-retention).
 
+## Slash commands
+
+Messages that start with `/` are intercepted by the chat client and answered
+locally instead of being forwarded to the LLM. The same vocabulary is shared
+with the [Telegram bot](../guide/telegram#bot-commands), so muscle memory
+carries between surfaces.
+
+| Command     | What it does                                                                |
+|-------------|-----------------------------------------------------------------------------|
+| `/help`     | List all available slash commands.                                          |
+| `/new`      | Summarize the current session, persist it, and start a fresh conversation.  |
+| `/stop`     | Abort the current agent turn and clear queued work. (alias `/kill`)         |
+| `/tasks`    | Show running and recent background tasks (read-only).                       |
+| `/cronjobs` | Show configured cronjobs and their next run time. (alias `/cron`)           |
+| `/settings` | Show the active provider and model. (alias `/model`)                        |
+
+Unknown commands respond with a hint pointing at `/help` and are not sent to
+the agent. To send a literal message that starts with a slash to the agent
+anyway, prefix it with a second slash — inputs starting with `//` bypass the
+slash-command interception and are delivered to the agent verbatim.
+
 ## Reconnecting
 
 If the WebSocket drops (network blip, server restart), the connection dot turns amber and the client reconnects automatically with backoff. Messages you sent before the drop arrive when the socket is back. The Send button stays disabled while disconnected.

--- a/docs/web-ui/chat.md
+++ b/docs/web-ui/chat.md
@@ -115,8 +115,13 @@ carries between surfaces.
 | `/stop`     | Abort the current agent turn and clear queued work. (alias `/kill`)         |
 | `/tasks`    | Show running and recent background tasks (read-only).                       |
 | `/cronjobs` | Show configured cronjobs and their next run time. (alias `/cron`)           |
-| `/settings` | Show the active provider and model. (alias `/model`)                        |
+| `/model`    | Show or switch the active provider and model. (alias `/provider`)           |
 | `/thinking` | Show or set the global main-agent thinking level.                           |
+
+On the web chat, `/model` (and its alias `/provider`) responds as an
+interactive button group: provider picker → model picker → confirmation.
+Selecting a model writes `providers.json` and switches the active model for
+the next turn.
 
 `/thinking` accepts `off`, `minimal`, `low`, `medium`, `high`, or `xhigh`.
 Like the brain-icon selector, it changes the global main-agent setting and

--- a/docs/web-ui/chat.md
+++ b/docs/web-ui/chat.md
@@ -116,6 +116,11 @@ carries between surfaces.
 | `/tasks`    | Show running and recent background tasks (read-only).                       |
 | `/cronjobs` | Show configured cronjobs and their next run time. (alias `/cron`)           |
 | `/settings` | Show the active provider and model. (alias `/model`)                        |
+| `/thinking` | Show or set the global main-agent thinking level.                           |
+
+`/thinking` accepts `off`, `minimal`, `low`, `medium`, `high`, or `xhigh`.
+Like the brain-icon selector, it changes the global main-agent setting and
+applies to the next turn.
 
 Unknown commands respond with a hint pointing at `/help` and are not sent to
 the agent. To send a literal message that starts with a slash to the agent

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -95,6 +95,7 @@ const TEMPLATES: Record<string, object> = {
     pollingMode: true,
     webhookUrl: '',
     batchingDelayMs: 2500,
+    sendVoiceReply: false,
   },
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -336,3 +336,20 @@ export type {
   DeepgramTtsEncoding,
   DeepgramTtsPresetModel,
 } from './deepgram.js'
+export {
+  parseSlashCommand,
+  SlashCommandRegistry,
+  registerBuiltInSlashCommands,
+  renderHelp,
+  formatTasksReply,
+  formatCronjobsReply,
+  formatSettingsReply,
+} from './slash-commands.js'
+export type {
+  SlashCommandSurface,
+  SlashCommandMetadata,
+  SlashCommandDefinition,
+  SlashCommandContext,
+  ParsedSlashCommand,
+  SlashCommandDispatchResult,
+} from './slash-commands.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -343,7 +343,7 @@ export {
   renderHelp,
   formatTasksReply,
   formatCronjobsReply,
-  formatSettingsReply,
+  isSlashCommandPicker,
 } from './slash-commands.js'
 export type {
   SlashCommandSurface,
@@ -352,4 +352,7 @@ export type {
   SlashCommandContext,
   ParsedSlashCommand,
   SlashCommandDispatchResult,
+  SlashCommandPicker,
+  SlashCommandPickerOption,
+  SlashCommandReply,
 } from './slash-commands.js'

--- a/packages/core/src/slash-commands.test.ts
+++ b/packages/core/src/slash-commands.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  parseSlashCommand,
+  SlashCommandRegistry,
+  registerBuiltInSlashCommands,
+  formatTasksReply,
+  formatCronjobsReply,
+  renderHelp,
+} from './slash-commands.js'
+
+describe('parseSlashCommand', () => {
+  it('parses a bare command', () => {
+    expect(parseSlashCommand('/help')).toEqual({ raw: '/help', name: 'help', args: '' })
+  })
+
+  it('lowercases the command name but preserves args', () => {
+    expect(parseSlashCommand('/HELP world')).toEqual({ raw: '/HELP world', name: 'help', args: 'world' })
+  })
+
+  it('strips a Telegram @botname suffix', () => {
+    expect(parseSlashCommand('/help@my_bot extra')).toEqual({
+      raw: '/help@my_bot extra',
+      name: 'help',
+      args: 'extra',
+    })
+  })
+
+  it('treats double-slash as literal text, not a command', () => {
+    expect(parseSlashCommand('//help')).toBeNull()
+  })
+
+  it('rejects input that does not start with a slash', () => {
+    expect(parseSlashCommand('help')).toBeNull()
+    expect(parseSlashCommand(' /help')).toBeNull()
+  })
+
+  it('rejects an empty slash', () => {
+    expect(parseSlashCommand('/')).toBeNull()
+  })
+
+  it('rejects names with invalid characters', () => {
+    expect(parseSlashCommand('/foo-bar')).toBeNull()
+    expect(parseSlashCommand('/foo!')).toBeNull()
+  })
+
+  it('captures multi-word args trimmed', () => {
+    expect(parseSlashCommand('/title  hello  world  ')).toEqual({
+      raw: '/title  hello  world  ',
+      name: 'title',
+      args: 'hello  world',
+    })
+  })
+})
+
+describe('SlashCommandRegistry', () => {
+  let registry: SlashCommandRegistry
+
+  beforeEach(() => {
+    registry = new SlashCommandRegistry()
+  })
+
+  it('registers and resolves by name', () => {
+    registry.register({ name: 'foo', description: 'foo cmd', surfaces: ['web'], handler: () => 'foo!' })
+    expect(registry.resolve('foo')?.description).toBe('foo cmd')
+    expect(registry.resolve('FOO')?.name).toBe('foo')
+  })
+
+  it('resolves by alias', () => {
+    registry.register({
+      name: 'help',
+      aliases: ['hh', 'h'],
+      description: 'help',
+      surfaces: ['web'],
+      handler: () => 'h',
+    })
+    expect(registry.resolve('hh')?.name).toBe('help')
+    expect(registry.resolve('H')?.name).toBe('help')
+  })
+
+  it('rejects duplicate names and conflicting aliases', () => {
+    registry.register({ name: 'a', description: 'a', surfaces: ['web'] })
+    expect(() => registry.register({ name: 'a', description: 'a2', surfaces: ['web'] })).toThrow(/already registered/)
+    expect(() =>
+      registry.register({ name: 'b', aliases: ['a'], description: 'b', surfaces: ['web'] }),
+    ).toThrow(/collides|conflicts/)
+  })
+
+  it('list() filters by surface', () => {
+    registry.register({ name: 'web1', description: 'w', surfaces: ['web'] })
+    registry.register({ name: 'tg1', description: 't', surfaces: ['telegram'] })
+    registry.register({ name: 'both', description: 'b', surfaces: ['web', 'telegram'] })
+    expect(registry.list('web').map((c) => c.name)).toEqual(['both', 'web1'])
+    expect(registry.list('telegram').map((c) => c.name)).toEqual(['both', 'tg1'])
+  })
+
+  it('dispatch returns no_command for non-slash input', async () => {
+    const r = await registry.dispatch('hello world', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('no_command')
+  })
+
+  it('dispatch returns not_found for unknown command', async () => {
+    const r = await registry.dispatch('/nope', { surface: 'web', userId: '1', registry })
+    expect(r).toEqual({ kind: 'not_found', name: 'nope' })
+  })
+
+  it('dispatch returns wrong_surface when a known command is invoked from the wrong surface', async () => {
+    registry.register({ name: 'tgonly', description: 'tg', surfaces: ['telegram'], handler: () => 'tg' })
+    const r = await registry.dispatch('/tgonly', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('wrong_surface')
+  })
+
+  it('dispatch returns external for metadata-only entries', async () => {
+    registry.register({ name: 'new', description: 'new session', surfaces: ['web', 'telegram'] })
+    const r = await registry.dispatch('/new now', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('external')
+    if (r.kind === 'external') {
+      expect(r.command.name).toBe('new')
+      expect(r.args).toBe('now')
+    }
+  })
+
+  it('dispatch invokes the handler and returns its reply', async () => {
+    registry.register({
+      name: 'echo',
+      description: 'echo',
+      surfaces: ['web'],
+      handler: (ctx) => `you said: ${ctx.args}`,
+    })
+    const r = await registry.dispatch('/echo hello', { surface: 'web', userId: '1', registry })
+    expect(r).toMatchObject({ kind: 'handled' })
+    if (r.kind === 'handled') expect(r.reply).toBe('you said: hello')
+  })
+
+  it('dispatch catches handler errors and returns a friendly reply', async () => {
+    registry.register({
+      name: 'boom',
+      description: 'boom',
+      surfaces: ['web'],
+      handler: () => {
+        throw new Error('kaboom')
+      },
+    })
+    const r = await registry.dispatch('/boom', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('handled')
+    if (r.kind === 'handled') expect(r.reply).toContain('kaboom')
+  })
+})
+
+describe('built-in slash commands', () => {
+  let registry: SlashCommandRegistry
+
+  beforeEach(() => {
+    registry = new SlashCommandRegistry()
+    registerBuiltInSlashCommands(registry)
+  })
+
+  it('registers help / tasks / cronjobs / settings on both surfaces', () => {
+    const names = registry.list('web').map((c) => c.name)
+    expect(names).toContain('help')
+    expect(names).toContain('tasks')
+    expect(names).toContain('cronjobs')
+    expect(names).toContain('settings')
+    expect(registry.list('telegram').map((c) => c.name)).toEqual(names)
+  })
+
+  it('/help renders all commands for the surface', async () => {
+    const r = await registry.dispatch('/help', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('handled')
+    if (r.kind === 'handled') {
+      expect(r.reply).toContain('/help')
+      expect(r.reply).toContain('/tasks')
+      expect(r.reply).toContain('/settings')
+    }
+  })
+
+  it('/tasks falls back gracefully without a task store', async () => {
+    const r = await registry.dispatch('/tasks', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('handled')
+    if (r.kind === 'handled') expect(r.reply).toMatch(/not available/)
+  })
+
+  it('/tasks renders running and recent tasks', async () => {
+    const taskStore = {
+      list: vi.fn((filters?: { status?: string; limit?: number }) => {
+        if (filters?.status === 'running') {
+          return [
+            {
+              id: '1',
+              name: 'do thing',
+              status: 'running',
+              triggerType: 'user',
+              createdAt: '2024-01-01 10:00:00',
+            },
+          ]
+        }
+        return [
+          {
+            id: '2',
+            name: 'old thing',
+            status: 'completed',
+            triggerType: 'agent',
+            createdAt: '2024-01-01 09:00:00',
+            finishedAt: '2024-01-01 09:05:00',
+          },
+        ]
+      }),
+    }
+    const r = await registry.dispatch('/tasks', {
+      surface: 'web',
+      userId: '1',
+      registry,
+      taskStore: taskStore as never,
+    })
+    expect(r.kind).toBe('handled')
+    if (r.kind === 'handled') {
+      expect(r.reply).toContain('Running tasks: 1')
+      expect(r.reply).toContain('do thing')
+      expect(r.reply).toContain('[completed]')
+      expect(r.reply).toContain('old thing')
+    }
+    expect(taskStore.list).toHaveBeenCalledTimes(2)
+  })
+
+  it('/cronjobs falls back gracefully without a store', async () => {
+    const r = await registry.dispatch('/cronjobs', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('handled')
+    if (r.kind === 'handled') expect(r.reply).toMatch(/not available/)
+  })
+
+  it('/cronjobs renders enabled state and next run', async () => {
+    const reply = formatCronjobsReply([
+      { id: 'a', name: 'morning', cronExpression: '0 9 * * *', enabled: true, nextRunAt: '2024-01-02 09:00' },
+      { id: 'b', name: 'paused', cronExpression: '0 0 * * *', enabled: false },
+    ])
+    expect(reply).toContain('morning')
+    expect(reply).toContain('[on ]')
+    expect(reply).toContain('[off]')
+    expect(reply).toContain('next: 2024-01-02 09:00')
+  })
+
+  it('formatTasksReply handles empty input', () => {
+    expect(formatTasksReply([], [])).toContain('Running tasks: 0')
+    expect(formatTasksReply([], [])).toContain('(none)')
+  })
+
+  it('renderHelp returns a helpful message for empty surfaces', () => {
+    const empty = new SlashCommandRegistry()
+    expect(renderHelp(empty, 'web')).toMatch(/No slash commands/)
+  })
+})

--- a/packages/core/src/slash-commands.test.ts
+++ b/packages/core/src/slash-commands.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   parseSlashCommand,
@@ -160,6 +163,7 @@ describe('built-in slash commands', () => {
     expect(names).toContain('tasks')
     expect(names).toContain('cronjobs')
     expect(names).toContain('settings')
+    expect(names).toContain('thinking')
     expect(registry.list('telegram').map((c) => c.name)).toEqual(names)
   })
 
@@ -171,6 +175,46 @@ describe('built-in slash commands', () => {
       expect(r.reply).toContain('/tasks')
       expect(r.reply).toContain('/settings')
     }
+  })
+
+  it('/thinking shows and updates the configured thinking level', async () => {
+    const previousDataDir = process.env.DATA_DIR
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axiom-thinking-command-'))
+    process.env.DATA_DIR = dataDir
+    try {
+      fs.mkdirSync(path.join(dataDir, 'config'), { recursive: true })
+      fs.writeFileSync(
+        path.join(dataDir, 'config', 'settings.json'),
+        `${JSON.stringify({ thinkingLevel: 'off' }, null, 2)}\n`,
+        'utf-8',
+      )
+
+      const onThinkingLevelChanged = vi.fn()
+      const show = await registry.dispatch('/thinking', { surface: 'web', userId: '1', registry })
+      expect(show.kind).toBe('handled')
+      if (show.kind === 'handled') expect(show.reply).toContain('Current thinking level: off')
+
+      const set = await registry.dispatch('/thinking medium', {
+        surface: 'web',
+        userId: '1',
+        registry,
+        onThinkingLevelChanged,
+      })
+      expect(set.kind).toBe('handled')
+      if (set.kind === 'handled') expect(set.reply).toBe('Thinking level set to: medium')
+      expect(onThinkingLevelChanged).toHaveBeenCalledWith('medium')
+      expect(JSON.parse(fs.readFileSync(path.join(dataDir, 'config', 'settings.json'), 'utf-8')).thinkingLevel).toBe('medium')
+    } finally {
+      if (previousDataDir === undefined) delete process.env.DATA_DIR
+      else process.env.DATA_DIR = previousDataDir
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    }
+  })
+
+  it('/thinking rejects invalid levels', async () => {
+    const r = await registry.dispatch('/thinking extreme', { surface: 'web', userId: '1', registry })
+    expect(r.kind).toBe('handled')
+    if (r.kind === 'handled') expect(r.reply).toContain('Unknown thinking level: extreme')
   })
 
   it('/tasks falls back gracefully without a task store', async () => {

--- a/packages/core/src/slash-commands.test.ts
+++ b/packages/core/src/slash-commands.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   parseSlashCommand,
   SlashCommandRegistry,
@@ -9,7 +9,19 @@ import {
   formatTasksReply,
   formatCronjobsReply,
   renderHelp,
+  isSlashCommandPicker,
 } from './slash-commands.js'
+import type { SlashCommandPicker, SlashCommandReply } from './slash-commands.js'
+
+function asText(reply: SlashCommandReply): string {
+  expect(typeof reply).toBe('string')
+  return reply as string
+}
+
+function asPicker(reply: SlashCommandReply): SlashCommandPicker {
+  expect(isSlashCommandPicker(reply)).toBe(true)
+  return reply as SlashCommandPicker
+}
 
 describe('parseSlashCommand', () => {
   it('parses a bare command', () => {
@@ -157,23 +169,31 @@ describe('built-in slash commands', () => {
     registerBuiltInSlashCommands(registry)
   })
 
-  it('registers help / tasks / cronjobs / settings on both surfaces', () => {
+  it('registers help / tasks / cronjobs / model on both surfaces', () => {
     const names = registry.list('web').map((c) => c.name)
     expect(names).toContain('help')
     expect(names).toContain('tasks')
     expect(names).toContain('cronjobs')
-    expect(names).toContain('settings')
+    expect(names).toContain('model')
     expect(names).toContain('thinking')
     expect(registry.list('telegram').map((c) => c.name)).toEqual(names)
+  })
+
+  it('exposes /provider as an alias of /model and does not register /settings', () => {
+    expect(registry.resolve('provider')?.name).toBe('model')
+    expect(registry.resolve('model')?.name).toBe('model')
+    expect(registry.resolve('settings')).toBeUndefined()
   })
 
   it('/help renders all commands for the surface', async () => {
     const r = await registry.dispatch('/help', { surface: 'web', userId: '1', registry })
     expect(r.kind).toBe('handled')
     if (r.kind === 'handled') {
-      expect(r.reply).toContain('/help')
-      expect(r.reply).toContain('/tasks')
-      expect(r.reply).toContain('/settings')
+      const text = asText(r.reply)
+      expect(text).toContain('/help')
+      expect(text).toContain('/tasks')
+      expect(text).toContain('/model')
+      expect(text).not.toContain('/settings')
     }
   })
 
@@ -192,7 +212,7 @@ describe('built-in slash commands', () => {
       const onThinkingLevelChanged = vi.fn()
       const show = await registry.dispatch('/thinking', { surface: 'web', userId: '1', registry })
       expect(show.kind).toBe('handled')
-      if (show.kind === 'handled') expect(show.reply).toContain('Current thinking level: off')
+      if (show.kind === 'handled') expect(asText(show.reply)).toContain('Current thinking level: off')
 
       const set = await registry.dispatch('/thinking medium', {
         surface: 'web',
@@ -201,7 +221,7 @@ describe('built-in slash commands', () => {
         onThinkingLevelChanged,
       })
       expect(set.kind).toBe('handled')
-      if (set.kind === 'handled') expect(set.reply).toBe('Thinking level set to: medium')
+      if (set.kind === 'handled') expect(asText(set.reply)).toBe('Thinking level set to: medium')
       expect(onThinkingLevelChanged).toHaveBeenCalledWith('medium')
       expect(JSON.parse(fs.readFileSync(path.join(dataDir, 'config', 'settings.json'), 'utf-8')).thinkingLevel).toBe('medium')
     } finally {
@@ -214,13 +234,13 @@ describe('built-in slash commands', () => {
   it('/thinking rejects invalid levels', async () => {
     const r = await registry.dispatch('/thinking extreme', { surface: 'web', userId: '1', registry })
     expect(r.kind).toBe('handled')
-    if (r.kind === 'handled') expect(r.reply).toContain('Unknown thinking level: extreme')
+    if (r.kind === 'handled') expect(asText(r.reply)).toContain('Unknown thinking level: extreme')
   })
 
   it('/tasks falls back gracefully without a task store', async () => {
     const r = await registry.dispatch('/tasks', { surface: 'web', userId: '1', registry })
     expect(r.kind).toBe('handled')
-    if (r.kind === 'handled') expect(r.reply).toMatch(/not available/)
+    if (r.kind === 'handled') expect(asText(r.reply)).toMatch(/not available/)
   })
 
   it('/tasks renders running and recent tasks', async () => {
@@ -257,10 +277,11 @@ describe('built-in slash commands', () => {
     })
     expect(r.kind).toBe('handled')
     if (r.kind === 'handled') {
-      expect(r.reply).toContain('Running tasks: 1')
-      expect(r.reply).toContain('do thing')
-      expect(r.reply).toContain('[completed]')
-      expect(r.reply).toContain('old thing')
+      const text = asText(r.reply)
+      expect(text).toContain('Running tasks: 1')
+      expect(text).toContain('do thing')
+      expect(text).toContain('[completed]')
+      expect(text).toContain('old thing')
     }
     expect(taskStore.list).toHaveBeenCalledTimes(2)
   })
@@ -268,7 +289,7 @@ describe('built-in slash commands', () => {
   it('/cronjobs falls back gracefully without a store', async () => {
     const r = await registry.dispatch('/cronjobs', { surface: 'web', userId: '1', registry })
     expect(r.kind).toBe('handled')
-    if (r.kind === 'handled') expect(r.reply).toMatch(/not available/)
+    if (r.kind === 'handled') expect(asText(r.reply)).toMatch(/not available/)
   })
 
   it('/cronjobs renders enabled state and next run', async () => {
@@ -290,5 +311,186 @@ describe('built-in slash commands', () => {
   it('renderHelp returns a helpful message for empty surfaces', () => {
     const empty = new SlashCommandRegistry()
     expect(renderHelp(empty, 'web')).toMatch(/No slash commands/)
+  })
+
+  describe('/model', () => {
+    let dataDir: string
+    let previousDataDir: string | undefined
+
+    function writeProviders(providers: unknown): void {
+      fs.mkdirSync(path.join(dataDir, 'config'), { recursive: true })
+      fs.writeFileSync(
+        path.join(dataDir, 'config', 'providers.json'),
+        `${JSON.stringify(providers, null, 2)}\n`,
+        'utf-8',
+      )
+    }
+
+    beforeEach(() => {
+      previousDataDir = process.env.DATA_DIR
+      dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axiom-model-command-'))
+      process.env.DATA_DIR = dataDir
+    })
+
+    afterEach(() => {
+      if (previousDataDir === undefined) delete process.env.DATA_DIR
+      else process.env.DATA_DIR = previousDataDir
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    })
+
+    it('reports when no providers are configured', async () => {
+      writeProviders({ providers: [] })
+      const r = await registry.dispatch('/model', { surface: 'web', userId: '1', registry })
+      expect(r.kind).toBe('handled')
+      if (r.kind === 'handled') expect(asText(r.reply)).toMatch(/No providers are configured/)
+    })
+
+    it('returns a provider picker with no args', async () => {
+      writeProviders({
+        activeProvider: 'p1',
+        activeModel: 'gpt-4o',
+        providers: [
+          {
+            id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+            provider: 'openai', baseUrl: 'https://api.openai.com', apiKey: '',
+            defaultModel: 'gpt-4o', enabledModels: ['gpt-4o', 'gpt-4o-mini'],
+          },
+          {
+            id: 'p2', name: 'Anthropic', type: 'anthropic-messages', providerType: 'anthropic',
+            provider: 'anthropic', baseUrl: 'https://api.anthropic.com', apiKey: '',
+            defaultModel: 'claude-sonnet-4-20250514',
+          },
+        ],
+      })
+      const r = await registry.dispatch('/model', { surface: 'web', userId: '1', registry })
+      expect(r.kind).toBe('handled')
+      if (r.kind !== 'handled') return
+      const picker = asPicker(r.reply)
+      expect(picker.pickerId).toBe('model:providers')
+      expect(picker.options).toHaveLength(2)
+      expect(picker.options[0]).toMatchObject({ command: '/model p1', label: 'OpenAI', badge: 'active' })
+      expect(picker.options[1]).toMatchObject({ command: '/model p2', label: 'Anthropic' })
+      expect(picker.description).toContain('OpenAI')
+      expect(picker.description).toContain('gpt-4o')
+    })
+
+    it('also exposes the picker via the /provider alias', async () => {
+      writeProviders({
+        activeProvider: 'p1',
+        providers: [{
+          id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+          provider: 'openai', baseUrl: '', apiKey: '', defaultModel: 'gpt-4o',
+        }],
+      })
+      const r = await registry.dispatch('/provider', { surface: 'web', userId: '1', registry })
+      expect(r.kind).toBe('handled')
+      if (r.kind !== 'handled') return
+      expect(asPicker(r.reply).pickerId).toBe('model:providers')
+    })
+
+    it('returns a model picker with active/default badges and a back button', async () => {
+      writeProviders({
+        activeProvider: 'p1',
+        activeModel: 'gpt-4o-mini',
+        providers: [{
+          id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+          provider: 'openai', baseUrl: '', apiKey: '',
+          defaultModel: 'gpt-4o', enabledModels: ['gpt-4o', 'gpt-4o-mini'],
+        }],
+      })
+      const r = await registry.dispatch('/model p1', { surface: 'web', userId: '1', registry })
+      expect(r.kind).toBe('handled')
+      if (r.kind !== 'handled') return
+      const picker = asPicker(r.reply)
+      expect(picker.pickerId).toBe('model:models:p1')
+      // gpt-4o, gpt-4o-mini, plus a back button
+      expect(picker.options).toHaveLength(3)
+      const byCmd = Object.fromEntries(picker.options.map((o) => [o.command, o]))
+      expect(byCmd['/model p1 gpt-4o']?.badge).toBe('default')
+      expect(byCmd['/model p1 gpt-4o-mini']?.badge).toBe('active')
+      // Back button is last
+      expect(picker.options[picker.options.length - 1]).toMatchObject({
+        command: '/model',
+        label: expect.stringMatching(/back/i),
+      })
+    })
+
+    it('resolves provider also by name (case-insensitive)', async () => {
+      writeProviders({
+        activeProvider: 'p1',
+        providers: [{
+          id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+          provider: 'openai', baseUrl: '', apiKey: '',
+          defaultModel: 'gpt-4o', enabledModels: ['gpt-4o'],
+        }],
+      })
+      const r = await registry.dispatch('/model openai', { surface: 'web', userId: '1', registry })
+      expect(r.kind).toBe('handled')
+      if (r.kind !== 'handled') return
+      expect(asPicker(r.reply).pickerId).toBe('model:models:p1')
+    })
+
+    it('rejects unknown providers with a hint to use /model', async () => {
+      writeProviders({
+        activeProvider: 'p1',
+        providers: [{
+          id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+          provider: 'openai', baseUrl: '', apiKey: '', defaultModel: 'gpt-4o',
+        }],
+      })
+      const r = await registry.dispatch('/model nope', { surface: 'web', userId: '1', registry })
+      expect(r.kind).toBe('handled')
+      if (r.kind !== 'handled') return
+      const text = asText(r.reply)
+      expect(text).toContain('Unknown provider: nope')
+      expect(text).toContain('/model')
+    })
+
+    it('switches active provider and model when both are valid', async () => {
+      writeProviders({
+        activeProvider: 'p1',
+        activeModel: 'gpt-4o',
+        providers: [
+          {
+            id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+            provider: 'openai', baseUrl: '', apiKey: '', defaultModel: 'gpt-4o',
+            enabledModels: ['gpt-4o', 'gpt-4o-mini'],
+          },
+          {
+            id: 'p2', name: 'Anthropic', type: 'anthropic-messages', providerType: 'anthropic',
+            provider: 'anthropic', baseUrl: '', apiKey: '',
+            defaultModel: 'claude-sonnet-4-20250514',
+            enabledModels: ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022'],
+          },
+        ],
+      })
+      const r = await registry.dispatch(
+        '/model p2 claude-3-5-sonnet-20241022',
+        { surface: 'web', userId: '1', registry },
+      )
+      expect(r.kind).toBe('handled')
+      if (r.kind !== 'handled') return
+      const text = asText(r.reply)
+      expect(text).toContain('Active provider: Anthropic')
+      expect(text).toContain('Active model: claude-3-5-sonnet-20241022')
+      const stored = JSON.parse(fs.readFileSync(path.join(dataDir, 'config', 'providers.json'), 'utf-8'))
+      expect(stored.activeProvider).toBe('p2')
+      expect(stored.activeModel).toBe('claude-3-5-sonnet-20241022')
+    })
+
+    it('rejects models that are not enabled for the provider', async () => {
+      writeProviders({
+        activeProvider: 'p1',
+        providers: [{
+          id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+          provider: 'openai', baseUrl: '', apiKey: '', defaultModel: 'gpt-4o',
+          enabledModels: ['gpt-4o'],
+        }],
+      })
+      const r = await registry.dispatch('/model p1 gpt-3.5-turbo', { surface: 'web', userId: '1', registry })
+      expect(r.kind).toBe('handled')
+      if (r.kind !== 'handled') return
+      expect(asText(r.reply)).toContain('not enabled')
+    })
   })
 })

--- a/packages/core/src/slash-commands.ts
+++ b/packages/core/src/slash-commands.ts
@@ -5,7 +5,11 @@ import type { Database } from './database.js'
 import type { TaskStore } from './task-store.js'
 import type { ScheduledTaskStore } from './scheduled-task-store.js'
 import { parseCronExpression, getNextRunTime } from './cron-parser.js'
-import { getActiveProvider, getActiveModelId } from './provider-config.js'
+import {
+  loadProviders,
+  setActiveProvider,
+} from './provider-config.js'
+import type { ProviderConfig } from './provider-config.js'
 import { getConfigDir, loadConfig } from './config.js'
 import { SETTINGS_THINKING_LEVELS, type SettingsThinkingLevel } from './contracts/settings.js'
 import { normalizeThinkingLevel } from './thinking-level.js'
@@ -20,8 +24,43 @@ export interface SlashCommandMetadata {
   surfaces: SlashCommandSurface[]
 }
 
+/**
+ * Structured reply for surfaces that can render interactive UI (web buttons,
+ * Telegram inline keyboards). Each option carries a verbatim slash-command
+ * string the surface should re-dispatch when picked, so the same handler
+ * runs again and produces the next picker / final confirmation.
+ */
+export interface SlashCommandPickerOption {
+  /** Slash-command text to re-dispatch on selection (must start with `/`). */
+  command: string
+  /** Primary label shown on the button. */
+  label: string
+  /** Optional secondary line shown beneath the label (web only). */
+  description?: string
+  /** Optional short tag rendered next to the label (e.g. "active", "default"). */
+  badge?: string
+}
+
+export interface SlashCommandPicker {
+  kind: 'picker'
+  /** Stable id for this picker step (e.g. "model:providers"). */
+  pickerId: string
+  /** Optional title shown above the buttons. */
+  title?: string
+  /** Optional explanatory text shown above the buttons. */
+  description?: string
+  options: SlashCommandPickerOption[]
+}
+
+export function isSlashCommandPicker(value: unknown): value is SlashCommandPicker {
+  return typeof value === 'object' && value !== null
+    && (value as { kind?: unknown }).kind === 'picker'
+}
+
+export type SlashCommandReply = string | SlashCommandPicker | null
+
 export interface SlashCommandDefinition extends SlashCommandMetadata {
-  handler?: (ctx: SlashCommandContext) => Promise<string | null> | string | null
+  handler?: (ctx: SlashCommandContext) => Promise<SlashCommandReply> | SlashCommandReply
 }
 
 export interface SlashCommandContext {
@@ -67,7 +106,7 @@ export type SlashCommandDispatchResult =
   | { kind: 'not_found'; name: string }
   | { kind: 'wrong_surface'; command: SlashCommandDefinition }
   | { kind: 'external'; command: SlashCommandDefinition; args: string }
-  | { kind: 'handled'; command: SlashCommandDefinition; reply: string | null }
+  | { kind: 'handled'; command: SlashCommandDefinition; reply: SlashCommandReply }
   | { kind: 'error'; command: SlashCommandDefinition; error: Error }
 
 export class SlashCommandRegistry {
@@ -192,11 +231,12 @@ export function registerBuiltInSlashCommands(registry: SlashCommandRegistry): vo
   })
 
   registry.register({
-    name: 'settings',
-    aliases: ['model'],
-    description: 'Show the active provider and model.',
+    name: 'model',
+    aliases: ['provider'],
+    description: 'Show or switch the active provider and model.',
+    usage: '/model [<provider> [<model>]]',
     surfaces: ['web', 'telegram'],
-    handler: () => formatSettingsReply(),
+    handler: (ctx) => handleModelCommand(ctx.args),
   })
 
   registry.register({
@@ -297,18 +337,135 @@ export function formatCronjobsReply(jobs: CronjobLike[]): string {
   return lines.join('\n')
 }
 
-export function formatSettingsReply(): string {
+/**
+ * Multi-step `/model` command. Returns either a structured picker (interactive
+ * surfaces render this as buttons / inline keyboards) or a plain text reply
+ * (terminal confirmation, errors).
+ *
+ * - `/model`                     → picker with provider buttons
+ * - `/model <provider>`          → picker with model buttons (+ "Back")
+ * - `/model <provider> <model>`  → text confirmation after switching
+ *
+ * Provider/model identifiers are resolved case-insensitively against both
+ * `id` and `name`, so picker callbacks can use ids while users typing the
+ * command directly can use names.
+ */
+export function handleModelCommand(rawArgs: string): SlashCommandReply {
+  const args = rawArgs.trim()
+  let file
   try {
-    const provider = getActiveProvider()
-    if (!provider) return 'No active provider is configured.'
-    const modelId = getActiveModelId() ?? provider.defaultModel ?? '(none)'
-    const lines = [
-      `Active provider: ${provider.name} (${provider.providerType})`,
-      `Active model: ${modelId}`,
-    ]
-    return lines.join('\n')
+    file = loadProviders()
   } catch (err) {
     return `Could not read provider settings: ${(err as Error).message}`
+  }
+  const providers = file.providers
+  if (providers.length === 0) {
+    return 'No providers are configured. Add one in the settings UI first.'
+  }
+
+  const tokens = args.length === 0 ? [] : args.split(/\s+/)
+
+  // No args → provider picker
+  if (tokens.length === 0) {
+    return buildProviderPicker(providers, file.activeProvider, file.activeModel)
+  }
+
+  const providerKey = tokens[0]!
+  const provider = findProvider(providers, providerKey)
+  if (!provider) {
+    return `Unknown provider: ${providerKey}\n\nUse /model to choose from the list.`
+  }
+
+  // 1 arg → model picker for the chosen provider
+  if (tokens.length === 1) {
+    return buildModelPicker(provider, file.activeProvider, file.activeModel)
+  }
+
+  // 2 args → switch active provider + model (terminal step)
+  if (tokens.length === 2) {
+    const modelKey = tokens[1]!
+    const enabled = enabledModelIds(provider)
+    const modelId = enabled.find((m) => m.toLowerCase() === modelKey.toLowerCase())
+    if (!modelId) {
+      return `Model "${modelKey}" is not enabled for provider "${provider.name}".`
+    }
+    try {
+      setActiveProvider(provider.id, modelId)
+    } catch (err) {
+      return `Could not switch model: ${(err as Error).message}`
+    }
+    return `\u2705 Active provider: ${provider.name} (${provider.providerType})\nActive model: ${modelId}`
+  }
+
+  return `Usage: /model [<provider> [<model>]]`
+}
+
+function findProvider(providers: ProviderConfig[], key: string): ProviderConfig | undefined {
+  const k = key.toLowerCase()
+  return providers.find((p) => p.id.toLowerCase() === k || p.name.toLowerCase() === k)
+}
+
+function enabledModelIds(provider: ProviderConfig): string[] {
+  return provider.enabledModels && provider.enabledModels.length > 0
+    ? provider.enabledModels
+    : [provider.defaultModel]
+}
+
+function buildProviderPicker(
+  providers: ProviderConfig[],
+  activeProviderId: string | undefined,
+  activeModelId: string | undefined,
+): SlashCommandPicker {
+  const active = providers.find((p) => p.id === activeProviderId) ?? providers[0]!
+  const activeModel = activeModelId ?? active.defaultModel ?? '(none)'
+  const options: SlashCommandPickerOption[] = providers.map((p) => {
+    const isActive = p.id === activeProviderId
+    return {
+      // Use provider id (always set, never collides) for the callback
+      command: `/model ${p.id}`,
+      label: p.name,
+      description: p.providerType,
+      badge: isActive ? 'active' : (p.status === 'error' ? 'error' : undefined),
+    }
+  })
+  return {
+    kind: 'picker',
+    pickerId: 'model:providers',
+    title: 'Choose a provider',
+    description: `Active: ${active.name} \u00b7 ${activeModel}`,
+    options,
+  }
+}
+
+function buildModelPicker(
+  provider: ProviderConfig,
+  activeProviderId: string | undefined,
+  activeModelId: string | undefined,
+): SlashCommandPicker {
+  const enabled = enabledModelIds(provider)
+  const isActiveProvider = provider.id === activeProviderId
+  const options: SlashCommandPickerOption[] = enabled.map((m) => {
+    const flags: string[] = []
+    if (isActiveProvider && m === activeModelId) flags.push('active')
+    if (m === provider.defaultModel) flags.push('default')
+    const status = provider.modelStatuses?.[m]
+    if (status && status !== 'untested') flags.push(status)
+    const overrideName = provider.models?.find((mm) => mm.id === m)?.name
+    return {
+      command: `/model ${provider.id} ${m}`,
+      label: overrideName ?? m,
+      description: overrideName ? m : undefined,
+      badge: flags[0],
+    }
+  })
+  // Back button → re-show provider picker
+  options.push({ command: '/model', label: '\u2190 Back to providers' })
+  return {
+    kind: 'picker',
+    pickerId: `model:models:${provider.id}`,
+    title: `Choose a model for ${provider.name}`,
+    description: provider.providerType,
+    options,
   }
 }
 

--- a/packages/core/src/slash-commands.ts
+++ b/packages/core/src/slash-commands.ts
@@ -350,7 +350,7 @@ export function formatCronjobsReply(jobs: CronjobLike[]): string {
  * `id` and `name`, so picker callbacks can use ids while users typing the
  * command directly can use names.
  */
-export function handleModelCommand(rawArgs: string): SlashCommandReply {
+function handleModelCommand(rawArgs: string): SlashCommandReply {
   const args = rawArgs.trim()
   let file
   try {

--- a/packages/core/src/slash-commands.ts
+++ b/packages/core/src/slash-commands.ts
@@ -173,11 +173,6 @@ export class SlashCommandRegistry {
       .sort((a, b) => a.name.localeCompare(b.name))
   }
 
-  /** All registered commands, sorted by name. */
-  all(): SlashCommandDefinition[] {
-    return [...this.byName.values()].sort((a, b) => a.name.localeCompare(b.name))
-  }
-
   /**
    * Try to dispatch a chat input. Returns a discriminated result describing
    * what happened. Surfaces use the result to decide how to respond.

--- a/packages/core/src/slash-commands.ts
+++ b/packages/core/src/slash-commands.ts
@@ -1,0 +1,362 @@
+/**
+ * Shared slash-command parser, registry and dispatcher.
+ *
+ * The same registry is used by the web chat WebSocket layer and the Telegram
+ * bot so both surfaces understand the same vocabulary. A command is metadata
+ * (`name`, `aliases`, `description`, `usage`, `surfaces`) plus an optional
+ * `handler`. Surface-specific commands that need to mutate transport state
+ * (e.g. aborting an in-flight WebSocket stream for `/stop`) register
+ * themselves *without* a handler so the surface keeps its custom behaviour
+ * while still appearing in `/help` and the Telegram command menu.
+ *
+ * Inspired by Hermes Agent's central `COMMAND_REGISTRY` (one source of truth
+ * for CLI + messaging surfaces) and OpenClaw's `setMyCommands`-based Telegram
+ * menu. Kept intentionally small for a first version: no skill commands,
+ * autocomplete or destructive operations.
+ */
+
+import type { Database } from './database.js'
+import type { TaskStore } from './task-store.js'
+import type { ScheduledTaskStore } from './scheduled-task-store.js'
+import { parseCronExpression, getNextRunTime } from './cron-parser.js'
+import { getActiveProvider, getActiveModelId } from './provider-config.js'
+
+/** Surface a command can be invoked from. */
+export type SlashCommandSurface = 'web' | 'telegram'
+
+/** Metadata describing a slash command. */
+export interface SlashCommandMetadata {
+  /** Canonical name without the leading slash. Lowercase, no whitespace. */
+  name: string
+  /** Optional alternate names (without leading slash). Lowercase. */
+  aliases?: string[]
+  /** One-line description shown in `/help` and the Telegram menu. */
+  description: string
+  /** Optional usage hint shown in detailed help (e.g. `/title <text>`). */
+  usage?: string
+  /** Surfaces this command is exposed on. */
+  surfaces: SlashCommandSurface[]
+}
+
+/** Definition stored in the registry. Handler is optional for surface-owned commands. */
+export interface SlashCommandDefinition extends SlashCommandMetadata {
+  /**
+   * Returns the markdown text reply, or `null` if the command produced no
+   * reply (e.g. surface-owned commands that handle the response themselves).
+   * Throwing inside a handler is caught by the dispatcher and surfaced as an
+   * error reply — handlers should not need their own try/catch.
+   */
+  handler?: (ctx: SlashCommandContext) => Promise<string | null> | string | null
+}
+
+/** Per-invocation context passed to handlers. */
+export interface SlashCommandContext {
+  /** Axiom user ID as string, or `null` for unauthenticated/anonymous calls. */
+  userId: string | null
+  /** Surface that received the command. */
+  surface: SlashCommandSurface
+  /** Trimmed argument string after the command name (may be empty). */
+  args: string
+  /** The matched definition. */
+  command: SlashCommandDefinition
+  /** Registry — handlers may call `registry.list(surface)` for `/help`. */
+  registry: SlashCommandRegistry
+  /** Database, when the surface has one. */
+  db?: Database
+  /** Task store, when configured. */
+  taskStore?: TaskStore
+  /** Scheduled-task (cronjob) store, when configured. */
+  scheduledTaskStore?: ScheduledTaskStore
+}
+
+/** Result of parsing an input string. */
+export interface ParsedSlashCommand {
+  /** The full raw line (input as given). */
+  raw: string
+  /** Lowercased name (without leading slash). */
+  name: string
+  /** Trimmed argument substring (may be empty). */
+  args: string
+}
+
+/**
+ * Parse a chat input. Returns `null` if the text is not a slash command (i.e.
+ * does not start with `/`, contains whitespace before the slash, is just `/`,
+ * or starts with `//` which is conventionally an escaped/literal slash).
+ *
+ * Rules:
+ *  - Must start with exactly one `/`.
+ *  - The command name is `[a-zA-Z0-9_]+` and is case-insensitive.
+ *  - Telegram-style `@botname` suffix on the name is stripped.
+ *  - Everything after the first whitespace is the argument string (trimmed).
+ */
+export function parseSlashCommand(input: string): ParsedSlashCommand | null {
+  if (typeof input !== 'string') return null
+  const raw = input
+  // Do not trim leading whitespace: a message that starts with whitespace is
+  // not a slash command.
+  if (!raw.startsWith('/')) return null
+  // Escaped slash: `//foo` is treated as literal text, not a command.
+  if (raw.startsWith('//')) return null
+  const body = raw.slice(1)
+  if (body.length === 0) return null
+
+  // Split off args at the first whitespace.
+  const wsIdx = body.search(/\s/)
+  let head = wsIdx === -1 ? body : body.slice(0, wsIdx)
+  const args = wsIdx === -1 ? '' : body.slice(wsIdx + 1).trim()
+
+  // Strip Telegram @botname suffix (e.g. `/help@my_bot`).
+  const atIdx = head.indexOf('@')
+  if (atIdx !== -1) head = head.slice(0, atIdx)
+
+  if (!/^[a-zA-Z0-9_]+$/.test(head)) return null
+
+  return { raw, name: head.toLowerCase(), args }
+}
+
+/** Outcome of `dispatch()`. */
+export type SlashCommandDispatchResult =
+  | { kind: 'no_command' }
+  | { kind: 'not_found'; name: string }
+  | { kind: 'wrong_surface'; command: SlashCommandDefinition }
+  | { kind: 'external'; command: SlashCommandDefinition; args: string }
+  | { kind: 'handled'; command: SlashCommandDefinition; reply: string | null }
+  | { kind: 'error'; command: SlashCommandDefinition; error: Error }
+
+/** Central registry of slash commands, shared by all surfaces. */
+export class SlashCommandRegistry {
+  private byName = new Map<string, SlashCommandDefinition>()
+  private aliasToName = new Map<string, string>()
+
+  register(def: SlashCommandDefinition): this {
+    const name = def.name.toLowerCase()
+    if (!/^[a-z0-9_]+$/.test(name)) {
+      throw new Error(`Invalid slash-command name: "${def.name}"`)
+    }
+    if (this.byName.has(name)) {
+      throw new Error(`Slash command already registered: "${name}"`)
+    }
+    if (this.aliasToName.has(name)) {
+      throw new Error(`Slash command name conflicts with existing alias: "${name}"`)
+    }
+    if (!def.surfaces || def.surfaces.length === 0) {
+      throw new Error(`Slash command "${name}" must declare at least one surface`)
+    }
+    this.byName.set(name, { ...def, name })
+    for (const alias of def.aliases ?? []) {
+      const a = alias.toLowerCase()
+      if (!/^[a-z0-9_]+$/.test(a)) {
+        throw new Error(`Invalid slash-command alias: "${alias}"`)
+      }
+      if (this.byName.has(a) || this.aliasToName.has(a)) {
+        throw new Error(`Slash command alias collides: "${a}"`)
+      }
+      this.aliasToName.set(a, name)
+    }
+    return this
+  }
+
+  /** Resolve a command by name or alias (case-insensitive). */
+  resolve(nameOrAlias: string): SlashCommandDefinition | undefined {
+    const key = nameOrAlias.toLowerCase()
+    const direct = this.byName.get(key)
+    if (direct) return direct
+    const aliased = this.aliasToName.get(key)
+    return aliased ? this.byName.get(aliased) : undefined
+  }
+
+  /** List commands available on the given surface, sorted by name. */
+  list(surface: SlashCommandSurface): SlashCommandDefinition[] {
+    return [...this.byName.values()]
+      .filter((c) => c.surfaces.includes(surface))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  /** All registered commands, sorted by name. */
+  all(): SlashCommandDefinition[] {
+    return [...this.byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  /**
+   * Try to dispatch a chat input. Returns a discriminated result describing
+   * what happened. Surfaces use the result to decide how to respond.
+   */
+  async dispatch(
+    input: string,
+    ctxBase: Omit<SlashCommandContext, 'args' | 'command'>,
+  ): Promise<SlashCommandDispatchResult> {
+    const parsed = parseSlashCommand(input)
+    if (!parsed) return { kind: 'no_command' }
+    const def = this.resolve(parsed.name)
+    if (!def) return { kind: 'not_found', name: parsed.name }
+    if (!def.surfaces.includes(ctxBase.surface)) {
+      return { kind: 'wrong_surface', command: def }
+    }
+    if (!def.handler) {
+      return { kind: 'external', command: def, args: parsed.args }
+    }
+    try {
+      const reply = await def.handler({ ...ctxBase, command: def, args: parsed.args })
+      return { kind: 'handled', command: def, reply: reply ?? null }
+    } catch (err) {
+      return { kind: 'handled', command: def, reply: `⚠️ ${(err as Error).message || 'Slash command failed.'}` }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in commands
+// ---------------------------------------------------------------------------
+
+/** Internal helper: render the help reply for a given surface. */
+export function renderHelp(registry: SlashCommandRegistry, surface: SlashCommandSurface): string {
+  const cmds = registry.list(surface)
+  if (cmds.length === 0) return 'No slash commands are available on this surface.'
+  const lines: string[] = ['Available commands:']
+  const namePad = Math.max(...cmds.map((c) => c.name.length + 1))
+  for (const c of cmds) {
+    const head = `/${c.name}`.padEnd(namePad + 1)
+    lines.push(`${head} — ${c.description}`)
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Register the built-in read-only commands (`/help`, `/tasks`, `/cronjobs`,
+ * `/settings`). Surfaces compose this with their own surface-specific
+ * metadata-only entries (e.g. `/new`, `/stop`) to get a single source of
+ * truth for `/help` and the Telegram menu.
+ */
+export function registerBuiltInSlashCommands(registry: SlashCommandRegistry): void {
+  registry.register({
+    name: 'help',
+    description: 'List available slash commands.',
+    surfaces: ['web', 'telegram'],
+    handler: (ctx) => renderHelp(ctx.registry, ctx.surface),
+  })
+
+  registry.register({
+    name: 'tasks',
+    description: 'Show recent and currently running background tasks.',
+    surfaces: ['web', 'telegram'],
+    handler: (ctx) => {
+      if (!ctx.taskStore) return 'Task store is not available on this surface.'
+      const running = ctx.taskStore.list({ status: 'running', limit: 10 })
+      const recent = ctx.taskStore.list({ limit: 5 })
+      return formatTasksReply(running, recent)
+    },
+  })
+
+  registry.register({
+    name: 'cronjobs',
+    aliases: ['cron'],
+    description: 'Show configured cronjobs and their next run times.',
+    surfaces: ['web', 'telegram'],
+    handler: (ctx) => {
+      if (!ctx.scheduledTaskStore) return 'Cronjob store is not available on this surface.'
+      const jobs = ctx.scheduledTaskStore.list().map((j) => ({
+        id: j.id,
+        name: j.name,
+        cronExpression: j.schedule,
+        enabled: j.enabled,
+        nextRunAt: computeNextRunAt(j.schedule),
+        lastRunAt: j.lastRunAt,
+      }))
+      return formatCronjobsReply(jobs)
+    },
+  })
+
+  registry.register({
+    name: 'settings',
+    aliases: ['model'],
+    description: 'Show the active provider and model.',
+    surfaces: ['web', 'telegram'],
+    handler: () => formatSettingsReply(),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Reply formatters (pure functions, exported for tests)
+// ---------------------------------------------------------------------------
+
+interface TaskLike {
+  id: string
+  name: string
+  status: string
+  triggerType: string
+  createdAt: string
+  finishedAt?: string | null
+}
+
+export function formatTasksReply(running: TaskLike[], recent: TaskLike[]): string {
+  const lines: string[] = []
+  lines.push(`Running tasks: ${running.length}`)
+  if (running.length > 0) {
+    for (const t of running.slice(0, 10)) {
+      lines.push(`  • ${truncate(t.name, 60)} (${t.triggerType}) — started ${t.createdAt}`)
+    }
+  }
+  lines.push('')
+  lines.push('Recent tasks (newest first):')
+  if (recent.length === 0) {
+    lines.push('  (none)')
+  } else {
+    for (const t of recent.slice(0, 5)) {
+      const when = t.finishedAt ?? t.createdAt
+      lines.push(`  • [${t.status}] ${truncate(t.name, 60)} — ${when}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+interface CronjobLike {
+  id: string
+  name: string
+  cronExpression: string
+  enabled: boolean
+  nextRunAt?: string | null
+  lastRunAt?: string | null
+}
+
+export function formatCronjobsReply(jobs: CronjobLike[]): string {
+  if (jobs.length === 0) return 'No cronjobs configured.'
+  const lines: string[] = [`Configured cronjobs: ${jobs.length}`]
+  for (const j of jobs) {
+    const state = j.enabled ? 'on ' : 'off'
+    const next = j.nextRunAt ?? '—'
+    lines.push(`  • [${state}] ${truncate(j.name, 50)} — ${j.cronExpression} (next: ${next})`)
+  }
+  return lines.join('\n')
+}
+
+export function formatSettingsReply(): string {
+  try {
+    const provider = getActiveProvider()
+    if (!provider) return 'No active provider is configured.'
+    const modelId = getActiveModelId() ?? provider.defaultModel ?? '(none)'
+    const lines = [
+      `Active provider: ${provider.name} (${provider.providerType})`,
+      `Active model: ${modelId}`,
+    ]
+    return lines.join('\n')
+  } catch (err) {
+    return `Could not read provider settings: ${(err as Error).message}`
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max - 1) + '…'
+}
+
+function computeNextRunAt(schedule: string): string | null {
+  try {
+    const fields = parseCronExpression(schedule)
+    const next = getNextRunTime(fields, new Date())
+    if (!next) return null
+    return next.toISOString().replace('T', ' ').slice(0, 16)
+  } catch {
+    return null
+  }
+}

--- a/packages/core/src/slash-commands.ts
+++ b/packages/core/src/slash-commands.ts
@@ -1,112 +1,59 @@
-/**
- * Shared slash-command parser, registry and dispatcher.
- *
- * The same registry is used by the web chat WebSocket layer and the Telegram
- * bot so both surfaces understand the same vocabulary. A command is metadata
- * (`name`, `aliases`, `description`, `usage`, `surfaces`) plus an optional
- * `handler`. Surface-specific commands that need to mutate transport state
- * (e.g. aborting an in-flight WebSocket stream for `/stop`) register
- * themselves *without* a handler so the surface keeps its custom behaviour
- * while still appearing in `/help` and the Telegram command menu.
- *
- * Inspired by Hermes Agent's central `COMMAND_REGISTRY` (one source of truth
- * for CLI + messaging surfaces) and OpenClaw's `setMyCommands`-based Telegram
- * menu. Kept intentionally small for a first version: no skill commands,
- * autocomplete or destructive operations.
- */
 
+import fs from 'node:fs'
+import path from 'node:path'
 import type { Database } from './database.js'
 import type { TaskStore } from './task-store.js'
 import type { ScheduledTaskStore } from './scheduled-task-store.js'
 import { parseCronExpression, getNextRunTime } from './cron-parser.js'
 import { getActiveProvider, getActiveModelId } from './provider-config.js'
+import { getConfigDir, loadConfig } from './config.js'
+import { SETTINGS_THINKING_LEVELS, type SettingsThinkingLevel } from './contracts/settings.js'
+import { normalizeThinkingLevel } from './thinking-level.js'
 
-/** Surface a command can be invoked from. */
 export type SlashCommandSurface = 'web' | 'telegram'
 
-/** Metadata describing a slash command. */
 export interface SlashCommandMetadata {
-  /** Canonical name without the leading slash. Lowercase, no whitespace. */
   name: string
-  /** Optional alternate names (without leading slash). Lowercase. */
   aliases?: string[]
-  /** One-line description shown in `/help` and the Telegram menu. */
   description: string
-  /** Optional usage hint shown in detailed help (e.g. `/title <text>`). */
   usage?: string
-  /** Surfaces this command is exposed on. */
   surfaces: SlashCommandSurface[]
 }
 
-/** Definition stored in the registry. Handler is optional for surface-owned commands. */
 export interface SlashCommandDefinition extends SlashCommandMetadata {
-  /**
-   * Returns the markdown text reply, or `null` if the command produced no
-   * reply (e.g. surface-owned commands that handle the response themselves).
-   * Throwing inside a handler is caught by the dispatcher and surfaced as an
-   * error reply — handlers should not need their own try/catch.
-   */
   handler?: (ctx: SlashCommandContext) => Promise<string | null> | string | null
 }
 
-/** Per-invocation context passed to handlers. */
 export interface SlashCommandContext {
-  /** Axiom user ID as string, or `null` for unauthenticated/anonymous calls. */
   userId: string | null
-  /** Surface that received the command. */
   surface: SlashCommandSurface
-  /** Trimmed argument string after the command name (may be empty). */
   args: string
-  /** The matched definition. */
   command: SlashCommandDefinition
-  /** Registry — handlers may call `registry.list(surface)` for `/help`. */
   registry: SlashCommandRegistry
-  /** Database, when the surface has one. */
   db?: Database
-  /** Task store, when configured. */
   taskStore?: TaskStore
-  /** Scheduled-task (cronjob) store, when configured. */
   scheduledTaskStore?: ScheduledTaskStore
+  onThinkingLevelChanged?: (level: SettingsThinkingLevel) => void
 }
 
-/** Result of parsing an input string. */
 export interface ParsedSlashCommand {
-  /** The full raw line (input as given). */
   raw: string
-  /** Lowercased name (without leading slash). */
   name: string
-  /** Trimmed argument substring (may be empty). */
   args: string
 }
 
-/**
- * Parse a chat input. Returns `null` if the text is not a slash command (i.e.
- * does not start with `/`, contains whitespace before the slash, is just `/`,
- * or starts with `//` which is conventionally an escaped/literal slash).
- *
- * Rules:
- *  - Must start with exactly one `/`.
- *  - The command name is `[a-zA-Z0-9_]+` and is case-insensitive.
- *  - Telegram-style `@botname` suffix on the name is stripped.
- *  - Everything after the first whitespace is the argument string (trimmed).
- */
 export function parseSlashCommand(input: string): ParsedSlashCommand | null {
   if (typeof input !== 'string') return null
   const raw = input
-  // Do not trim leading whitespace: a message that starts with whitespace is
-  // not a slash command.
   if (!raw.startsWith('/')) return null
-  // Escaped slash: `//foo` is treated as literal text, not a command.
   if (raw.startsWith('//')) return null
   const body = raw.slice(1)
   if (body.length === 0) return null
 
-  // Split off args at the first whitespace.
   const wsIdx = body.search(/\s/)
   let head = wsIdx === -1 ? body : body.slice(0, wsIdx)
   const args = wsIdx === -1 ? '' : body.slice(wsIdx + 1).trim()
 
-  // Strip Telegram @botname suffix (e.g. `/help@my_bot`).
   const atIdx = head.indexOf('@')
   if (atIdx !== -1) head = head.slice(0, atIdx)
 
@@ -115,7 +62,6 @@ export function parseSlashCommand(input: string): ParsedSlashCommand | null {
   return { raw, name: head.toLowerCase(), args }
 }
 
-/** Outcome of `dispatch()`. */
 export type SlashCommandDispatchResult =
   | { kind: 'no_command' }
   | { kind: 'not_found'; name: string }
@@ -124,7 +70,6 @@ export type SlashCommandDispatchResult =
   | { kind: 'handled'; command: SlashCommandDefinition; reply: string | null }
   | { kind: 'error'; command: SlashCommandDefinition; error: Error }
 
-/** Central registry of slash commands, shared by all surfaces. */
 export class SlashCommandRegistry {
   private byName = new Map<string, SlashCommandDefinition>()
   private aliasToName = new Map<string, string>()
@@ -157,8 +102,7 @@ export class SlashCommandRegistry {
     return this
   }
 
-  /** Resolve a command by name or alias (case-insensitive). */
-  resolve(nameOrAlias: string): SlashCommandDefinition | undefined {
+    resolve(nameOrAlias: string): SlashCommandDefinition | undefined {
     const key = nameOrAlias.toLowerCase()
     const direct = this.byName.get(key)
     if (direct) return direct
@@ -166,17 +110,12 @@ export class SlashCommandRegistry {
     return aliased ? this.byName.get(aliased) : undefined
   }
 
-  /** List commands available on the given surface, sorted by name. */
-  list(surface: SlashCommandSurface): SlashCommandDefinition[] {
+    list(surface: SlashCommandSurface): SlashCommandDefinition[] {
     return [...this.byName.values()]
       .filter((c) => c.surfaces.includes(surface))
       .sort((a, b) => a.name.localeCompare(b.name))
   }
 
-  /**
-   * Try to dispatch a chat input. Returns a discriminated result describing
-   * what happened. Surfaces use the result to decide how to respond.
-   */
   async dispatch(
     input: string,
     ctxBase: Omit<SlashCommandContext, 'args' | 'command'>,
@@ -200,11 +139,7 @@ export class SlashCommandRegistry {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Built-in commands
-// ---------------------------------------------------------------------------
 
-/** Internal helper: render the help reply for a given surface. */
 export function renderHelp(registry: SlashCommandRegistry, surface: SlashCommandSurface): string {
   const cmds = registry.list(surface)
   if (cmds.length === 0) return 'No slash commands are available on this surface.'
@@ -217,12 +152,6 @@ export function renderHelp(registry: SlashCommandRegistry, surface: SlashCommand
   return lines.join('\n')
 }
 
-/**
- * Register the built-in read-only commands (`/help`, `/tasks`, `/cronjobs`,
- * `/settings`). Surfaces compose this with their own surface-specific
- * metadata-only entries (e.g. `/new`, `/stop`) to get a single source of
- * truth for `/help` and the Telegram menu.
- */
 export function registerBuiltInSlashCommands(registry: SlashCommandRegistry): void {
   registry.register({
     name: 'help',
@@ -252,7 +181,7 @@ export function registerBuiltInSlashCommands(registry: SlashCommandRegistry): vo
       if (!ctx.scheduledTaskStore) return 'Cronjob store is not available on this surface.'
       const jobs = ctx.scheduledTaskStore.list().map((j) => ({
         id: j.id,
-        name: j.name,
+      name: j.name,
         cronExpression: j.schedule,
         enabled: j.enabled,
         nextRunAt: computeNextRunAt(j.schedule),
@@ -269,11 +198,54 @@ export function registerBuiltInSlashCommands(registry: SlashCommandRegistry): vo
     surfaces: ['web', 'telegram'],
     handler: () => formatSettingsReply(),
   })
+
+  registry.register({
+    name: 'thinking',
+    description: 'Show or set the main chat thinking level.',
+  usage: '/thinking <off|minimal|low|medium|high|xhigh>',
+    surfaces: ['web', 'telegram'],
+    handler: (ctx) => handleThinkingCommand(ctx),
+  })
 }
 
-// ---------------------------------------------------------------------------
-// Reply formatters (pure functions, exported for tests)
-// ---------------------------------------------------------------------------
+function handleThinkingCommand(ctx: SlashCommandContext): string {
+  const args = ctx.args.trim().toLowerCase()
+  if (!args) {
+    const current = readConfiguredThinkingLevel() ?? 'off'
+    return `Current thinking level: ${current}\nUsage: /thinking ${SETTINGS_THINKING_LEVELS.join('|')}`
+  }
+
+  const [level, ...rest] = args.split(/\s+/)
+  if (rest.length > 0 || !level) {
+    return `Usage: /thinking ${SETTINGS_THINKING_LEVELS.join('|')}`
+  }
+
+  const normalized = normalizeThinkingLevel(level)
+  if (!normalized) {
+    return `Unknown thinking level: ${level}\nValid levels: ${SETTINGS_THINKING_LEVELS.join(', ')}`
+  }
+
+  writeConfiguredThinkingLevel(normalized)
+  ctx.onThinkingLevelChanged?.(normalized)
+  return `Thinking level set to: ${normalized}`
+}
+
+function readConfiguredThinkingLevel(): SettingsThinkingLevel | undefined {
+  try {
+    const settings = loadConfig<{ thinkingLevel?: string }>('settings.json')
+    return normalizeThinkingLevel(settings.thinkingLevel)
+  } catch {
+    return undefined
+  }
+}
+
+function writeConfiguredThinkingLevel(level: SettingsThinkingLevel): void {
+  const settingsPath = path.join(getConfigDir(), 'settings.json')
+  const settings = loadConfig<Record<string, unknown>>('settings.json')
+  settings.thinkingLevel = level
+  fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8')
+}
+
 
 interface TaskLike {
   id: string

--- a/packages/telegram/src/bot.test.ts
+++ b/packages/telegram/src/bot.test.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type, @typescript-eslint/no-explicit-any */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { AgentCore, ResponseChunk, Database } from '@axiom/core'
 
@@ -34,8 +37,31 @@ vi.mock('grammy', () => {
     _commandHandlers: commandHandlers,
   }))
 
+  // Minimal InlineKeyboard stand-in: enough surface area for our picker
+  // builder (text + row) and for the test to inspect the resulting layout
+  // via the expected `{ inline_keyboard: ... }` shape. Mirrors grammY's
+  // serialization which strips trailing empty rows.
+  class MockInlineKeyboard {
+    private rows: { text: string; callback_data: string }[][] = [[]]
+    text(label: string, callback_data: string): this {
+      this.rows[this.rows.length - 1]!.push({ text: label, callback_data })
+      return this
+    }
+    row(): this {
+      this.rows.push([])
+      return this
+    }
+    get inline_keyboard(): { text: string; callback_data: string }[][] {
+      // Drop trailing empty rows so callers see exactly one row per option.
+      const out = this.rows.slice()
+      while (out.length > 0 && out[out.length - 1]!.length === 0) out.pop()
+      return out
+    }
+  }
+
   return {
     Bot: MockBot,
+    InlineKeyboard: MockInlineKeyboard,
     GrammyError: class GrammyError extends Error {
       error_code: number
       description: string
@@ -252,7 +278,7 @@ describe('TelegramBot', () => {
       expect(msg).toContain('/stop')
       expect(msg).toContain('/tasks')
       expect(msg).toContain('/cronjobs')
-      expect(msg).toContain('/settings')
+      expect(msg).toContain('/model')
       expect(msg).toContain('/thinking')
     })
   })
@@ -273,20 +299,187 @@ describe('TelegramBot', () => {
     })
   })
 
-  describe('/settings command', () => {
-    it('replies with active provider/model summary', async () => {
+  describe('/model and /provider commands', () => {
+    let dataDir: string
+    let previousDataDir: string | undefined
+
+    function writeProviders(providers: unknown): void {
+      fs.mkdirSync(path.join(dataDir, 'config'), { recursive: true })
+      fs.writeFileSync(
+        path.join(dataDir, 'config', 'providers.json'),
+        `${JSON.stringify(providers, null, 2)}\n`,
+        'utf-8',
+      )
+    }
+
+    beforeEach(() => {
+      previousDataDir = process.env.DATA_DIR
+      dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axiom-tg-model-'))
+      process.env.DATA_DIR = dataDir
+      writeProviders({
+        activeProvider: 'p1',
+        activeModel: 'gpt-4o',
+        providers: [
+          {
+            id: 'p1', name: 'OpenAI', type: 'openai-completions', providerType: 'openai',
+            provider: 'openai', baseUrl: '', apiKey: '',
+            defaultModel: 'gpt-4o', enabledModels: ['gpt-4o', 'gpt-4o-mini'],
+          },
+          {
+            id: 'p2', name: 'Anthropic', type: 'anthropic-messages', providerType: 'anthropic',
+            provider: 'anthropic', baseUrl: '', apiKey: '',
+            defaultModel: 'claude-sonnet-4-20250514',
+            enabledModels: ['claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022'],
+          },
+        ],
+      })
+    })
+
+    afterEach(() => {
+      if (previousDataDir === undefined) delete process.env.DATA_DIR
+      else process.env.DATA_DIR = previousDataDir
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    })
+
+    it('does not register a /settings command anymore', () => {
       const bot = new TelegramBot({ agentCore, config: defaultConfig })
       const underlying = bot.getBot() as unknown as MockBotInternals
-      const handler = underlying._commandHandlers.get('settings')!
+      expect(underlying._commandHandlers.has('settings')).toBe(false)
+      expect(underlying._commandHandlers.has('model')).toBe(true)
+      expect(underlying._commandHandlers.has('provider')).toBe(true)
+    })
+
+    it('/model sends an inline keyboard with one button per provider', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._commandHandlers.get('model')!
 
       const ctx = createMockContext()
-      ctx.message = { text: '/settings', message_id: 1 }
+      ctx.message = { text: '/model', message_id: 1 }
       await handler(ctx)
 
       expect(ctx.reply).toHaveBeenCalledTimes(1)
-      const msg = ctx.reply.mock.calls[0][0] as string
-      expect(typeof msg).toBe('string')
-      expect(msg.length).toBeGreaterThan(0)
+      const [text, opts] = ctx.reply.mock.calls[0] as [string, { reply_markup: { inline_keyboard: { text: string; callback_data: string }[][] } }]
+      expect(text).toContain('Choose a provider')
+      const rows = opts.reply_markup.inline_keyboard
+      expect(rows).toHaveLength(2)
+      expect(rows[0]![0]!.text).toMatch(/OpenAI/)
+      expect(rows[1]![0]!.text).toMatch(/Anthropic/)
+      // All callback_data values should fit Telegram's 64-byte limit and use
+      // the picker prefix, not the raw slash command (which contains UUIDs).
+      for (const row of rows) {
+        const cb = row[0]!.callback_data
+        expect(cb.startsWith('pick:')).toBe(true)
+        expect(Buffer.byteLength(cb, 'utf-8')).toBeLessThanOrEqual(64)
+      }
+    })
+
+    it('/provider alias produces the same provider picker', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._commandHandlers.get('provider')!
+
+      const ctx = createMockContext()
+      ctx.message = { text: '/provider', message_id: 1 }
+      await handler(ctx)
+
+      expect(ctx.reply).toHaveBeenCalledTimes(1)
+      const [text] = ctx.reply.mock.calls[0] as [string, unknown]
+      expect(text).toContain('Choose a provider')
+    })
+
+    it('button tap drills down to the model picker (edits the message in place)', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+
+      // Step 1: send /model to get the provider picker + collect tokens
+      const cmdCtx = createMockContext()
+      cmdCtx.message = { text: '/model', message_id: 1 }
+      await underlying._commandHandlers.get('model')!(cmdCtx)
+      const rows = (cmdCtx.reply.mock.calls[0] as [string, { reply_markup: { inline_keyboard: { text: string; callback_data: string }[][] } }])[1].reply_markup.inline_keyboard
+      const openaiCallback = rows[0]![0]!.callback_data
+
+      // Step 2: simulate the callback for the OpenAI button
+      const callbackHandler = underlying._handlers.get('callback_query:data')!
+      const cbCtx = createMockContext({
+        callbackQuery: { data: openaiCallback, message: { message_id: 1 } },
+        answerCallbackQuery: vi.fn().mockResolvedValue(true),
+        editMessageText: vi.fn().mockResolvedValue(true),
+        editMessageReplyMarkup: vi.fn().mockResolvedValue(true),
+      })
+      await callbackHandler(cbCtx as any)
+
+      expect((cbCtx as any).answerCallbackQuery).toHaveBeenCalled()
+      expect((cbCtx as any).editMessageText).toHaveBeenCalledTimes(1)
+      const [editedText, editedOpts] = (cbCtx as any).editMessageText.mock.calls[0] as [string, { reply_markup: { inline_keyboard: { text: string; callback_data: string }[][] } }]
+      expect(editedText).toContain('OpenAI')
+      const modelRows = editedOpts.reply_markup.inline_keyboard
+      // 2 enabled models + 1 back button
+      expect(modelRows).toHaveLength(3)
+      expect(modelRows[0]![0]!.text).toMatch(/gpt-4o/)
+      expect(modelRows[modelRows.length - 1]![0]!.text).toMatch(/back/i)
+    })
+
+    it('selecting a model edits the message with a confirmation and updates providers.json', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const callbackHandler = underlying._handlers.get('callback_query:data')!
+
+      // Step 1: /model → provider picker
+      const ctx1 = createMockContext()
+      ctx1.message = { text: '/model', message_id: 1 }
+      await underlying._commandHandlers.get('model')!(ctx1)
+      const providerRows = (ctx1.reply.mock.calls[0] as [string, { reply_markup: { inline_keyboard: { text: string; callback_data: string }[][] } }])[1].reply_markup.inline_keyboard
+      const anthropicCb = providerRows[1]![0]!.callback_data
+
+      // Step 2: tap Anthropic → model picker (in cb editMessageText)
+      const ctx2 = createMockContext({
+        callbackQuery: { data: anthropicCb, message: { message_id: 1 } },
+        answerCallbackQuery: vi.fn().mockResolvedValue(true),
+        editMessageText: vi.fn().mockResolvedValue(true),
+      })
+      await callbackHandler(ctx2 as any)
+      const modelKeyboard = ((ctx2 as any).editMessageText.mock.calls[0] as [string, { reply_markup: { inline_keyboard: { text: string; callback_data: string }[][] } }])[1]
+      // Find the non-default model button (claude-3-5-sonnet-20241022)
+      const modelRows = modelKeyboard.reply_markup.inline_keyboard
+      const targetRow = modelRows.find((r) => /claude-3-5-sonnet-20241022/.test(r[0]!.text))
+      expect(targetRow).toBeDefined()
+      const modelCb = targetRow![0]!.callback_data
+
+      // Step 3: tap that model → confirmation text, no keyboard
+      const ctx3 = createMockContext({
+        callbackQuery: { data: modelCb, message: { message_id: 1 } },
+        answerCallbackQuery: vi.fn().mockResolvedValue(true),
+        editMessageText: vi.fn().mockResolvedValue(true),
+      })
+      await callbackHandler(ctx3 as any)
+      const [confirmText, confirmOpts] = (ctx3 as any).editMessageText.mock.calls[0] as [string, { reply_markup?: unknown }]
+      expect(confirmText).toContain('Active provider')
+      expect(confirmText).toContain('Anthropic')
+      expect(confirmText).toContain('claude-3-5-sonnet-20241022')
+      expect(confirmOpts.reply_markup).toBeUndefined()
+
+      // providers.json was actually mutated
+      const stored = JSON.parse(fs.readFileSync(path.join(dataDir, 'config', 'providers.json'), 'utf-8'))
+      expect(stored.activeProvider).toBe('p2')
+      expect(stored.activeModel).toBe('claude-3-5-sonnet-20241022')
+    })
+
+    it('expired or unknown picker tokens show an alert and strip the keyboard', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const callbackHandler = underlying._handlers.get('callback_query:data')!
+
+      const ctx = createMockContext({
+        callbackQuery: { data: 'pick:deadbeef', message: { message_id: 1 } },
+        answerCallbackQuery: vi.fn().mockResolvedValue(true),
+        editMessageReplyMarkup: vi.fn().mockResolvedValue(true),
+      })
+      await callbackHandler(ctx as any)
+      expect((ctx as any).answerCallbackQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ show_alert: true }),
+      )
+      expect((ctx as any).editMessageReplyMarkup).toHaveBeenCalled()
     })
   })
 

--- a/packages/telegram/src/bot.test.ts
+++ b/packages/telegram/src/bot.test.ts
@@ -242,7 +242,7 @@ describe('TelegramBot', () => {
       const handler = underlying._commandHandlers.get('help')!
 
       const ctx = createMockContext()
-      ctx.message = { text: '/help' }
+      ctx.message = { text: '/help', message_id: 1 }
       await handler(ctx)
 
       expect(ctx.reply).toHaveBeenCalledTimes(1)
@@ -264,7 +264,7 @@ describe('TelegramBot', () => {
       const handler = underlying._commandHandlers.get('cron')!
 
       const ctx = createMockContext()
-      ctx.message = { text: '/cron' }
+      ctx.message = { text: '/cron', message_id: 1 }
       await handler(ctx)
 
       expect(ctx.reply).toHaveBeenCalledTimes(1)
@@ -280,7 +280,7 @@ describe('TelegramBot', () => {
       const handler = underlying._commandHandlers.get('settings')!
 
       const ctx = createMockContext()
-      ctx.message = { text: '/settings' }
+      ctx.message = { text: '/settings', message_id: 1 }
       await handler(ctx)
 
       expect(ctx.reply).toHaveBeenCalledTimes(1)

--- a/packages/telegram/src/bot.test.ts
+++ b/packages/telegram/src/bot.test.ts
@@ -55,22 +55,26 @@ vi.mock('grammy', () => {
 })
 
 // Mock @axiom/core
-vi.mock('@axiom/core', () => ({
-  loadConfig: vi.fn((filename: string) => {
-    if (filename === 'settings.json') {
-      return { batchingDelayMs: 2500 }
-    }
+vi.mock('@axiom/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@axiom/core')>()
+  return {
+    ...actual,
+    loadConfig: vi.fn((filename: string) => {
+      if (filename === 'settings.json') {
+        return { batchingDelayMs: 2500 }
+      }
 
-    return {
-      enabled: true,
-      botToken: 'test-token-123',
-      adminUserIds: [],
-      pollingMode: true,
-      webhookUrl: '',
-      batchingDelayMs: 2500,
-    }
-  }),
-}))
+      return {
+        enabled: true,
+        botToken: 'test-token-123',
+        adminUserIds: [],
+        pollingMode: true,
+        webhookUrl: '',
+        batchingDelayMs: 2500,
+      }
+    }),
+  }
+})
 
 import { TelegramBot, createTelegramBot, extractReplyContext, buildAgentMessage } from './bot.js'
 import type { TelegramConfig, TelegramChatEvent } from './bot.js'
@@ -216,7 +220,7 @@ describe('TelegramBot', () => {
   })
 
   describe('/start command', () => {
-    it('sends welcome message', async () => {
+    it('sends welcome message that points at /help', async () => {
       const bot = new TelegramBot({ agentCore, config: defaultConfig })
       const underlying = bot.getBot() as unknown as MockBotInternals
       const handler = underlying._commandHandlers.get('start')!
@@ -227,9 +231,48 @@ describe('TelegramBot', () => {
       expect(ctx.reply).toHaveBeenCalledTimes(1)
       const msg = ctx.reply.mock.calls[0][0] as string
       expect(msg).toContain('Welcome to Axiom')
+      expect(msg).toContain('/help')
+    })
+  })
+
+  describe('/help command', () => {
+    it('lists all available slash commands', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._commandHandlers.get('help')!
+
+      const ctx = createMockContext()
+      ctx.message = { text: '/help' }
+      await handler(ctx)
+
+      expect(ctx.reply).toHaveBeenCalledTimes(1)
+      const msg = ctx.reply.mock.calls[0][0] as string
+      expect(msg).toContain('/help')
       expect(msg).toContain('/new')
-      expect(msg).toContain('/start')
       expect(msg).toContain('/stop')
+      expect(msg).toContain('/tasks')
+      expect(msg).toContain('/cronjobs')
+      expect(msg).toContain('/settings')
+    })
+  })
+
+  describe('/settings command', () => {
+    it('replies with active provider/model summary', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._commandHandlers.get('settings')!
+
+      const ctx = createMockContext()
+      ctx.message = { text: '/settings' }
+      await handler(ctx)
+
+      expect(ctx.reply).toHaveBeenCalledTimes(1)
+      const msg = ctx.reply.mock.calls[0][0] as string
+      // /settings reads provider config from disk; in the test env it falls
+      // back to the “no active provider” branch, but the reply is still
+      // produced and human-readable.
+      expect(typeof msg).toBe('string')
+      expect(msg.length).toBeGreaterThan(0)
     })
   })
 

--- a/packages/telegram/src/bot.test.ts
+++ b/packages/telegram/src/bot.test.ts
@@ -268,9 +268,6 @@ describe('TelegramBot', () => {
 
       expect(ctx.reply).toHaveBeenCalledTimes(1)
       const msg = ctx.reply.mock.calls[0][0] as string
-      // /settings reads provider config from disk; in the test env it falls
-      // back to the “no active provider” branch, but the reply is still
-      // produced and human-readable.
       expect(typeof msg).toBe('string')
       expect(msg.length).toBeGreaterThan(0)
     })

--- a/packages/telegram/src/bot.test.ts
+++ b/packages/telegram/src/bot.test.ts
@@ -253,6 +253,23 @@ describe('TelegramBot', () => {
       expect(msg).toContain('/tasks')
       expect(msg).toContain('/cronjobs')
       expect(msg).toContain('/settings')
+      expect(msg).toContain('/thinking')
+    })
+  })
+
+  describe('/cron alias command', () => {
+    it('dispatches through the shared /cronjobs handler', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._commandHandlers.get('cron')!
+
+      const ctx = createMockContext()
+      ctx.message = { text: '/cron' }
+      await handler(ctx)
+
+      expect(ctx.reply).toHaveBeenCalledTimes(1)
+      const msg = ctx.reply.mock.calls[0][0] as string
+      expect(msg).toContain('Cronjob store is not available')
     })
   })
 

--- a/packages/telegram/src/bot.test.ts
+++ b/packages/telegram/src/bot.test.ts
@@ -280,6 +280,54 @@ describe('TelegramBot', () => {
       expect(msg).toContain('/cronjobs')
       expect(msg).toContain('/model')
       expect(msg).toContain('/thinking')
+      expect(msg).toContain('/tts')
+    })
+  })
+
+  describe('/tts command', () => {
+    let dataDir: string
+    let previousDataDir: string | undefined
+
+    beforeEach(() => {
+      previousDataDir = process.env.DATA_DIR
+      dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axiom-tg-voice-'))
+      process.env.DATA_DIR = dataDir
+      fs.mkdirSync(path.join(dataDir, 'config'), { recursive: true })
+      fs.writeFileSync(path.join(dataDir, 'config', 'telegram.json'), JSON.stringify({
+        enabled: true,
+        botToken: 'test-token-123',
+        adminUserIds: [],
+        pollingMode: true,
+        webhookUrl: '',
+        batchingDelayMs: 2500,
+        sendVoiceReply: false,
+      }, null, 2) + '\n', 'utf-8')
+      vi.mocked(loadConfig).mockImplementation((filename: string) => {
+        if (filename === 'telegram.json') {
+          return JSON.parse(fs.readFileSync(path.join(dataDir, 'config', 'telegram.json'), 'utf-8'))
+        }
+        return { batchingDelayMs: 2500 }
+      })
+    })
+
+    afterEach(() => {
+      if (previousDataDir === undefined) delete process.env.DATA_DIR
+      else process.env.DATA_DIR = previousDataDir
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    })
+
+    it('toggles automatic Telegram voice replies without changing global TTS', async () => {
+      const bot = new TelegramBot({ agentCore, config: defaultConfig })
+      const underlying = bot.getBot() as unknown as MockBotInternals
+      const handler = underlying._commandHandlers.get('tts')!
+
+      const ctx = createMockContext()
+      ctx.message = { text: '/tts', message_id: 1 }
+      await handler(ctx)
+
+      expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining('enabled'))
+      const saved = JSON.parse(fs.readFileSync(path.join(dataDir, 'config', 'telegram.json'), 'utf-8'))
+      expect(saved.sendVoiceReply).toBe(true)
     })
   })
 

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -1,8 +1,14 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { Bot, GrammyError, HttpError, InputFile } from 'grammy'
+import crypto from 'node:crypto'
+import { Bot, GrammyError, HttpError, InlineKeyboard, InputFile } from 'grammy'
 import type { Context } from 'grammy'
-import type { AgentCore, Database, SlashCommandRegistry } from '@axiom/core'
+import type {
+  AgentCore,
+  Database,
+  SlashCommandRegistry,
+  SlashCommandPicker,
+} from '@axiom/core'
 import {
   loadConfig,
   saveUpload,
@@ -14,10 +20,21 @@ import {
   synthesizeTts,
   SlashCommandRegistry as SlashCommandRegistryCtor,
   registerBuiltInSlashCommands,
+  isSlashCommandPicker,
   TaskStore,
   ScheduledTaskStore,
 } from '@axiom/core'
 import type { UploadDescriptor } from '@axiom/core'
+
+/**
+ * Inline-keyboard callbacks live under this prefix. Telegram limits
+ * `callback_data` to 64 bytes, so we can't ship the full slash command in
+ * the payload — instead we generate a short opaque token, stash the
+ * verbatim slash command in `pickerTokenStore`, and resolve it back on
+ * the callback. Tokens auto-expire (see `PICKER_TOKEN_TTL_MS`).
+ */
+const PICKER_CALLBACK_PREFIX = 'pick:'
+const PICKER_TOKEN_TTL_MS = 10 * 60 * 1000 // 10 minutes
 
 /**
  * Telegram config stored in /data/config/telegram.json
@@ -144,6 +161,17 @@ export function buildAgentMessage(text: string, replyContext?: string): string {
   return `<reply-context>${replyContext}</reply-context>\n${text}`
 }
 const STOP_COMMANDS = new Set(['/stop', '/kill'])
+
+/**
+ * Render a picker's title + description as the message body. The buttons
+ * themselves live in `reply_markup`, so this only handles the lead text.
+ */
+function formatPickerMessage(picker: SlashCommandPicker): string {
+  const lines: string[] = []
+  if (picker.title) lines.push(picker.title)
+  if (picker.description) lines.push(picker.description)
+  return lines.join('\n') || 'Choose an option:'
+}
 
 /**
  * Convert standard Markdown to Telegram-compatible HTML.
@@ -327,6 +355,13 @@ export class TelegramBot {
   private slashRegistry: SlashCommandRegistry
   private taskStore: TaskStore | null
   private scheduledTaskStore: ScheduledTaskStore | null
+  /**
+   * Map of `pick:<token>` callback-data tokens to the verbatim slash command
+   * they should re-dispatch when clicked. Bounded by `PICKER_TOKEN_TTL_MS`;
+   * pruned opportunistically before each new picker is created so the map
+   * doesn't grow unbounded for chats that abandon pickers mid-flow.
+   */
+  private pickerTokenStore = new Map<string, { command: string; expiresAt: number }>()
 
   constructor(options: TelegramBotOptions) {
     this.agentCore = options.agentCore
@@ -446,14 +481,23 @@ export class TelegramBot {
     this.bot.command('cron', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'cron')
     })
-    this.bot.command('settings', async (ctx) => {
-      await this.handleRegistryCommand(ctx, 'settings')
-    })
     this.bot.command('thinking', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'thinking')
     })
     this.bot.command('model', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'model')
+    })
+    this.bot.command('provider', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'provider')
+    })
+
+    // Inline-keyboard button taps from picker messages (e.g. /model).
+    // The original message is edited in place to either show the next
+    // picker step or the final text confirmation.
+    this.bot.on('callback_query:data', async (ctx) => {
+      const data = ctx.callbackQuery.data
+      if (!data.startsWith(PICKER_CALLBACK_PREFIX)) return
+      await this.handlePickerCallback(ctx, data.slice(PICKER_CALLBACK_PREFIX.length))
     })
 
     this.bot.on('message:text', async (ctx) => {
@@ -1092,6 +1136,10 @@ export class TelegramBot {
       onThinkingLevelChanged: (level) => this.agentCore.setThinkingLevel(level),
     })
     if (result.kind === 'handled') {
+      if (isSlashCommandPicker(result.reply)) {
+        await this.sendPicker(ctx, result.reply)
+        return
+      }
       if (result.reply) await ctx.reply(result.reply)
       return
     }
@@ -1104,6 +1152,127 @@ export class TelegramBot {
       return
     }
     await ctx.reply(`Cannot handle /${name}.`)
+  }
+
+  /**
+   * Render a slash-command picker as an inline keyboard. Each option becomes
+   * one button row; clicking re-dispatches its verbatim slash command via
+   * `handlePickerCallback`.
+   */
+  private async sendPicker(ctx: Context, picker: SlashCommandPicker): Promise<void> {
+    const text = formatPickerMessage(picker)
+    const keyboard = this.buildPickerKeyboard(picker)
+    await ctx.reply(text, { reply_markup: keyboard })
+  }
+
+  /**
+   * Build a fresh inline keyboard for `picker`, registering each option's
+   * slash command under a short token in `pickerTokenStore`.
+   */
+  private buildPickerKeyboard(picker: SlashCommandPicker): InlineKeyboard {
+    this.prunePickerTokens()
+    const keyboard = new InlineKeyboard()
+    for (const opt of picker.options) {
+      const token = this.registerPickerToken(opt.command)
+      const label = opt.badge ? `${opt.label} \u2022 ${opt.badge}` : opt.label
+      keyboard.text(label, `${PICKER_CALLBACK_PREFIX}${token}`).row()
+    }
+    return keyboard
+  }
+
+  private registerPickerToken(command: string): string {
+    // 8 hex chars = 4 bytes of entropy. Plenty for short-lived per-user tokens
+    // and well under Telegram's 64-byte callback-data limit.
+    let token = crypto.randomBytes(4).toString('hex')
+    // Vanishingly unlikely collision, but be robust anyway.
+    while (this.pickerTokenStore.has(token)) {
+      token = crypto.randomBytes(4).toString('hex')
+    }
+    this.pickerTokenStore.set(token, { command, expiresAt: Date.now() + PICKER_TOKEN_TTL_MS })
+    return token
+  }
+
+  private prunePickerTokens(): void {
+    const now = Date.now()
+    for (const [token, entry] of this.pickerTokenStore) {
+      if (entry.expiresAt <= now) this.pickerTokenStore.delete(token)
+    }
+  }
+
+  /**
+   * Resolve a `pick:<token>` callback into a re-dispatch of the original
+   * slash command. Edits the source message in place to show the next
+   * picker (or final text), so the chat doesn't accumulate stale keyboards.
+   */
+  private async handlePickerCallback(ctx: Context, token: string): Promise<void> {
+    const entry = this.pickerTokenStore.get(token)
+    if (!entry || entry.expiresAt <= Date.now()) {
+      await ctx.answerCallbackQuery({ text: 'This menu has expired. Run the command again.', show_alert: true })
+      // Best-effort: strip the keyboard so the user can't re-tap stale buttons.
+      try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }) } catch { /* ignore */ }
+      return
+    }
+
+    if (!await this.checkAuthorized(ctx)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.', show_alert: true })
+      return
+    }
+
+    // One-shot: each token is consumed on first use. The next picker step
+    // generates a fresh batch of tokens.
+    this.pickerTokenStore.delete(token)
+    await ctx.answerCallbackQuery()
+
+    const userId = this.resolveUserId(ctx)
+    const result = await this.slashRegistry.dispatch(entry.command, {
+      surface: 'telegram',
+      userId,
+      registry: this.slashRegistry,
+      db: this.db ?? undefined,
+      taskStore: this.taskStore ?? undefined,
+      scheduledTaskStore: this.scheduledTaskStore ?? undefined,
+      onThinkingLevelChanged: (level) => this.agentCore.setThinkingLevel(level),
+    })
+
+    if (result.kind !== 'handled') {
+      await this.editPickerMessage(ctx, `\u26A0\uFE0F Could not handle that selection.`)
+      return
+    }
+
+    if (isSlashCommandPicker(result.reply)) {
+      // Next step — swap the message in place with a fresh keyboard.
+      await this.editPickerMessage(
+        ctx,
+        formatPickerMessage(result.reply),
+        this.buildPickerKeyboard(result.reply),
+      )
+      return
+    }
+
+    // Final text reply (confirmation, error, no-op). Drop the keyboard.
+    await this.editPickerMessage(ctx, result.reply ?? '\u2705 Done.')
+  }
+
+  /**
+   * Edit the source message of a callback query, falling back to a new
+   * message if Telegram refuses (e.g. message too old, content unchanged).
+   */
+  private async editPickerMessage(
+    ctx: Context,
+    text: string,
+    keyboard?: InlineKeyboard,
+  ): Promise<void> {
+    try {
+      await ctx.editMessageText(text, { reply_markup: keyboard })
+    } catch (err) {
+      // "message is not modified" is harmless and shouldn't be a fallback trigger.
+      if (err instanceof GrammyError && /message is not modified/i.test(err.description)) return
+      try {
+        await ctx.reply(text, keyboard ? { reply_markup: keyboard } : undefined)
+      } catch (replyErr) {
+        console.error('Failed to deliver picker reply:', replyErr)
+      }
+    }
   }
 
   private async handleKillSwitch(ctx: Context): Promise<void> {

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -1429,7 +1429,7 @@ export class TelegramBot {
    * Used for proactive task result notifications.
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
-  // fallow-ignore-next-line unused-class-members
+  // fallow-ignore-next-line unused-class-member
   async sendTaskNotification(chatId: string | number, html: string): Promise<boolean> {
     const parts = splitMessage(html)
     const plainFull = telegramHtmlToPlainText(html)
@@ -1458,7 +1458,7 @@ export class TelegramBot {
    * Returns null if no linked & approved Telegram user exists.
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
-  // fallow-ignore-next-line unused-class-members
+  // fallow-ignore-next-line unused-class-member
   getTelegramChatIdForUser(userId: number): string | null {
     if (!this.db) return null
 
@@ -1475,7 +1475,7 @@ export class TelegramBot {
    * Does NOT sync back to web chat (intended for task injection responses).
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
-  // fallow-ignore-next-line unused-class-members
+  // fallow-ignore-next-line unused-class-member
   async sendFormattedMessage(chatId: string | number, markdown: string): Promise<boolean> {
     const parts = splitMessage(markdown)
 

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -1429,7 +1429,6 @@ export class TelegramBot {
    * Used for proactive task result notifications.
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
-  // fallow-ignore-next-line unused-class-member
   async sendTaskNotification(chatId: string | number, html: string): Promise<boolean> {
     const parts = splitMessage(html)
     const plainFull = telegramHtmlToPlainText(html)
@@ -1458,7 +1457,6 @@ export class TelegramBot {
    * Returns null if no linked & approved Telegram user exists.
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
-  // fallow-ignore-next-line unused-class-member
   getTelegramChatIdForUser(userId: number): string | null {
     if (!this.db) return null
 
@@ -1475,7 +1473,6 @@ export class TelegramBot {
    * Does NOT sync back to web chat (intended for task injection responses).
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
-  // fallow-ignore-next-line unused-class-member
   async sendFormattedMessage(chatId: string | number, markdown: string): Promise<boolean> {
     const parts = splitMessage(markdown)
 
@@ -1544,7 +1541,7 @@ function sleep(ms: number): Promise<void> {
  * `/stop`, `/kill`) so they appear in `/help` and the Telegram command menu
  * even though their behaviour stays inline in `setupHandlers()`.
  */
-export function buildTelegramSlashCommandRegistry(): SlashCommandRegistry {
+function buildTelegramSlashCommandRegistry(): SlashCommandRegistry {
   const registry = new SlashCommandRegistryCtor()
   registerBuiltInSlashCommands(registry)
   registry.register({

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -1429,6 +1429,7 @@ export class TelegramBot {
    * Used for proactive task result notifications.
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
+  // fallow-ignore-next-line unused-class-members
   async sendTaskNotification(chatId: string | number, html: string): Promise<boolean> {
     const parts = splitMessage(html)
     const plainFull = telegramHtmlToPlainText(html)
@@ -1457,6 +1458,7 @@ export class TelegramBot {
    * Returns null if no linked & approved Telegram user exists.
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
+  // fallow-ignore-next-line unused-class-members
   getTelegramChatIdForUser(userId: number): string | null {
     if (!this.db) return null
 
@@ -1473,6 +1475,7 @@ export class TelegramBot {
    * Does NOT sync back to web chat (intended for task injection responses).
    */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
+  // fallow-ignore-next-line unused-class-members
   async sendFormattedMessage(chatId: string | number, markdown: string): Promise<boolean> {
     const parts = splitMessage(markdown)
 

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -443,6 +443,9 @@ export class TelegramBot {
     this.bot.command('cronjobs', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'cronjobs')
     })
+    this.bot.command('cron', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'cron')
+    })
     this.bot.command('settings', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'settings')
     })

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -2,8 +2,21 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { Bot, GrammyError, HttpError, InputFile } from 'grammy'
 import type { Context } from 'grammy'
-import type { AgentCore, Database } from '@axiom/core'
-import { loadConfig, saveUpload, serializeUploadsMetadata, parseUploadsMetadata, loadSttSettings, transcribeAudio, extractUploadsFromToolResult, synthesizeTts } from '@axiom/core'
+import type { AgentCore, Database, SlashCommandRegistry } from '@axiom/core'
+import {
+  loadConfig,
+  saveUpload,
+  serializeUploadsMetadata,
+  parseUploadsMetadata,
+  loadSttSettings,
+  transcribeAudio,
+  extractUploadsFromToolResult,
+  synthesizeTts,
+  SlashCommandRegistry as SlashCommandRegistryCtor,
+  registerBuiltInSlashCommands,
+  TaskStore,
+  ScheduledTaskStore,
+} from '@axiom/core'
 import type { UploadDescriptor } from '@axiom/core'
 
 /**
@@ -326,6 +339,9 @@ export class TelegramBot {
   private chatStates = new Map<string, ChatState>()
   private onQueueDepthChanged?: (queueDepth: number) => void
   private onChatEvent?: (event: TelegramChatEvent) => void
+  private slashRegistry: SlashCommandRegistry
+  private taskStore: TaskStore | null
+  private scheduledTaskStore: ScheduledTaskStore | null
 
   constructor(options: TelegramBotOptions) {
     this.agentCore = options.agentCore
@@ -333,6 +349,9 @@ export class TelegramBot {
     this.config = options.config ?? loadTelegramRuntimeConfig()
     this.onQueueDepthChanged = options.onQueueDepthChanged
     this.onChatEvent = options.onChatEvent
+    this.slashRegistry = buildTelegramSlashCommandRegistry()
+    this.taskStore = this.db ? new TaskStore(this.db) : null
+    this.scheduledTaskStore = this.db ? new ScheduledTaskStore(this.db) : null
 
     if (!this.config.botToken) {
       throw new Error(
@@ -400,11 +419,7 @@ export class TelegramBot {
       const welcomeText = [
         '👋 *Welcome to Axiom!*',
         '',
-        'I\'m your AI assistant. You can chat with me directly or use these commands:',
-        '',
-        '`/new` — Start a fresh conversation (summarizes & resets current session)',
-        '`/start` — Show this welcome message',
-        '`/stop` — Abort the current task and clear queued work',
+        'I\'m your AI assistant. You can chat with me directly or type /help to see all available commands.',
         '',
         'Just send me a message to get started!',
       ].join('\n')
@@ -438,6 +453,23 @@ export class TelegramBot {
 
     this.bot.command('kill', async (ctx) => {
       await this.handleKillSwitch(ctx)
+    })
+
+    // Read-only commands routed through the shared slash-command registry.
+    this.bot.command('help', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'help')
+    })
+    this.bot.command('tasks', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'tasks')
+    })
+    this.bot.command('cronjobs', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'cronjobs')
+    })
+    this.bot.command('settings', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'settings')
+    })
+    this.bot.command('model', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'model')
     })
 
     this.bot.on('message:text', async (ctx) => {
@@ -1114,6 +1146,40 @@ export class TelegramBot {
     }
   }
 
+  /**
+   * Dispatch a typed slash command through the shared registry and reply with
+   * its rendered markdown text. Used for read-only commands (/help, /tasks,
+   * /cronjobs, /settings, /model).
+   */
+  private async handleRegistryCommand(ctx: Context, name: string): Promise<void> {
+    if (!await this.checkAuthorized(ctx)) return
+    const text = ctx.message?.text ?? `/${name}`
+    const userId = this.resolveUserId(ctx)
+    const result = await this.slashRegistry.dispatch(text, {
+      surface: 'telegram',
+      userId,
+      registry: this.slashRegistry,
+      db: this.db ?? undefined,
+      taskStore: this.taskStore ?? undefined,
+      scheduledTaskStore: this.scheduledTaskStore ?? undefined,
+    })
+    if (result.kind === 'handled') {
+      if (result.reply) await ctx.reply(result.reply)
+      return
+    }
+    if (result.kind === 'not_found') {
+      await ctx.reply(`Unknown command: /${result.name}. Try /help.`)
+      return
+    }
+    if (result.kind === 'wrong_surface') {
+      await ctx.reply(`/${result.command.name} is not available on Telegram.`)
+      return
+    }
+    // 'external' or 'no_command' should not happen here since we route only
+    // registered commands, but fall back gracefully.
+    await ctx.reply(`Cannot handle /${name}.`)
+  }
+
   private async handleKillSwitch(ctx: Context): Promise<void> {
     const chatKey = getChatKey(ctx)
     const state = this.getOrCreateChatState(chatKey)
@@ -1250,6 +1316,20 @@ export class TelegramBot {
       // Verify the bot token by fetching bot info
       const me = await this.bot.api.getMe()
       console.log(`✅ Telegram bot connected: @${me.username} (${me.first_name})`)
+
+      // Publish the slash-command menu to Telegram so users see autocomplete
+      // suggestions. Telegram limits each command name to 1–32 chars and the
+      // total list to 100 entries, with a description of up to 256 chars
+      // (BotCommand). Failures are non-fatal — the bot still works without
+      // the menu.
+      try {
+        const menu = this.slashRegistry
+          .list('telegram')
+          .map((c) => ({ command: c.name, description: c.description.slice(0, 256) }))
+        if (menu.length > 0) await this.bot.api.setMyCommands(menu)
+      } catch (err) {
+        console.warn('[telegram] setMyCommands failed (menu may be missing):', (err as Error).message)
+      }
 
       // Start polling
       this.running = true
@@ -1456,4 +1536,32 @@ export function createTelegramBot(
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Build the slash-command registry used by the Telegram surface.
+ * Adds metadata-only entries for surface-owned commands (`/start`, `/new`,
+ * `/stop`, `/kill`) so they appear in `/help` and the Telegram command menu
+ * even though their behaviour stays inline in `setupHandlers()`.
+ */
+export function buildTelegramSlashCommandRegistry(): SlashCommandRegistry {
+  const registry = new SlashCommandRegistryCtor()
+  registerBuiltInSlashCommands(registry)
+  registry.register({
+    name: 'start',
+    description: 'Welcome message and bot introduction.',
+    surfaces: ['telegram'],
+  })
+  registry.register({
+    name: 'new',
+    description: 'Summarize the current session and start a fresh conversation.',
+    surfaces: ['web', 'telegram'],
+  })
+  registry.register({
+    name: 'stop',
+    aliases: ['kill'],
+    description: 'Abort the current agent turn and clear queued work.',
+    surfaces: ['web', 'telegram'],
+  })
+  return registry
 }

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -58,11 +58,6 @@ export interface TelegramChatEvent {
   senderName?: string
   /** Uploaded file attached to the current assistant turn (for type='attachment') */
   attachment?: UploadDescriptor
-  /**
-   * Excerpt of the message the user replied to in Telegram (truncated to 500 chars).
-   * Forwarded to the web UI so it can render a quote bubble above the user
-   * message. Absent for non-reply messages.
-   */
   replyContext?: string
 }
 
@@ -92,16 +87,6 @@ interface QueuedMessage {
   ctx: Context
   text: string
   attachments?: UploadDescriptor[]
-  /**
-   * Plain-text excerpt of the message the user replied to (`reply_to_message`),
-   * already truncated to REPLY_CONTEXT_MAX_LENGTH. Present only when the incoming
-   * Telegram update carried a `reply_to_message` with extractable text/caption.
-   * Used to:
-   *   1. wrap the agent-facing prompt with `<reply-context>…</reply-context>`,
-   *   2. persist alongside the user's message in `chat_messages.metadata` so the
-   *      web UI can render a quote bubble on reload,
-   *   3. ship to live web clients via the `user_message` chat event.
-   */
   replyContext?: string
 }
 
@@ -392,9 +377,6 @@ export class TelegramBot {
     this.onQueueDepthChanged?.(this.getQueueDepth())
   }
 
-  /**
-   * Total queue depth across all chats, including pending batches and active work.
-   */
   getQueueDepth(): number {
     let total = 0
 
@@ -407,9 +389,6 @@ export class TelegramBot {
     return total
   }
 
-  /**
-   * Set up command and message handlers
-   */
   private setupHandlers(): void {
     // /start command - welcome message
     this.bot.command('start', async (ctx) => {
@@ -455,7 +434,6 @@ export class TelegramBot {
       await this.handleKillSwitch(ctx)
     })
 
-    // Read-only commands routed through the shared slash-command registry.
     this.bot.command('help', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'help')
     })
@@ -467,6 +445,9 @@ export class TelegramBot {
     })
     this.bot.command('settings', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'settings')
+    })
+    this.bot.command('thinking', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'thinking')
     })
     this.bot.command('model', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'model')
@@ -489,10 +470,6 @@ export class TelegramBot {
     })
   }
 
-  /**
-   * Ensure a telegram user record exists in the database.
-   * Returns the row or null if no db is configured.
-   */
   private ensureTelegramUser(ctx: Context): TelegramUserRow | null {
     if (!this.db || !ctx.from) return null
 
@@ -533,9 +510,6 @@ export class TelegramBot {
     ).get(result.lastInsertRowid) as TelegramUserRow
   }
 
-  /**
-   * Check if an avatar file exists for a given telegram user.
-   */
   private hasAvatarFile(telegramId: string): boolean {
     const avatarDir = path.join(process.env.DATA_DIR ?? '/data', 'avatars')
     try {
@@ -546,9 +520,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Fetch a user's Telegram profile photo and save it locally.
-   */
   private async fetchAndSaveAvatar(telegramId: number): Promise<void> {
     try {
       const photos = await this.bot.api.getUserProfilePhotos(telegramId, { limit: 1 })
@@ -579,10 +550,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Check if a telegram user is authorized. If not, sends a status message.
-   * Returns true if the user may proceed.
-   */
   private async checkAuthorized(ctx: Context): Promise<boolean> {
     if (!this.db) return true // No db = no access control
 
@@ -600,11 +567,6 @@ export class TelegramBot {
     return false
   }
 
-  /**
-   * Resolve the user ID for session management.
-   * If the telegram user is linked to an Axiom user, use that user's ID
-   * in the same format as the web backend (plain string number).
-   */
   private resolveUserId(ctx: Context): string {
     if (!this.db || !ctx.from) return getUserId(ctx)
 
@@ -620,10 +582,6 @@ export class TelegramBot {
     return getUserId(ctx)
   }
 
-  /**
-   * Resolve the numeric Axiom user ID for a Telegram user.
-   * Returns null if unlinked.
-   */
   private resolveNumericUserId(ctx: Context): number | null {
     if (!this.db || !ctx.from) return null
 
@@ -635,9 +593,6 @@ export class TelegramBot {
     return row?.user_id ?? null
   }
 
-  /**
-   * Get a display name for the Telegram user.
-   */
   private getSenderName(ctx: Context): string {
     const from = ctx.from
     if (!from) return 'Unknown'
@@ -645,9 +600,6 @@ export class TelegramBot {
     return [from.first_name, from.last_name].filter(Boolean).join(' ') || 'Unknown'
   }
 
-  /**
-   * Handle an incoming text message
-   */
   private async handleMessage(ctx: Context): Promise<void> {
     const text = ctx.message?.text
     if (!text) return
@@ -735,22 +687,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Synthesize the assistant's text response via the configured TTS provider
-   * and upload it as a Telegram voice/audio message. No-op when the
-   * Telegram-side `sendVoiceReply` toggle is off. Errors propagate so the
-   * caller can log them — the text reply has already been sent.
-   *
-   * Provider is whatever `settings.tts.provider` says (OpenAI, Mistral, or
-   * Deepgram). The toggle lives in `telegram.json` because it controls a
-   * Telegram delivery channel, not synthesis behavior; the synthesis config
-   * (provider/voice/format) stays under `settings.tts`.
-   *
-   * Telegram requires OGG/Opus for the native voice-bubble UI; any other
-   * audio format falls back to `sendAudio` (regular file player). Deepgram
-   * users get the voice bubble by picking `opus` encoding; OpenAI/Mistral
-   * default to `mp3` so they show as a regular audio attachment.
-   */
   private async maybeSendVoiceReply(chatId: string | number, text: string): Promise<void> {
     const telegramConfig = loadConfig<{ sendVoiceReply?: boolean }>('telegram.json')
     if (!telegramConfig.sendVoiceReply) return
@@ -951,10 +887,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Resolve the username from the users table for a linked Telegram user.
-   * Returns null if unlinked or not found.
-   */
   private resolveUsername(ctx: Context): string | null {
     if (!this.db || !ctx.from) return null
 
@@ -968,9 +900,6 @@ export class TelegramBot {
     return row?.username ?? null
   }
 
-  /**
-   * Check if this is a DM (private) chat as opposed to a group chat.
-   */
   private isDMChat(ctx: Context): boolean {
     return ctx.chat?.type === 'private'
   }
@@ -1146,11 +1075,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Dispatch a typed slash command through the shared registry and reply with
-   * its rendered markdown text. Used for read-only commands (/help, /tasks,
-   * /cronjobs, /settings, /model).
-   */
   private async handleRegistryCommand(ctx: Context, name: string): Promise<void> {
     if (!await this.checkAuthorized(ctx)) return
     const text = ctx.message?.text ?? `/${name}`
@@ -1162,6 +1086,7 @@ export class TelegramBot {
       db: this.db ?? undefined,
       taskStore: this.taskStore ?? undefined,
       scheduledTaskStore: this.scheduledTaskStore ?? undefined,
+      onThinkingLevelChanged: (level) => this.agentCore.setThinkingLevel(level),
     })
     if (result.kind === 'handled') {
       if (result.reply) await ctx.reply(result.reply)
@@ -1175,8 +1100,6 @@ export class TelegramBot {
       await ctx.reply(`/${result.command.name} is not available on Telegram.`)
       return
     }
-    // 'external' or 'no_command' should not happen here since we route only
-    // registered commands, but fall back gracefully.
     await ctx.reply(`Cannot handle /${name}.`)
   }
 
@@ -1213,9 +1136,6 @@ export class TelegramBot {
     this.cleanupChatState(chatKey)
   }
 
-  /**
-   * Send a potentially long message, splitting if necessary
-   */
   private async sendLongMessage(ctx: Context, text: string): Promise<void> {
     const parts = splitMessage(text)
 
@@ -1224,10 +1144,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Send a message with error handling for Telegram API issues.
-   * Attempts to send as HTML (converted from Markdown) first, then falls back to plain text.
-   */
   private async safeSendMessage(ctx: Context, text: string, retries = 2): Promise<void> {
     // Try sending with HTML formatting first
     const htmlText = markdownToTelegramHtml(text)
@@ -1283,9 +1199,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Set up global error handler for the bot
-   */
   private setupErrorHandler(): void {
     this.bot.catch((err) => {
       const ctx = err.ctx
@@ -1303,9 +1216,6 @@ export class TelegramBot {
     })
   }
 
-  /**
-   * Start the bot in polling mode
-   */
   async start(): Promise<void> {
     if (this.running) {
       console.warn('Telegram bot is already running')
@@ -1317,11 +1227,6 @@ export class TelegramBot {
       const me = await this.bot.api.getMe()
       console.log(`✅ Telegram bot connected: @${me.username} (${me.first_name})`)
 
-      // Publish the slash-command menu to Telegram so users see autocomplete
-      // suggestions. Telegram limits each command name to 1–32 chars and the
-      // total list to 100 entries, with a description of up to 256 chars
-      // (BotCommand). Failures are non-fatal — the bot still works without
-      // the menu.
       try {
         const menu = this.slashRegistry
           .list('telegram')
@@ -1348,9 +1253,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Stop the bot gracefully
-   */
   async stop(): Promise<void> {
     if (!this.running) return
 
@@ -1364,9 +1266,6 @@ export class TelegramBot {
     console.log('🛑 Telegram bot stopped')
   }
 
-  /**
-   * Check if the bot is currently running
-   */
   isRunning(): boolean {
     return this.running
   }
@@ -1407,10 +1306,6 @@ export class TelegramBot {
     })
   }
 
-  /**
-   * Send a message directly to a Telegram chat by chat ID.
-   * Used by the web backend for admin-triggered approval/rejection notifications.
-   */
   // fallow-ignore-next-line unused-class-member
   async sendDirectMessage(chatId: string | number, text: string): Promise<boolean> {
     try {
@@ -1423,11 +1318,6 @@ export class TelegramBot {
     }
   }
 
-  /**
-   * Send a task notification to a Telegram chat with HTML formatting.
-   * Automatically splits long messages to stay within Telegram's 4096 char limit.
-   * Used for proactive task result notifications.
-   */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
   // fallow-ignore-next-line unused-class-member
   async sendTaskNotification(chatId: string | number, html: string): Promise<boolean> {
@@ -1453,10 +1343,6 @@ export class TelegramBot {
     return true
   }
 
-  /**
-   * Get the Telegram chat ID for a given Axiom user ID.
-   * Returns null if no linked & approved Telegram user exists.
-   */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
   // fallow-ignore-next-line unused-class-member
   getTelegramChatIdForUser(userId: number): string | null {
@@ -1469,11 +1355,6 @@ export class TelegramBot {
     return row?.telegram_id ?? null
   }
 
-  /**
-   * Send a Markdown-formatted message to a Telegram chat.
-   * Converts Markdown to Telegram HTML and sends with fallback to plain text.
-   * Does NOT sync back to web chat (intended for task injection responses).
-   */
   // Public cross-workspace API used by web-backend; Fallow cannot see this in clean CI before workspace dist files exist.
   // fallow-ignore-next-line unused-class-member
   async sendFormattedMessage(chatId: string | number, markdown: string): Promise<boolean> {
@@ -1496,9 +1377,6 @@ export class TelegramBot {
     return true
   }
 
-  /**
-   * Get the underlying grammy Bot instance (for advanced usage)
-   */
   getBot(): Bot {
     return this.bot
   }
@@ -1538,12 +1416,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-/**
- * Build the slash-command registry used by the Telegram surface.
- * Adds metadata-only entries for surface-owned commands (`/start`, `/new`,
- * `/stop`, `/kill`) so they appear in `/help` and the Telegram command menu
- * even though their behaviour stays inline in `setupHandlers()`.
- */
 function buildTelegramSlashCommandRegistry(): SlashCommandRegistry {
   const registry = new SlashCommandRegistryCtor()
   registerBuiltInSlashCommands(registry)

--- a/packages/telegram/src/bot.ts
+++ b/packages/telegram/src/bot.ts
@@ -11,6 +11,7 @@ import type {
 } from '@axiom/core'
 import {
   loadConfig,
+  getConfigDir,
   saveUpload,
   serializeUploadsMetadata,
   parseUploadsMetadata,
@@ -46,6 +47,7 @@ export interface TelegramConfig {
   pollingMode: boolean
   webhookUrl: string
   batchingDelayMs: number
+  sendVoiceReply?: boolean
 }
 
 /**
@@ -307,7 +309,7 @@ function getChatKey(ctx: Context): string {
 }
 
 function isHandledCommand(text: string): boolean {
-  return /^\/(start|new|stop|kill)(?:@[\w_]+)?\b/i.test(text.trim())
+  return /^\/(start|new|stop|kill|tts|voice)(?:@[\w_]+)?\b/i.test(text.trim())
 }
 
 function normalizeCommand(text: string): string {
@@ -489,6 +491,12 @@ export class TelegramBot {
     })
     this.bot.command('provider', async (ctx) => {
       await this.handleRegistryCommand(ctx, 'provider')
+    })
+    this.bot.command('tts', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'tts')
+    })
+    this.bot.command('voice', async (ctx) => {
+      await this.handleRegistryCommand(ctx, 'voice')
     })
 
     // Inline-keyboard button taps from picker messages (e.g. /model).
@@ -1607,5 +1615,42 @@ function buildTelegramSlashCommandRegistry(): SlashCommandRegistry {
     description: 'Abort the current agent turn and clear queued work.',
     surfaces: ['web', 'telegram'],
   })
+  registry.register({
+    name: 'tts',
+    aliases: ['voice'],
+    description: 'Toggle automatic Telegram voice replies.',
+    surfaces: ['telegram'],
+    handler: (ctx) => handleTelegramVoiceCommand(ctx.args),
+  })
   return registry
+}
+
+function handleTelegramVoiceCommand(args: string): string {
+  const config = loadConfig<Record<string, unknown>>('telegram.json')
+  const current = config.sendVoiceReply === true
+  const arg = args.trim().toLowerCase()
+
+  if (arg === 'status') {
+    return `🔊 Telegram voice replies are ${current ? 'enabled' : 'disabled'}. Global TTS settings are unchanged.`
+  }
+
+  let next: boolean
+  if (!arg) {
+    next = !current
+  } else if (['on', 'enable', 'enabled', 'true', '1', 'yes'].includes(arg)) {
+    next = true
+  } else if (['off', 'disable', 'disabled', 'false', '0', 'no'].includes(arg)) {
+    next = false
+  } else {
+    return 'Usage: /tts [on|off|status]'
+  }
+
+  const nextConfig = { ...config, sendVoiceReply: next }
+  const filePath = path.join(getConfigDir(), 'telegram.json')
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify(nextConfig, null, 2) + '\n', 'utf-8')
+
+  return next
+    ? '🔊 Telegram voice replies enabled. Text replies will still be sent first.'
+    : '🔇 Telegram voice replies disabled. Global TTS settings are unchanged.'
 }

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -1114,7 +1114,10 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
 
       const activeModelId = getActiveModelId()
       const model = buildModel(provider, activeModelId ?? undefined)
-      const apiKey = await getApiKeyForProvider(provider)
+      const apiKey = await getApiKeyForProvider(provider).catch((err) => {
+        logger.error('[axiom] Failed to resolve active provider API key; chat may be unavailable until provider auth is fixed, but Telegram commands will still start:', err)
+        return provider.apiKey || 'no-key'
+      })
       const fallbackProvider = getFallbackProvider()
 
       providerManager = new ProviderManager(provider, fallbackProvider)

--- a/packages/web-backend/src/slash-commands.ts
+++ b/packages/web-backend/src/slash-commands.ts
@@ -1,21 +1,9 @@
-/**
- * Web-backend wrapper around the shared slash-command registry.
- *
- * Builds the registry used by the web chat WebSocket layer. Adds metadata-only
- * entries for surface-owned commands (`/new`, `/stop`, `/kill`) so they show up
- * in `/help` even though their behaviour stays inline in `ws-chat.ts` (they
- * have to manipulate transport-level state like the active stream and the
- * cached session ID, which the registry deliberately doesn't know about).
- */
-
 import { SlashCommandRegistry, registerBuiltInSlashCommands } from '@axiom/core'
 
 export function buildWebChatSlashCommandRegistry(): SlashCommandRegistry {
   const registry = new SlashCommandRegistry()
   registerBuiltInSlashCommands(registry)
 
-  // Surface-owned commands — handler intentionally omitted; ws-chat.ts handles
-  // them inline because they need to abort the active stream / reset session.
   registry.register({
     name: 'new',
     description: 'Summarize the current session and start a fresh conversation.',

--- a/packages/web-backend/src/slash-commands.ts
+++ b/packages/web-backend/src/slash-commands.ts
@@ -1,0 +1,32 @@
+/**
+ * Web-backend wrapper around the shared slash-command registry.
+ *
+ * Builds the registry used by the web chat WebSocket layer. Adds metadata-only
+ * entries for surface-owned commands (`/new`, `/stop`, `/kill`) so they show up
+ * in `/help` even though their behaviour stays inline in `ws-chat.ts` (they
+ * have to manipulate transport-level state like the active stream and the
+ * cached session ID, which the registry deliberately doesn't know about).
+ */
+
+import { SlashCommandRegistry, registerBuiltInSlashCommands } from '@axiom/core'
+
+export function buildWebChatSlashCommandRegistry(): SlashCommandRegistry {
+  const registry = new SlashCommandRegistry()
+  registerBuiltInSlashCommands(registry)
+
+  // Surface-owned commands — handler intentionally omitted; ws-chat.ts handles
+  // them inline because they need to abort the active stream / reset session.
+  registry.register({
+    name: 'new',
+    description: 'Summarize the current session and start a fresh conversation.',
+    surfaces: ['web', 'telegram'],
+  })
+  registry.register({
+    name: 'stop',
+    aliases: ['kill'],
+    description: 'Abort the current agent turn and clear queued work.',
+    surfaces: ['web', 'telegram'],
+  })
+
+  return registry
+}

--- a/packages/web-backend/src/ws-chat.test.ts
+++ b/packages/web-backend/src/ws-chat.test.ts
@@ -391,7 +391,8 @@ describe('setupWebSocketChat kill switch', () => {
       expect(text).toContain('/stop')
       expect(text).toContain('/tasks')
       expect(text).toContain('/cronjobs')
-      expect(text).toContain('/settings')
+      expect(text).toContain('/model')
+      expect(text).not.toContain('/settings')
       expect(agentCore.sendMessage).not.toHaveBeenCalled()
       ws.close()
     } finally {

--- a/packages/web-backend/src/ws-chat.test.ts
+++ b/packages/web-backend/src/ws-chat.test.ts
@@ -358,6 +358,94 @@ describe('setupWebSocketChat kill switch', () => {
     }
   })
 
+  it('responds to /help with a system message listing slash commands', async () => {
+    const db = initDatabase(':memory:')
+    const mockSessionManager3 = {
+      getOrCreateSession: vi.fn(() => ({ id: 'session-1-mock', userId: '1', source: 'web', startedAt: Date.now(), lastActivity: Date.now(), messageCount: 0, summaryWritten: false, restored: false })),
+    }
+    const agentCore = {
+      sendMessage: vi.fn(),
+      abort: vi.fn(),
+      resetSession: vi.fn(),
+      getSessionManager: vi.fn(() => mockSessionManager3),
+    } as unknown as AgentCore
+
+    const app = createApp({ db })
+    const server = http.createServer(app)
+    const { wss } = setupWebSocketChat(server, db, agentCore)
+
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    const token = generateAccessToken({ userId: 1, username: 'admin', role: 'admin' })
+
+    try {
+      const { ws, waitForMessage } = await connectWs(port, token)
+      await waitForMessage() // authenticated
+
+      ws.send(JSON.stringify({ type: 'command', content: '/help' }))
+      const helpMessage = await waitForMessage()
+      expect(helpMessage.type).toBe('system')
+      const text = (helpMessage.text as string) ?? ''
+      expect(text).toContain('/help')
+      expect(text).toContain('/new')
+      expect(text).toContain('/stop')
+      expect(text).toContain('/tasks')
+      expect(text).toContain('/cronjobs')
+      expect(text).toContain('/settings')
+      expect(agentCore.sendMessage).not.toHaveBeenCalled()
+      ws.close()
+    } finally {
+      for (const client of wss.clients) {
+        client.terminate()
+      }
+      wss.close()
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      )
+    }
+  })
+
+  it('responds to /unknown with a system message and does not forward to the agent', async () => {
+    const db = initDatabase(':memory:')
+    const mockSessionManager4 = {
+      getOrCreateSession: vi.fn(() => ({ id: 'session-1-mock', userId: '1', source: 'web', startedAt: Date.now(), lastActivity: Date.now(), messageCount: 0, summaryWritten: false, restored: false })),
+    }
+    const agentCore = {
+      sendMessage: vi.fn(),
+      abort: vi.fn(),
+      resetSession: vi.fn(),
+      getSessionManager: vi.fn(() => mockSessionManager4),
+    } as unknown as AgentCore
+
+    const app = createApp({ db })
+    const server = http.createServer(app)
+    const { wss } = setupWebSocketChat(server, db, agentCore)
+
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    const token = generateAccessToken({ userId: 1, username: 'admin', role: 'admin' })
+
+    try {
+      const { ws, waitForMessage } = await connectWs(port, token)
+      await waitForMessage() // authenticated
+
+      ws.send(JSON.stringify({ type: 'command', content: '/doesnotexist' }))
+      const reply = await waitForMessage()
+      expect(reply.type).toBe('system')
+      expect(reply.text).toContain('Unknown command')
+      expect(agentCore.sendMessage).not.toHaveBeenCalled()
+      ws.close()
+    } finally {
+      for (const client of wss.clients) {
+        client.terminate()
+      }
+      wss.close()
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      )
+    }
+  })
+
   it('treats /kill as an alias for /stop over web chat', async () => {
     const db = initDatabase(':memory:')
     const mockSessionManager2 = {

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -1,6 +1,12 @@
 import { WebSocketServer, WebSocket } from 'ws'
 import type { Server } from 'node:http'
-import type { Database, UploadDescriptor, SlashCommandRegistry } from '@axiom/core'
+import type {
+  Database,
+  UploadDescriptor,
+  SlashCommandRegistry,
+  SlashCommandPicker,
+} from '@axiom/core'
+import { isSlashCommandPicker } from '@axiom/core'
 import type { AgentCore, ResponseChunk } from '@axiom/core'
 import {
   extractUploadsFromToolResult,
@@ -28,6 +34,14 @@ interface ChatMessage {
 interface ChatResponse {
   type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'reminder' | 'pong' | 'attachment'
   text?: string
+  /**
+   * Interactive picker payload (slash-command driven). When present on a
+   * `system` message the frontend renders a button group; clicking a button
+   * sends back `{ type: 'command', content: <option.command> }`, which the
+   * server re-dispatches through the slash registry to produce the next
+   * picker (or final confirmation).
+   */
+  picker?: SlashCommandPicker
   /** Uploaded file attached to the current assistant turn (for type='attachment') */
   attachment?: UploadDescriptor
   /** Streamed thinking delta (for type='thinking') */
@@ -219,7 +233,15 @@ export function setupWebSocketChat(
           onThinkingLevelChanged: (level) => resolveAgentCore()?.setThinkingLevel(level),
         })
         if (dispatch.kind === 'handled') {
-          if (dispatch.reply !== null) {
+          if (isSlashCommandPicker(dispatch.reply)) {
+            sendMessage(ws, {
+              type: 'system',
+              // Title/description rendered as the bubble's text; buttons live
+              // alongside via the `picker` field.
+              text: formatPickerText(dispatch.reply),
+              picker: dispatch.reply,
+            })
+          } else if (dispatch.reply !== null) {
             sendMessage(ws, { type: 'system', text: dispatch.reply })
           }
           return
@@ -674,6 +696,18 @@ export function setupWebSocketChat(
       return !!clients && clients.size > 0
     },
   }
+}
+
+/**
+ * Render a picker's title + description as the bubble's body text. The
+ * frontend always renders the buttons separately, but we still want the
+ * fallback text so old clients (or history reloads) see something.
+ */
+function formatPickerText(picker: SlashCommandPicker): string {
+  const parts: string[] = []
+  if (picker.title) parts.push(picker.title)
+  if (picker.description) parts.push(picker.description)
+  return parts.join('\n') || ''
 }
 
 function sendMessage(ws: WebSocket, msg: ChatResponse): void {

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -43,10 +43,6 @@ interface ChatResponse {
   source?: string
   /** Sender display name (for external_user_message) */
   senderName?: string
-  /**
-   * Excerpt of the message the user replied to (Telegram reply-to), truncated to 500 chars.
-   * Rendered as a quote bubble above the user message. Only set for `external_user_message`.
-   */
   replyContext?: string
   /** Task ID (for task events) */
   taskId?: string
@@ -70,10 +66,6 @@ interface ChatResponse {
   telegramDelivered?: boolean
   /** Whether this is a task injection response */
   isTaskInjection?: boolean
-  /**
-   * Human-readable single-line summary for `task_status_update` events,
-   * matching the value persisted in `chat_messages.content`.
-   */
   taskStatusContent?: string
   /** How long the task has been running, in minutes. */
   taskStatusRuntimeMinutes?: number
@@ -116,9 +108,6 @@ export function setupWebSocketChat(
   const resolveAgentCore = typeof getAgentCore === 'function' ? getAgentCore : () => getAgentCore
   const wss = new WebSocketServer({ noServer: true })
 
-  // Shared slash-command registry. Surface-owned commands (`/new`, `/stop`)
-  // are registered as metadata-only so they appear in `/help` even though
-  // their behaviour stays inline below.
   const slashRegistry: SlashCommandRegistry = buildWebChatSlashCommandRegistry()
   const taskStore = new TaskStore(db)
   const scheduledTaskStore = new ScheduledTaskStore(db)
@@ -220,11 +209,6 @@ export function setupWebSocketChat(
 
       // Handle commands
       if (parsed.type === 'command' || parsed.content.startsWith('/')) {
-        // Bare `/`-prefixed input goes through the shared slash-command registry.
-        // Surface-owned commands (`/new`, `/stop`/`/kill`) keep their custom
-        // behaviour because they need to abort an active stream / reset session
-        // state on this transport — they are registered as metadata-only so
-        // they still appear in `/help` and the Telegram menu.
         const dispatch = await slashRegistry.dispatch(parsed.content, {
           surface: 'web',
           userId: String(currentUser.userId),
@@ -232,6 +216,7 @@ export function setupWebSocketChat(
           db,
           taskStore,
           scheduledTaskStore,
+          onThinkingLevelChanged: (level) => resolveAgentCore()?.setThinkingLevel(level),
         })
         if (dispatch.kind === 'handled') {
           if (dispatch.reply !== null) {
@@ -253,10 +238,6 @@ export function setupWebSocketChat(
           })
           return
         }
-        // dispatch.kind === 'external' or 'no_command': fall through to legacy handling.
-        // For 'external' we trust the registry's resolved command name; for 'no_command'
-        // (e.g. `//foo` literal escape, `/foo-bar` invalid name) we mirror the original
-        // pre-registry regex so existing behaviour is preserved exactly.
         const command = dispatch.kind === 'external'
           ? dispatch.command.name
           : parsed.content.replace(/^\//, '').trim().toLowerCase()

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -1,8 +1,14 @@
 import { WebSocketServer, WebSocket } from 'ws'
 import type { Server } from 'node:http'
-import type { Database, UploadDescriptor } from '@axiom/core'
+import type { Database, UploadDescriptor, SlashCommandRegistry } from '@axiom/core'
 import type { AgentCore, ResponseChunk } from '@axiom/core'
-import { extractUploadsFromToolResult, serializeUploadsMetadata } from '@axiom/core'
+import {
+  extractUploadsFromToolResult,
+  serializeUploadsMetadata,
+  TaskStore,
+  ScheduledTaskStore,
+} from '@axiom/core'
+import { buildWebChatSlashCommandRegistry } from './slash-commands.js'
 import { verifyToken } from './auth.js'
 import type { JwtPayload } from './auth.js'
 import { URL } from 'node:url'
@@ -110,6 +116,13 @@ export function setupWebSocketChat(
   const resolveAgentCore = typeof getAgentCore === 'function' ? getAgentCore : () => getAgentCore
   const wss = new WebSocketServer({ noServer: true })
 
+  // Shared slash-command registry. Surface-owned commands (`/new`, `/stop`)
+  // are registered as metadata-only so they appear in `/help` even though
+  // their behaviour stays inline below.
+  const slashRegistry: SlashCommandRegistry = buildWebChatSlashCommandRegistry()
+  const taskStore = new TaskStore(db)
+  const scheduledTaskStore = new ScheduledTaskStore(db)
+
   // Handle upgrade requests for /ws/chat path
   server.on('upgrade', (request, socket, head) => {
     const pathname = new URL(request.url ?? '', 'http://localhost').pathname
@@ -207,7 +220,46 @@ export function setupWebSocketChat(
 
       // Handle commands
       if (parsed.type === 'command' || parsed.content.startsWith('/')) {
-        const command = parsed.content.replace(/^\//, '').trim().toLowerCase()
+        // Bare `/`-prefixed input goes through the shared slash-command registry.
+        // Surface-owned commands (`/new`, `/stop`/`/kill`) keep their custom
+        // behaviour because they need to abort an active stream / reset session
+        // state on this transport — they are registered as metadata-only so
+        // they still appear in `/help` and the Telegram menu.
+        const dispatch = await slashRegistry.dispatch(parsed.content, {
+          surface: 'web',
+          userId: String(currentUser.userId),
+          registry: slashRegistry,
+          db,
+          taskStore,
+          scheduledTaskStore,
+        })
+        if (dispatch.kind === 'handled') {
+          if (dispatch.reply !== null) {
+            sendMessage(ws, { type: 'system', text: dispatch.reply })
+          }
+          return
+        }
+        if (dispatch.kind === 'not_found') {
+          sendMessage(ws, {
+            type: 'system',
+            text: `Unknown command: /${dispatch.name}. Type /help for a list of commands.`,
+          })
+          return
+        }
+        if (dispatch.kind === 'wrong_surface') {
+          sendMessage(ws, {
+            type: 'system',
+            text: `/${dispatch.command.name} is not available on the web chat.`,
+          })
+          return
+        }
+        // dispatch.kind === 'external' or 'no_command': fall through to legacy handling.
+        // For 'external' we trust the registry's resolved command name; for 'no_command'
+        // (e.g. `//foo` literal escape, `/foo-bar` invalid name) we mirror the original
+        // pre-registry regex so existing behaviour is preserved exactly.
+        const command = dispatch.kind === 'external'
+          ? dispatch.command.name
+          : parsed.content.replace(/^\//, '').trim().toLowerCase()
 
         if (command === 'new') {
           // Abort any active stream

--- a/packages/web-frontend/app/composables/useChat.ts
+++ b/packages/web-frontend/app/composables/useChat.ts
@@ -6,6 +6,26 @@ export interface ToolCallData {
   toolIsError?: boolean
 }
 
+/**
+ * One option in a slash-command-driven picker (e.g. /model). When the user
+ * clicks the corresponding button the frontend re-sends `command` as a
+ * verbatim slash-command, which the backend dispatches through the same
+ * registry to produce the next picker (or final confirmation).
+ */
+export interface ChatPickerOption {
+  command: string
+  label: string
+  description?: string
+  badge?: string
+}
+
+export interface ChatPicker {
+  pickerId: string
+  title?: string
+  description?: string
+  options: ChatPickerOption[]
+}
+
 export interface ChatAttachment {
   kind: 'image' | 'file'
   originalName: string
@@ -69,11 +89,22 @@ export interface ChatMessage {
    * message body with `[Replying to: "…"]`. Only set for `role: 'user'`.
    */
   replyContext?: string
+  /**
+   * Interactive picker (button group) attached to a system message.
+   * Set on `role: 'system'`. Once the user picks an option we mark the
+   * picker as resolved (see `pickerResolvedCommand`) so the buttons are
+   * disabled and a single “selected” indicator is shown.
+   */
+  picker?: ChatPicker
+  /** The picker option command the user picked (disables the buttons). */
+  pickerResolvedCommand?: string
 }
 
 interface WsMessage {
   type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'reminder' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'pong' | 'attachment'
   text?: string
+  /** Picker payload for interactive slash-command replies (e.g. /model). */
+  picker?: ChatPicker
   /** Uploaded file the agent sent for the current turn (for type='attachment') */
   attachment?: ChatAttachment
   /** Thinking delta (for type='thinking') */
@@ -310,7 +341,16 @@ export function useChat() {
         if (msg.sessionId) {
           sessionId.value = msg.sessionId
         }
-        if (msg.text && msg.text !== 'Authenticated') {
+        if (msg.picker) {
+          // Interactive slash-command reply. Always rendered — the frontend
+          // shows title + description (msg.text fallback) above the buttons.
+          messages.value = [...messages.value, {
+            role: 'system',
+            content: msg.text ?? '',
+            timestamp: new Date().toISOString(),
+            picker: msg.picker,
+          }]
+        } else if (msg.text && msg.text !== 'Authenticated') {
           // Show system messages (like session reset)
           messages.value = [...messages.value, {
             role: 'system',
@@ -630,6 +670,31 @@ export function useChat() {
     ws.send(JSON.stringify({ type: 'command', content: `/${command}` }))
   }
 
+  /**
+   * Send a verbatim slash command (must include the leading `/`). Used by
+   * picker buttons that already carry a fully-formed command from the
+   * backend, e.g. `/model <providerId> <modelId>`.
+   */
+  function sendRawCommand(command: string) {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    if (!command.startsWith('/')) return
+    ws.send(JSON.stringify({ type: 'command', content: command }))
+  }
+
+  /**
+   * Mark a picker message as resolved (button clicked). Disables the buttons
+   * and records which option fired so the UI can highlight it.
+   */
+  function resolvePicker(messageIndex: number, command: string) {
+    const list = messages.value
+    const target = list[messageIndex]
+    if (!target || !target.picker || target.pickerResolvedCommand) return
+    const updated = [...list]
+    updated[messageIndex] = { ...target, pickerResolvedCommand: command }
+    messages.value = updated
+    sendRawCommand(command)
+  }
+
   function newSession() {
     sendCommand('new')
   }
@@ -664,6 +729,8 @@ export function useChat() {
     connect,
     disconnect,
     sendMessage,
+    sendRawCommand,
+    resolvePicker,
     newSession,
     stopTask,
     clearMessages,

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -104,11 +104,11 @@
             // Mobile: messages fill the available width (minus avatar + gap
             // or the pl-11 offset for tool cards). On sm+ screens we cap them
             // so bubbles don't span edge-to-edge on wider viewports.
-            msg.role === 'divider' ? 'w-full' : (msg.role === 'tool' || (msg.role === 'system' && (msg.isTaskResult || msg.isTaskStatusUpdate)) || msg.isThinking) ? 'self-start w-full max-w-full sm:max-w-[75%] pl-11' : 'flex max-w-full gap-3 sm:max-w-[75%]',
+            msg.role === 'divider' ? 'w-full' : (msg.role === 'tool' || (msg.role === 'system' && (msg.isTaskResult || msg.isTaskStatusUpdate || msg.picker)) || msg.isThinking) ? 'self-start w-full max-w-full sm:max-w-[75%] pl-11' : 'flex max-w-full gap-3 sm:max-w-[75%]',
             {
               'self-end flex-row-reverse': msg.role === 'user',
               'self-start': msg.role === 'assistant' && !msg.isThinking,
-              'self-center max-w-full sm:max-w-[85%]': msg.role === 'system' && !msg.isTaskResult && !msg.isTaskStatusUpdate,
+              'self-center max-w-full sm:max-w-[85%]': msg.role === 'system' && !msg.isTaskResult && !msg.isTaskStatusUpdate && !msg.picker,
             },
           ]"
         >
@@ -258,6 +258,55 @@
                 <div class="max-h-60 overflow-y-auto px-3 py-2">
                   <div class="prose-chat break-words text-xs text-foreground" v-html="renderMarkdown(taskResultBody(msg.content))" />
                 </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- Slash-command picker (e.g. /model). Renders the title +
+               description plus a button group; clicking a button sends the
+               option's verbatim slash command back to the server, which
+               re-dispatches it through the registry to produce the next
+               picker (or final confirmation). -->
+          <template v-else-if="msg.role === 'system' && msg.picker">
+            <div class="w-full overflow-hidden rounded-lg border border-border bg-muted/30">
+              <div v-if="msg.picker.title || msg.picker.description" class="border-b border-border/60 px-3 py-2 text-xs">
+                <p v-if="msg.picker.title" class="font-medium text-foreground">{{ msg.picker.title }}</p>
+                <p v-if="msg.picker.description" class="mt-0.5 text-muted-foreground">{{ msg.picker.description }}</p>
+              </div>
+              <div class="flex flex-col gap-1 p-1.5">
+                <button
+                  v-for="opt in msg.picker.options"
+                  :key="opt.command"
+                  type="button"
+                  class="group flex w-full items-center gap-2 rounded-md border border-transparent px-2.5 py-1.5 text-left text-xs transition-colors"
+                  :class="msg.pickerResolvedCommand
+                    ? (opt.command === msg.pickerResolvedCommand
+                        ? 'border-primary/30 bg-primary/10 text-foreground'
+                        : 'cursor-not-allowed text-muted-foreground/60')
+                    : 'text-foreground hover:border-border hover:bg-muted'"
+                  :disabled="!!msg.pickerResolvedCommand"
+                  @click="handlePickerSelect(msg, opt.command)"
+                >
+                  <span class="min-w-0 flex-1 truncate font-medium">{{ opt.label }}</span>
+                  <span
+                    v-if="opt.description"
+                    class="shrink-0 truncate text-[10px] text-muted-foreground/80"
+                  >{{ opt.description }}</span>
+                  <span
+                    v-if="opt.badge"
+                    class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium"
+                    :class="opt.badge === 'active'
+                      ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                      : opt.badge === 'error'
+                        ? 'bg-destructive/10 text-destructive'
+                        : 'bg-muted text-muted-foreground'"
+                  >{{ opt.badge }}</span>
+                  <AppIcon
+                    v-if="opt.command === msg.pickerResolvedCommand"
+                    name="check"
+                    class="h-3 w-3 shrink-0 text-primary"
+                  />
+                </button>
               </div>
             </div>
           </template>
@@ -635,7 +684,19 @@ function formatTokenCount(count: number): string {
   if (count >= 1000) return `${(count / 1000).toFixed(1)}k`
   return String(count)
 }
-const { messages, connectionStatus, isStreaming, connect, disconnect, sendMessage, newSession, stopTask } = useChat()
+const { messages, connectionStatus, isStreaming, connect, disconnect, sendMessage, newSession, stopTask, resolvePicker } = useChat()
+
+/**
+ * Map a clicked picker option back to the position of its message inside
+ * `messages.value`. We can't use the `i` from the v-for directly because
+ * `filteredMessages` filters out e.g. tool calls / task injections, so its
+ * indices don't line up with the underlying array.
+ */
+function handlePickerSelect(msg: ChatMessage, command: string) {
+  const idx = messages.value.indexOf(msg)
+  if (idx === -1) return
+  resolvePicker(idx, command)
+}
 const { playingIndex: ttsPlayingIndex, loading: ttsLoading, ttsEnabled, error: ttsError, fetchTtsSettings, play: ttsPlay, stop: ttsStop, clearError: clearTtsError } = useTts()
 const { recording: sttRecording, transcribing: sttTranscribing, error: sttError, sttEnabled, fetchSttSettings, startRecording: sttStartRecording, stopAndTranscribe: sttStopAndTranscribe, cleanup: sttCleanup } = useStt()
 


### PR DESCRIPTION
## Problem

Slash commands were duplicated between the web chat WebSocket layer and the Telegram bot — `/new` and `/stop` were hard-coded twice with slightly different wording, and Telegram had no native command menu so users had to remember the names. There was no `/help`, no read-only introspection (`/tasks`, `/cronjobs`, `/settings`), and no central place to add new commands.

## Change

A small first-version slash-command system shared by both surfaces.

- **Core (`@axiom/core`)** — new `SlashCommandRegistry` and `parseSlashCommand`. Commands carry typed metadata (`name`, `aliases`, `description`, `usage`, `surfaces`) and an optional handler. Surface-owned commands (`/new`, `/stop`, `/kill`, `/start`) register as metadata-only so they appear in `/help` and the Telegram menu while their behaviour stays inline in the surface that owns the transport state.
- **Built-in commands** — `/help`, `/tasks`, `/cronjobs` (alias `/cron`), `/settings` (alias `/model`), and `/thinking` (show/set the global main-agent thinking level). Both surfaces.
- **Telegram bot** — calls `bot.api.setMyCommands()` on start, populating the native command menu (the `/` button) from the registry. Failures are non-fatal: typed commands still work, the menu just stays empty until the next successful start.
- **Web chat** — `ws-chat.ts` intercepts typed slash commands via the registry before forwarding to the LLM; unknown commands respond with a hint pointing at `/help`. `//` (double-slash) bypass for literal slashes is preserved.
- **Docs** — `docs/web-ui/chat.md` gets a "Slash commands" section; `docs/guide/telegram.md` updates the bot-commands table to reflect the shared vocabulary and the native menu.

Destructive operations (`/undo`, `/rollback`, `/compress`) are intentionally out of scope for v1 — none have safe primitives in the codebase yet.

## Architecture notes

- A command's `handler` is optional. When omitted, the registry returns `{ kind: 'external' }` from `dispatch()` and the surface keeps full control of the response. This is how `/new` and `/stop` keep their existing behaviour (aborting the active stream, resetting the session) while still appearing in `/help`.
- The parser is conservative: only `[a-zA-Z0-9_]+` after a single leading slash, Telegram `@botname` suffix stripped, double-slash treated as escape so users can still send literal `/foo` to the LLM.
- Inspired by [Hermes Agent](https://hermes-agent.nousresearch.com/docs/reference/slash-commands)'s central `COMMAND_REGISTRY` driving both CLI and messaging surfaces, and OpenClaw's `setMyCommands`-based Telegram menu. Skill-based dynamic commands and CLI-style autocomplete are deliberately left for a later iteration.

## Testing

- CI `Lint + Baseline + Critical Flows` and `Dead code and dependency analysis` are green on the current head. Local targeted verification passed: `npm test -- packages/core/src/slash-commands.test.ts packages/telegram/src/bot.test.ts packages/web-backend/src/ws-chat.test.ts`, plus `npx eslint packages/telegram/src/bot.ts packages/telegram/src/bot.test.ts`.
- 28 slash-command tests in `packages/core/src/slash-commands.test.ts` covering parser edge cases (Telegram `@bot` suffix, double-slash escape, invalid names), registry registration/aliases/conflicts, dispatch outcomes, `/thinking`, and built-in command formatting.
- 2 new ws-chat tests for `/help` listing and unknown-command handling, plus the existing `/new` and `/stop` tests still pass unchanged.
- 3 new Telegram bot tests for `/help`, `/cron`, and `/settings` dispatching through the registry; the existing `/start` test was updated to reflect the slimmer welcome message that points at `/help`.