### PR TITLE
fix(core): refresh OAuth tokens during long-running background tasks

### DIFF
--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -19,10 +19,6 @@ vi.mock('./provider-config.js', async (importOriginal) => {
   }
 })
 
-// Captured PiAgent constructor options for tests that need to inspect
-// what the runner passes to pi-agent-core (e.g. getApiKey resolution).
-// We track the most recent options on a stable singleton so test isolation
-// works even when individual tests override `mockImplementation`.
 interface CapturedAgentOptions {
   getApiKey?: () => unknown
 }
@@ -1548,13 +1544,6 @@ describe('TaskRunner', () => {
   })
 
   describe('OAuth token refresh during long-running tasks', () => {
-    /**
-     * Restore a minimal default Agent mock that exposes the constructor
-     * options via `lastAgentOptions`. Some earlier tests (e.g. periodic
-     * status updates) replace the mock implementation with a long-running
-     * stub that ignores its options, so we re-install a friendly default
-     * before each OAuth-refresh test instead of relying on test ordering.
-     */
     async function restoreCapturingAgentMock(): Promise<void> {
       const { Agent } = await import('@mariozechner/pi-agent-core')
       const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
@@ -1569,8 +1558,6 @@ describe('TaskRunner', () => {
             return () => { subscribeFn = null }
           }),
           prompt: vi.fn(async () => {
-            // Push a minimal completion so `runTaskAsync` reaches the
-            // success path without invoking `options.getApiKey`.
             const msg = {
               role: 'assistant',
               content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: ok' }],
@@ -1591,18 +1578,6 @@ describe('TaskRunner', () => {
       })
     }
 
-    // Regression: tasks used to capture `apiKey` synchronously at startTask()
-    // time. For OAuth providers (ChatGPT Codex, Claude Pro) the access token
-    // expires within ~1 hour, so a long-running task would 401 every LLM call
-    // after that. pi-ai turns those failures into a final assistant message
-    // with stopReason='error' and empty content, which the runner then logs
-    // as `status='completed'` with an empty summary — matching the symptom
-    // users reported on the websocket-cached transport.
-    //
-    // These tests pin the contract: the `getApiKey` callback handed to
-    // PiAgent must re-resolve on every call, and (when available) it must
-    // route through `getProviderById` so disk-persisted refreshed credentials
-    // are picked up.
     it('PiAgent.getApiKey re-resolves on every call instead of capturing once', async () => {
       await restoreCapturingAgentMock()
       resetAgentOptions()
@@ -1628,13 +1603,11 @@ describe('TaskRunner', () => {
       await customRunner.startTask(task, mockProvider)
       await new Promise(resolve => setTimeout(resolve, 50))
 
-      // Pre-resolve at startTask happened (call #1).
       expect(getApiKey).toHaveBeenCalledTimes(1)
       const captured = getCapturedAgentOptions()
       const capturedGetApiKey = captured.getApiKey
       if (!capturedGetApiKey) throw new Error('getApiKey missing on captured options')
 
-      // Subsequent invocations of the agent's getApiKey hit getApiKey again.
       const k1 = await capturedGetApiKey()
       const k2 = await capturedGetApiKey()
       expect(k1).toBe('key-fresh-2')
@@ -1680,16 +1653,11 @@ describe('TaskRunner', () => {
       const captured = getCapturedAgentOptions()
       const capturedGetApiKey = captured.getApiKey
       if (!capturedGetApiKey) throw new Error('getApiKey missing on captured options')
-      // Each invocation of the agent's getApiKey must reload the latest
-      // provider snapshot via getProviderById; otherwise OAuth credentials
-      // refreshed on disk would never reach the LLM call.
       const k1 = await capturedGetApiKey()
       const k2 = await capturedGetApiKey()
       expect(k1).toBe('snapshot-1')
       expect(k2).toBe('snapshot-2')
       expect(getProviderById).toHaveBeenCalledWith(mockProvider.id)
-      // Two LLM-side resolutions → two getProviderById hits (the pre-resolve
-      // at startTask uses the captured provider directly).
       expect(getProviderById).toHaveBeenCalledTimes(2)
 
       customRunner.dispose()
@@ -1705,7 +1673,6 @@ describe('TaskRunner', () => {
         throw new Error('OAuth refresh exploded')
       })
 
-      // Silence expected error log
       const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const customRunner = new TaskRunner({

--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -19,10 +19,34 @@ vi.mock('./provider-config.js', async (importOriginal) => {
   }
 })
 
+// Captured PiAgent constructor options for tests that need to inspect
+// what the runner passes to pi-agent-core (e.g. getApiKey resolution).
+// We track the most recent options on a stable singleton so test isolation
+// works even when individual tests override `mockImplementation`.
+interface CapturedAgentOptions {
+  getApiKey?: () => unknown
+}
+interface AgentOptionsBox {
+  value: CapturedAgentOptions | null
+}
+const lastAgentOptions: AgentOptionsBox = { value: null }
+function recordAgentOptions(options: CapturedAgentOptions): void {
+  lastAgentOptions.value = options
+}
+function resetAgentOptions(): void {
+  lastAgentOptions.value = null
+}
+function getCapturedAgentOptions(): CapturedAgentOptions {
+  const v = lastAgentOptions.value
+  if (!v) throw new Error('Agent options not captured')
+  return v
+}
+
 // Mock the PiAgent to avoid actual LLM calls
 vi.mock('@mariozechner/pi-agent-core', () => {
   return {
-    Agent: vi.fn().mockImplementation((_options: unknown) => {
+    Agent: vi.fn().mockImplementation((options: CapturedAgentOptions) => {
+      recordAgentOptions(options)
       let subscribeFn: ((event: unknown) => void) | null = null
       const messages: unknown[] = []
 
@@ -1520,6 +1544,197 @@ describe('TaskRunner', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+  })
+
+  describe('OAuth token refresh during long-running tasks', () => {
+    /**
+     * Restore a minimal default Agent mock that exposes the constructor
+     * options via `lastAgentOptions`. Some earlier tests (e.g. periodic
+     * status updates) replace the mock implementation with a long-running
+     * stub that ignores its options, so we re-install a friendly default
+     * before each OAuth-refresh test instead of relying on test ordering.
+     */
+    async function restoreCapturingAgentMock(): Promise<void> {
+      const { Agent } = await import('@mariozechner/pi-agent-core')
+      const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+      MockAgent.mockReset()
+      MockAgent.mockImplementation((options: CapturedAgentOptions) => {
+        recordAgentOptions(options)
+        let subscribeFn: ((event: unknown) => void) | null = null
+        const messages: unknown[] = []
+        return {
+          subscribe: vi.fn((fn: (event: unknown) => void) => {
+            subscribeFn = fn
+            return () => { subscribeFn = null }
+          }),
+          prompt: vi.fn(async () => {
+            // Push a minimal completion so `runTaskAsync` reaches the
+            // success path without invoking `options.getApiKey`.
+            const msg = {
+              role: 'assistant',
+              content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: ok' }],
+              provider: 'test-provider',
+              model: 'test-model',
+              usage: {
+                input: 1, output: 1, cacheRead: 0, cacheWrite: 0,
+                cost: { total: 0 },
+              },
+            }
+            subscribeFn?.({ type: 'message_end', message: msg })
+            subscribeFn?.({ type: 'agent_end', messages: [] })
+            messages.push(msg)
+          }),
+          abort: vi.fn(),
+          state: { get messages() { return messages } },
+        }
+      })
+    }
+
+    // Regression: tasks used to capture `apiKey` synchronously at startTask()
+    // time. For OAuth providers (ChatGPT Codex, Claude Pro) the access token
+    // expires within ~1 hour, so a long-running task would 401 every LLM call
+    // after that. pi-ai turns those failures into a final assistant message
+    // with stopReason='error' and empty content, which the runner then logs
+    // as `status='completed'` with an empty summary — matching the symptom
+    // users reported on the websocket-cached transport.
+    //
+    // These tests pin the contract: the `getApiKey` callback handed to
+    // PiAgent must re-resolve on every call, and (when available) it must
+    // route through `getProviderById` so disk-persisted refreshed credentials
+    // are picked up.
+    it('PiAgent.getApiKey re-resolves on every call instead of capturing once', async () => {
+      await restoreCapturingAgentMock()
+      resetAgentOptions()
+      let getApiKeyCallCount = 0
+      const apiKeys = ['key-fresh-1', 'key-fresh-2', 'key-fresh-3']
+      const getApiKey = vi.fn(async () => apiKeys[getApiKeyCallCount++] ?? 'key-fallback')
+
+      const customRunner = new TaskRunner({
+        db,
+        buildModel: () => ({} as ReturnType<TaskRunnerOptions['buildModel']>),
+        getApiKey,
+        tools: [],
+        memoryDir: undefined,
+        onTaskComplete: () => {},
+        sessionManager,
+      })
+
+      const task = store.create({
+        name: 'OAuth task',
+        prompt: 'Do work',
+        triggerType: 'agent',
+      })
+      await customRunner.startTask(task, mockProvider)
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      // Pre-resolve at startTask happened (call #1).
+      expect(getApiKey).toHaveBeenCalledTimes(1)
+      const captured = getCapturedAgentOptions()
+      const capturedGetApiKey = captured.getApiKey
+      if (!capturedGetApiKey) throw new Error('getApiKey missing on captured options')
+
+      // Subsequent invocations of the agent's getApiKey hit getApiKey again.
+      const k1 = await capturedGetApiKey()
+      const k2 = await capturedGetApiKey()
+      expect(k1).toBe('key-fresh-2')
+      expect(k2).toBe('key-fresh-3')
+      expect(getApiKey).toHaveBeenCalledTimes(3)
+
+      customRunner.dispose()
+    })
+
+    it('PiAgent.getApiKey routes through getProviderById when available so refreshed OAuth credentials on disk are picked up', async () => {
+      await restoreCapturingAgentMock()
+      resetAgentOptions()
+      const providerSnapshots: ProviderConfig[] = [
+        { ...mockProvider, apiKey: 'snapshot-1' },
+        { ...mockProvider, apiKey: 'snapshot-2' },
+      ]
+      let snapshotIdx = 0
+      const getProviderById = vi.fn((id: string) => {
+        if (id !== mockProvider.id) return null
+        return providerSnapshots[Math.min(snapshotIdx++, providerSnapshots.length - 1)]
+      })
+      const getApiKey = vi.fn(async (p: ProviderConfig) => p.apiKey)
+
+      const customRunner = new TaskRunner({
+        db,
+        buildModel: () => ({} as ReturnType<TaskRunnerOptions['buildModel']>),
+        getApiKey,
+        getProviderById,
+        tools: [],
+        memoryDir: undefined,
+        onTaskComplete: () => {},
+        sessionManager,
+      })
+
+      const task = store.create({
+        name: 'OAuth task with refresh',
+        prompt: 'Do work',
+        triggerType: 'agent',
+      })
+      await customRunner.startTask(task, mockProvider)
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      const captured = getCapturedAgentOptions()
+      const capturedGetApiKey = captured.getApiKey
+      if (!capturedGetApiKey) throw new Error('getApiKey missing on captured options')
+      // Each invocation of the agent's getApiKey must reload the latest
+      // provider snapshot via getProviderById; otherwise OAuth credentials
+      // refreshed on disk would never reach the LLM call.
+      const k1 = await capturedGetApiKey()
+      const k2 = await capturedGetApiKey()
+      expect(k1).toBe('snapshot-1')
+      expect(k2).toBe('snapshot-2')
+      expect(getProviderById).toHaveBeenCalledWith(mockProvider.id)
+      // Two LLM-side resolutions → two getProviderById hits (the pre-resolve
+      // at startTask uses the captured provider directly).
+      expect(getProviderById).toHaveBeenCalledTimes(2)
+
+      customRunner.dispose()
+    })
+
+    it('PiAgent.getApiKey falls back to the last known good key when refresh throws', async () => {
+      await restoreCapturingAgentMock()
+      resetAgentOptions()
+      let calls = 0
+      const getApiKey = vi.fn(async () => {
+        calls++
+        if (calls === 1) return 'initial-good-key'
+        throw new Error('OAuth refresh exploded')
+      })
+
+      // Silence expected error log
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const customRunner = new TaskRunner({
+        db,
+        buildModel: () => ({} as ReturnType<TaskRunnerOptions['buildModel']>),
+        getApiKey,
+        tools: [],
+        memoryDir: undefined,
+        onTaskComplete: () => {},
+        sessionManager,
+      })
+
+      const task = store.create({
+        name: 'OAuth task with broken refresh',
+        prompt: 'Do work',
+        triggerType: 'agent',
+      })
+      await customRunner.startTask(task, mockProvider)
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      const captured = getCapturedAgentOptions()
+      const capturedGetApiKey = captured.getApiKey
+      if (!capturedGetApiKey) throw new Error('getApiKey missing on captured options')
+      const k = await capturedGetApiKey()
+      expect(k).toBe('initial-good-key')
+      expect(errSpy).toHaveBeenCalled()
+
+      errSpy.mockRestore()
+      customRunner.dispose()
     })
   })
 })

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -420,9 +420,13 @@ export class TaskRunner {
     try {
       const sessionId = this.ensureTaskSession(task, parentSessionId)
 
-      // Build model and get API key
+      // Build model and resolve the initial API key. We pre-resolve once so
+      // that obviously broken credentials fail fast at startTask() time
+      // (preserved by the outer try/catch below). The actual key handed to
+      // PiAgent is re-resolved on every LLM call further down so OAuth tokens
+      // refresh during long task runs — see the `getApiKey` callback below.
       const model = this.options.buildModel(provider)
-      const apiKey = await this.options.getApiKey(provider)
+      const initialApiKey = await this.options.getApiKey(provider)
 
       // Determine effective system prompt
       const baseSystemPrompt = overrides?.systemPromptOverride
@@ -450,6 +454,32 @@ export class TaskRunner {
       }
 
       // Create isolated PiAgent
+      //
+      // For OAuth providers (e.g. ChatGPT Codex / Claude Pro) the access token
+      // expires within ~1 hour. A long-running background task that captured
+      // the apiKey synchronously at startTask() time would keep sending the
+      // expired token until every LLM call 401s. pi-ai turns those failures
+      // into a final assistant message with `stopReason='error'` and empty
+      // content, which the task-runner then records as `status='completed'`
+      // with an empty summary — exactly the symptom users see.
+      //
+      // We therefore re-resolve the apiKey on every LLM call by calling
+      // `getApiKey` against the freshest provider snapshot we can get. The
+      // host wires `getApiKey` to `getApiKeyForProvider`, which routes OAuth
+      // through pi-ai's `getOAuthApiKey` and only refreshes when expired, so
+      // this stays cheap for non-expired and api-key providers.
+      const resolveApiKey = async (): Promise<string> => {
+        try {
+          const fresh = this.options.getProviderById?.(provider.id) ?? provider
+          return await this.options.getApiKey(fresh)
+        } catch (err) {
+          console.error(`[task-runner] Failed to refresh API key for task ${taskId}:`, err)
+          // Fall back to the last known good key so a transient failure during
+          // refresh does not also break the in-flight call.
+          return initialApiKey
+        }
+      }
+
       const agent = new PiAgent({
         initialState: {
           systemPrompt,
@@ -460,7 +490,7 @@ export class TaskRunner {
         streamFn: buildStreamFn(provider),
         ...(provider.transport && provider.transport !== 'sse'
           && { transport: provider.transport }),
-        getApiKey: () => apiKey,
+        getApiKey: resolveApiKey,
       })
 
       const abortController = new AbortController()

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -420,11 +420,7 @@ export class TaskRunner {
     try {
       const sessionId = this.ensureTaskSession(task, parentSessionId)
 
-      // Build model and resolve the initial API key. We pre-resolve once so
-      // that obviously broken credentials fail fast at startTask() time
-      // (preserved by the outer try/catch below). The actual key handed to
-      // PiAgent is re-resolved on every LLM call further down so OAuth tokens
-      // refresh during long task runs — see the `getApiKey` callback below.
+      // Pre-resolve once so broken credentials still fail before the task starts.
       const model = this.options.buildModel(provider)
       const initialApiKey = await this.options.getApiKey(provider)
 
@@ -454,28 +450,12 @@ export class TaskRunner {
       }
 
       // Create isolated PiAgent
-      //
-      // For OAuth providers (e.g. ChatGPT Codex / Claude Pro) the access token
-      // expires within ~1 hour. A long-running background task that captured
-      // the apiKey synchronously at startTask() time would keep sending the
-      // expired token until every LLM call 401s. pi-ai turns those failures
-      // into a final assistant message with `stopReason='error'` and empty
-      // content, which the task-runner then records as `status='completed'`
-      // with an empty summary — exactly the symptom users see.
-      //
-      // We therefore re-resolve the apiKey on every LLM call by calling
-      // `getApiKey` against the freshest provider snapshot we can get. The
-      // host wires `getApiKey` to `getApiKeyForProvider`, which routes OAuth
-      // through pi-ai's `getOAuthApiKey` and only refreshes when expired, so
-      // this stays cheap for non-expired and api-key providers.
       const resolveApiKey = async (): Promise<string> => {
         try {
           const fresh = this.options.getProviderById?.(provider.id) ?? provider
           return await this.options.getApiKey(fresh)
         } catch (err) {
           console.error(`[task-runner] Failed to refresh API key for task ${taskId}:`, err)
-          // Fall back to the last known good key so a transient failure during
-          // refresh does not also break the in-flight call.
           return initialApiKey
         }
       }


### PR DESCRIPTION
## Problem

Background tasks captured the `apiKey` synchronously at `startTask()` time and forwarded it to PiAgent via a closure (`getApiKey: () => apiKey`). For OAuth providers — ChatGPT Codex / Claude Pro — the access token expires within ~1 hour, so any task running longer than that kept sending the expired token. pi-ai turns the resulting 401s into a final assistant message with `stopReason='error'` and empty content; the task-runner then recorded the run as `status='completed'` with an empty summary.

The user-visible symptom: long-running OAuth tasks "finish" with no useful output / no diff / planning-only, while still consuming many tokens. This was reported in the context of the `websocket-cached` transport (added in #56), but the underlying bug is transport-agnostic — `websocket-cached` just made it more visible because Codex / Responses is currently the only `apiType` that supports it, and Codex is OAuth-only.

For comparison, the interactive `AgentCore` path (`packages/core/src/agent-runtime.ts`) already wires `getApiKey` so it reloads the provider snapshot from disk and re-resolves on every LLM call. Tasks just didn't.

## Change

Mirror the OAuth-refresh wiring from `agent-runtime` in `task-runner`:

- `startTask()` still pre-resolves once so obviously broken credentials fail fast (preserved by the outer `try/catch`).
- The callback handed to `new PiAgent({ getApiKey })` now re-resolves on every LLM call. It routes through `options.getProviderById(provider.id)` (which reloads from disk in the web-backend) so refreshed credentials persisted by `getApiKeyForProvider` are picked up; if `getProviderById` is not configured it falls back to the captured provider object.
- A refresh-time exception is caught and logged, falling back to the last known good key so a transient refresh failure does not also break the in-flight call.
- Non-OAuth providers stay cheap: `getApiKeyForProvider` returns synchronously without a network round-trip, and pi-ai's `getOAuthApiKey` only hits the network when the token has actually expired.

The smart-loop-detection agent path is left as-is — it's a one-shot prompt that already calls `getApiKey` freshly on each invocation.

## Testing

- Added three regression tests in `packages/core/src/task-runner.test.ts` under `OAuth token refresh during long-running tasks`:
  1. The agent's `getApiKey` re-resolves on every call instead of capturing once.
  2. It routes through `getProviderById` so refreshed OAuth credentials on disk are picked up.
  3. It falls back to the last known good key when refresh throws.
- Verified the new tests fail without the fix and pass with it.
- `npx vitest run packages/core` — 916 / 916 passing.
- `npx vitest run` (full repo) — 1165 / 1165 passing.
- `npm run build` — clean.
- `npm run lint` — same 8 pre-existing errors as `upstream/main`; nothing new.