### PR TITLE
fix: parse task startedAt as UTC and persist live metrics during execution

### DIFF
--- a/packages/core/src/task-runner.test.ts
+++ b/packages/core/src/task-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { initDatabase } from './database.js'
 import { TaskStore } from './task-store.js'
-import { TaskRunner, formatTaskInjection } from './task-runner.js'
+import { TaskRunner, formatTaskInjection, parseTaskTimestampMs } from './task-runner.js'
 import type { TaskRunnerOptions, TaskOverrides } from './task-runner.js'
 import type { Database } from './database.js'
 import type { ProviderConfig } from './provider-config.js'
@@ -1540,6 +1540,172 @@ describe('TaskRunner', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+  })
+
+
+  describe('parseTaskTimestampMs', () => {
+    it('parses a task store timestamp as UTC, regardless of host TZ', () => {
+      const ms = parseTaskTimestampMs('2024-01-15 12:00:00')
+      expect(ms).toBe(Date.UTC(2024, 0, 15, 12, 0, 0))
+    })
+
+    it('returns null for empty / invalid input', () => {
+      expect(parseTaskTimestampMs(null)).toBe(null)
+      expect(parseTaskTimestampMs(undefined)).toBe(null)
+      expect(parseTaskTimestampMs('')).toBe(null)
+      expect(parseTaskTimestampMs('not a date')).toBe(null)
+    })
+  })
+
+  describe('task injection duration uses real elapsed time', () => {
+    it('reports duration based on actual elapsed time, not a TZ-offset artefact', async () => {
+      const { Agent } = await import('@mariozechner/pi-agent-core')
+      const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+      MockAgent.mockImplementationOnce(() => {
+        let subscribeFn: ((event: unknown) => void) | null = null
+        const messages: unknown[] = []
+        return {
+          subscribe: vi.fn((fn: (event: unknown) => void) => {
+            subscribeFn = fn
+            return () => { subscribeFn = null }
+          }),
+          prompt: vi.fn(async () => {
+            if (subscribeFn) {
+              subscribeFn({
+                type: 'message_end',
+                message: {
+                  role: 'assistant',
+                  content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: ok' }],
+                  provider: 'test-provider',
+                  model: 'test-model',
+                  usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+                },
+              })
+            }
+            messages.push({
+              role: 'assistant',
+              content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: ok' }],
+            })
+          }),
+          abort: vi.fn(),
+          state: { get messages() { return messages } },
+        }
+      })
+
+      const task = store.create({
+        name: 'Smoke Test',
+        prompt: 'quick',
+        triggerType: 'agent',
+        maxDurationMinutes: 5,
+      })
+
+      await runner.startTask(task, mockProvider)
+      await new Promise(resolve => setTimeout(resolve, 100))
+
+      expect(onTaskCompleteCalls).toHaveLength(1)
+      const m = onTaskCompleteCalls[0].injection.match(/duration_minutes="(\d+)"/)
+      expect(m).not.toBeNull()
+      const reported = parseInt(m![1], 10)
+      expect(reported).toBeLessThan(2)
+    })
+  })
+
+  describe('live metric persistence during execution', () => {
+    it('persists token / cost counters to the task row on message_end', async () => {
+      const { Agent } = await import('@mariozechner/pi-agent-core')
+      const MockAgent = Agent as unknown as ReturnType<typeof vi.fn>
+
+      let subscribeFn: ((event: unknown) => void) | null = null
+      let resumePromptResolve: (() => void) | null = null
+      MockAgent.mockImplementationOnce(() => {
+        const messages: unknown[] = []
+        return {
+          subscribe: vi.fn((fn: (event: unknown) => void) => {
+            subscribeFn = fn
+            return () => { subscribeFn = null }
+          }),
+          prompt: vi.fn(() => new Promise<void>((resolve) => {
+            resumePromptResolve = () => {
+              messages.push({
+                role: 'assistant',
+                content: [{ type: 'text', text: 'STATUS: completed\nSUMMARY: ok' }],
+              })
+              resolve()
+            }
+          })),
+          abort: vi.fn(() => { resumePromptResolve?.() }),
+          state: { get messages() { return messages } },
+        }
+      })
+
+      const task = store.create({
+        name: 'Live Metrics Task',
+        prompt: 'work',
+        triggerType: 'agent',
+        sessionId: 'live-metrics-session',
+      })
+
+      await runner.startTask(task, mockProvider)
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      const beforeEvent = store.getById(task.id)!
+      expect(beforeEvent.status).toBe('running')
+      expect(beforeEvent.promptTokens).toBe(0)
+      expect(beforeEvent.completionTokens).toBe(0)
+      expect(beforeEvent.toolCallCount).toBe(0)
+
+      expect(subscribeFn).not.toBeNull()
+      subscribeFn!({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'thinking out loud' }],
+          provider: 'test-provider',
+          model: 'test-model',
+          usage: {
+            input: 250,
+            output: 90,
+            cacheRead: 0,
+            cacheWrite: 0,
+            cost: { total: 0.0042 },
+          },
+        },
+      })
+
+      const afterMsg = store.getById(task.id)!
+      expect(afterMsg.status).toBe('running')
+      expect(afterMsg.promptTokens).toBe(250)
+      expect(afterMsg.completionTokens).toBe(90)
+      expect(afterMsg.estimatedCost).toBeCloseTo(0.0042, 6)
+
+      subscribeFn!({
+        type: 'tool_execution_start',
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        args: { command: 'ls' },
+      })
+      subscribeFn!({
+        type: 'tool_execution_end',
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        result: 'ok',
+        isError: false,
+      })
+
+      const afterTool = store.getById(task.id)!
+      expect(afterTool.status).toBe('running')
+      expect(afterTool.toolCallCount).toBe(1)
+      expect(afterTool.promptTokens).toBe(250)
+
+      resumePromptResolve!()
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      const finalRow = store.getById(task.id)!
+      expect(finalRow.status).toBe('completed')
+      expect(finalRow.promptTokens).toBe(250)
+      expect(finalRow.completionTokens).toBe(90)
+      expect(finalRow.toolCallCount).toBe(1)
     })
   })
 

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -28,6 +28,16 @@ import { getWorkspaceDir } from './agent.js'
 
 const MAX_STATUS_UPDATE_INTERVAL_MINUTES = 120
 
+export function parseTaskTimestampMs(value: string | null | undefined): number | null {
+  if (!value) return null
+  const ms = new Date(value.replace(' ', 'T') + 'Z').getTime()
+  return Number.isFinite(ms) ? ms : null
+}
+
+function taskStartedAtMs(value: string | null | undefined): number {
+  return parseTaskTimestampMs(value) ?? Date.now()
+}
+
 export interface TaskOverrides {
   /** JSON array of tool names to exclude (null = all enabled) */
   toolsOverride?: string | null
@@ -615,7 +625,7 @@ export class TaskRunner {
 
         // Notify via injection with question status
         const task = this.store.getById(taskId)!
-        const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+        const startedAt = taskStartedAtMs(task.startedAt)
         const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
         const injection = formatTaskInjection(task, durationMinutes)
         this.notifyTaskPaused(taskId, injection, summary)
@@ -653,7 +663,7 @@ export class TaskRunner {
 
       if (updatedTask) {
         const task = this.store.getById(taskId)!
-        const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+        const startedAt = taskStartedAtMs(task.startedAt)
         const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
         const injection = formatTaskInjection(task, durationMinutes)
         this.notifyTaskComplete(taskId, injection, task.status, task.resultSummary ?? undefined)
@@ -680,7 +690,7 @@ export class TaskRunner {
 
       if (updatedTask) {
         const task = this.store.getById(taskId)!
-        const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+        const startedAt = taskStartedAtMs(task.startedAt)
         const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
         const injection = formatTaskInjection(task, durationMinutes)
         this.notifyTaskComplete(taskId, injection, "failed", errorMessage)
@@ -730,6 +740,8 @@ export class TaskRunner {
           runningTask.promptTokens += assistantMsg.usage.input
           runningTask.completionTokens += assistantMsg.usage.output
           runningTask.estimatedCost += finalCost
+
+          this.persistLiveMetrics(runningTask)
 
           // Log to token_usage table with task's session_id
           logTokenUsage(this.db, {
@@ -793,6 +805,8 @@ export class TaskRunner {
         runningTask.toolCallArgs.delete(event.toolCallId)
 
         runningTask.toolCallCount++
+
+        this.persistLiveMetrics(runningTask)
 
         const outputStr = JSON.stringify(event.result ?? {})
         const isError = event.isError === true || (typeof event.result === 'string' && event.result.startsWith('Error'))
@@ -975,7 +989,7 @@ export class TaskRunner {
 
     const task = this.store.getById(taskId)
     if (task) {
-      const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+      const startedAt = taskStartedAtMs(task.startedAt)
       const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
       const injection = `<task_injection task_id="${task.id}" task_name="${task.name}" status="failed" trigger="${task.triggerType}" duration_minutes="${durationMinutes}" tokens_used="${task.promptTokens + task.completionTokens}">
 ${reason}
@@ -1102,7 +1116,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
 
       const task = this.store.getById(taskId)
       if (task) {
-        const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+        const startedAt = taskStartedAtMs(task.startedAt)
         const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
         const injection = formatTaskInjection(task, durationMinutes)
         this.notifyTaskComplete(taskId, injection, 'failed', reason)
@@ -1128,7 +1142,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
 
     const task = this.store.getById(taskId)
     if (task) {
-      const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+      const startedAt = taskStartedAtMs(task.startedAt)
       const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
       const injection = formatTaskInjection(task, durationMinutes)
       this.notifyTaskComplete(taskId, injection, "failed", reason)
@@ -1181,9 +1195,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
           : 0)
     if (maxMinutes <= 0) return
 
-    const startedAtMs = task.startedAt
-      ? new Date(task.startedAt.replace(' ', 'T') + 'Z').getTime()
-      : runningTask.startedAtMs
+    const startedAtMs = parseTaskTimestampMs(task.startedAt) ?? runningTask.startedAtMs
     const deadline = startedAtMs + maxMinutes * 60 * 1000
     const remaining = deadline - Date.now()
 
@@ -1196,6 +1208,19 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
     runningTask.timeoutTimer = setTimeout(() => {
       this.abortTask(runningTask.taskId, 'Max duration exceeded')
     }, remaining)
+  }
+
+  private persistLiveMetrics(runningTask: RunningTask): void {
+    try {
+      this.store.update(runningTask.taskId, {
+        promptTokens: runningTask.promptTokens,
+        completionTokens: runningTask.completionTokens,
+        estimatedCost: runningTask.estimatedCost,
+        toolCallCount: runningTask.toolCallCount,
+      })
+    } catch (err) {
+      console.warn(`[task-runner] live metrics update failed for ${runningTask.taskId}:`, err)
+    }
   }
 
   /**
@@ -1267,7 +1292,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       toolCallArgs: new Map(),
       toolCallTracker: new ToolCallTracker(),
       statusUpdateTimer: null,
-      startedAtMs: task.startedAt ? new Date(task.startedAt).getTime() : Date.now(),
+      startedAtMs: taskStartedAtMs(task.startedAt),
     }
 
     // Set up periodic status updates for resumed task
@@ -1361,7 +1386,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
         })
 
         const task = this.store.getById(taskId)!
-        const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+        const startedAt = taskStartedAtMs(task.startedAt)
         const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
         const injection = formatTaskInjection(task, durationMinutes)
         this.notifyTaskPaused(taskId, injection, summary)
@@ -1396,7 +1421,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       })
 
       const task = this.store.getById(taskId)!
-      const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+      const startedAt = taskStartedAtMs(task.startedAt)
       const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
       const injection = formatTaskInjection(task, durationMinutes)
       this.notifyTaskComplete(taskId, injection, task.status, task.resultSummary ?? undefined)
@@ -1420,7 +1445,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       })
 
       const task = this.store.getById(taskId)!
-      const startedAt = task.startedAt ? new Date(task.startedAt).getTime() : Date.now()
+      const startedAt = taskStartedAtMs(task.startedAt)
       const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
       const injection = formatTaskInjection(task, durationMinutes)
       this.notifyTaskComplete(taskId, injection, "failed", errorMessage)
@@ -1455,8 +1480,8 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
             : 0)
 
       let maxDurationExceeded = false
-      if (effectiveMaxMinutes > 0 && task?.startedAt) {
-        const startedAtMs = new Date(task.startedAt.replace(' ', 'T') + 'Z').getTime()
+      const startedAtMs = parseTaskTimestampMs(task?.startedAt)
+      if (effectiveMaxMinutes > 0 && startedAtMs !== null) {
         const deadline = startedAtMs + effectiveMaxMinutes * 60 * 1000
         maxDurationExceeded = now >= deadline
       }
@@ -1488,7 +1513,7 @@ Hint: Use /kill_task ${task.id} if the task needs to be cleaned up.
       // Notify via injection
       const updated = this.store.getById(taskId)
       if (updated) {
-        const startedAt = updated.startedAt ? new Date(updated.startedAt).getTime() : Date.now()
+        const startedAt = taskStartedAtMs(updated.startedAt)
         const durationMinutes = Math.round((Date.now() - startedAt) / 60000)
         const injection = formatTaskInjection(updated, durationMinutes)
         this.notifyTaskComplete(taskId, injection, 'failed', reason)

--- a/packages/core/src/task-tools.test.ts
+++ b/packages/core/src/task-tools.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+import { initDatabase } from './database.js'
+import type { Database } from './database.js'
+import { TaskRunner } from './task-runner.js'
+import type { TaskRunnerOptions } from './task-runner.js'
+import { SessionManager } from './session-manager.js'
+import { createTaskTool } from './task-tools.js'
+import type { ProviderConfig } from './provider-config.js'
+import type { Task, CreateTaskInput, UpdateTaskInput, TaskListFilters } from './task-store.js'
+import type { TaskRuntimeTaskBoundary } from './task-runtime.js'
+
+vi.mock('./provider-config.js', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>
+  return { ...original, estimateCost: vi.fn(() => 0.001) }
+})
+
+vi.mock('@mariozechner/pi-agent-core', () => {
+  return {
+    Agent: vi.fn().mockImplementation((_options: unknown) => {
+      const messages: unknown[] = []
+      return {
+        subscribe: vi.fn(() => () => {}),
+        prompt: vi.fn(() => new Promise<void>(() => { })),
+        abort: vi.fn(),
+        state: { get messages() { return messages } },
+      }
+    }),
+  }
+})
+
+const mockProvider: ProviderConfig = {
+  id: 'test-provider-id',
+  name: 'test-provider',
+  type: 'openai',
+  providerType: 'openai',
+  provider: 'openai',
+  baseUrl: 'http://localhost:1234',
+  apiKey: 'test-key',
+  defaultModel: 'test-model',
+  models: [],
+  status: 'connected',
+  authMethod: 'api-key',
+}
+
+describe('createTaskTool', () => {
+  const tmpFiles: string[] = []
+  let db: Database
+  let runner: TaskRunner
+  let sessionManager: SessionManager
+
+  function tmpDbPath(): string {
+    const p = path.join(os.tmpdir(), `axiom-task-tools-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+    tmpFiles.push(p)
+    return p
+  }
+
+  function buildBoundary(): TaskRuntimeTaskBoundary {
+    const store = runner.getStore()
+    return {
+      create: (input: CreateTaskInput) => store.create(input),
+      getById: (id: string) => store.getById(id),
+      list: (filters?: TaskListFilters) => store.list(filters),
+      update: (id: string, updates: UpdateTaskInput) => store.update(id, updates),
+      start: (task: Task, provider, overrides, parentSessionId) =>
+        runner.startTask(task, provider, overrides, parentSessionId),
+      resume: (taskId: string, message: string) => runner.resumeTask(taskId, message),
+      abort: (taskId: string, reason?: string) => runner.abortTask(taskId, reason),
+      isRunning: (taskId: string) => runner.isRunning(taskId),
+      getRunningIds: () => runner.getRunningTaskIds(),
+      isPaused: (taskId: string) => runner.isPaused(taskId),
+      getPausedIds: () => runner.getPausedTaskIds(),
+      cleanupStalePaused: () => runner.cleanupStalePausedTasks(),
+      recover: (getProvider, defaultProvider) => runner.recoverTasks(getProvider, defaultProvider),
+    }
+  }
+
+  beforeEach(() => {
+    db = initDatabase(tmpDbPath())
+    sessionManager = new SessionManager({ db })
+
+    const options: TaskRunnerOptions = {
+      db,
+      buildModel: () => ({} as ReturnType<TaskRunnerOptions['buildModel']>),
+      getApiKey: async () => 'test-key',
+      tools: [],
+      memoryDir: undefined,
+      onTaskComplete: () => { },
+      sessionManager,
+    }
+    runner = new TaskRunner(options)
+  })
+
+  afterEach(() => {
+    runner.dispose()
+    db.close()
+    for (const f of tmpFiles) {
+      try { fs.unlinkSync(f) } catch { }
+    }
+    tmpFiles.length = 0
+  })
+
+  it('persists max_duration_minutes from the tool input onto the Task row', async () => {
+    const tool = createTaskTool({
+      taskRuntime: buildBoundary(),
+      getDefaultProvider: () => mockProvider,
+      resolveProvider: () => mockProvider,
+      defaultMaxDurationMinutes: 60,
+      maxDurationMinutesCap: 240,
+    })
+
+    const result = await tool.execute('call-1', {
+      prompt: 'do work',
+      name: 'Test',
+      max_duration_minutes: 5,
+    })
+
+    const taskId = (result.details as { taskId: string }).taskId
+    const task = runner.getStore().getById(taskId)!
+    expect(task.maxDurationMinutes).toBe(5)
+    const first = result.content[0]
+    expect(first.type).toBe('text')
+    expect((first as { type: 'text'; text: string }).text).toContain('Max Duration: 5 minutes')
+
+    runner.abortTask(taskId, 'cleanup')
+  })
+
+  it('falls back to defaultMaxDurationMinutes when the caller omits max_duration_minutes', async () => {
+    const tool = createTaskTool({
+      taskRuntime: buildBoundary(),
+      getDefaultProvider: () => mockProvider,
+      resolveProvider: () => mockProvider,
+      defaultMaxDurationMinutes: 30,
+      maxDurationMinutesCap: 240,
+    })
+
+    const result = await tool.execute('call-2', {
+      prompt: 'do work',
+      name: 'Default',
+    })
+
+    const taskId = (result.details as { taskId: string }).taskId
+    const task = runner.getStore().getById(taskId)!
+    expect(task.maxDurationMinutes).toBe(30)
+
+    runner.abortTask(taskId, 'cleanup')
+  })
+
+  it('caps max_duration_minutes at maxDurationMinutesCap', async () => {
+    const tool = createTaskTool({
+      taskRuntime: buildBoundary(),
+      getDefaultProvider: () => mockProvider,
+      resolveProvider: () => mockProvider,
+      defaultMaxDurationMinutes: 30,
+      maxDurationMinutesCap: 120,
+    })
+
+    const result = await tool.execute('call-3', {
+      prompt: 'do work',
+      name: 'Capped',
+      max_duration_minutes: 9999,
+    })
+
+    const taskId = (result.details as { taskId: string }).taskId
+    const task = runner.getStore().getById(taskId)!
+    expect(task.maxDurationMinutes).toBe(120)
+
+    runner.abortTask(taskId, 'cleanup')
+  })
+
+  it('the TaskRunner timeout uses the tool-supplied max_duration_minutes', async () => {
+    const tool = createTaskTool({
+      taskRuntime: buildBoundary(),
+      getDefaultProvider: () => mockProvider,
+      resolveProvider: () => mockProvider,
+      defaultMaxDurationMinutes: 999,
+      maxDurationMinutesCap: 9999,
+    })
+
+    const result = await tool.execute('call-4', {
+      prompt: 'do work',
+      name: 'BudgetCheck',
+      max_duration_minutes: 1,
+    })
+    const taskId = (result.details as { taskId: string }).taskId
+
+    const longAgo = new Date(Date.now() - 2 * 60 * 1000)
+      .toISOString().replace('T', ' ').slice(0, 19)
+    runner.getStore().update(taskId, { startedAt: longAgo })
+
+    const internal = runner as unknown as {
+      scheduleMaxDurationTimeout: (rt: { taskId: string; timeoutTimer: unknown; startedAtMs: number }, t: { id: string; maxDurationMinutes: number | null; startedAt: string | null }) => void
+      runningTasks: Map<string, { taskId: string; timeoutTimer: unknown; startedAtMs: number }>
+    }
+    const rt = internal.runningTasks.get(taskId)!
+    const refreshed = runner.getStore().getById(taskId)!
+    internal.scheduleMaxDurationTimeout(rt, refreshed)
+
+    const updated = runner.getStore().getById(taskId)!
+    expect(updated.status).toBe('failed')
+    expect(updated.errorMessage).toBe('Max duration exceeded')
+  })
+})


### PR DESCRIPTION
## Problem

Two related issues in the task runtime that combine to make running tasks hard to observe:

1. Task injections reported wrong `duration_minutes`. A smoke test created with `max_duration_minutes=5` that ran for a few seconds reported `duration_minutes=120`. Root cause: the task store writes timestamps as `YYYY-MM-DD HH:MM:SS` via `new Date().toISOString().slice(0,19)` (always UTC), but most call sites read them back with `new Date(...).getTime()` (no `Z`), which Node parses as **local** time. On a UTC+2 host, `startedAt` moves 2h into the past, so `Date.now() - startedAt` ≈ 120 min regardless of the real runtime.
2. `prompt_tokens`, `completion_tokens`, `estimated_cost`, `tool_call_count` were only flushed to the `tasks` row at finalization. While a task ran, the API/UI/`list_tasks` output therefore showed zero progress, making it impossible to see from outside whether a task was advancing, stuck, or quietly burning budget.

## Change

- New `parseTaskTimestampMs` helper plus a `taskStartedAtMs` wrapper. All `task.startedAt` reads in `task-runner.ts` (injections, max-duration timer, paused-task cleanup, resume) now go through one UTC-aware path.
- New `persistLiveMetrics` writes the in-memory counters back to the task row after every `message_end` and `tool_execution_end` event. Errors are swallowed; the final update at completion still overrides everything, so the change is backward compatible.
- No schema changes. `create_task` / `max_duration_minutes` / `Task.maxDurationMinutes` flow was already correct — verified by new tests.

## Testing

```
npx vitest run packages/core packages/web-backend
# Test Files  60 passed (60)
# Tests       1103 passed (1103)
```

New tests:
- `parseTaskTimestampMs`: parses `'YYYY-MM-DD HH:MM:SS'` as UTC; returns `null` on bad input.
- `task injection duration uses real elapsed time`: a task with `maxDurationMinutes=5` that finishes in ~0s reports `duration_minutes < 2`, not a TZ-offset artefact (60/120/180).
- `live metric persistence during execution`: token / cost / tool-call counters become visible on the task row after `message_end` and `tool_execution_end`, before final completion.
- `task-tools.test.ts` (new file): `create_task` `max_duration_minutes` maps to `Task.maxDurationMinutes`, falls back to default, is capped at `maxDurationMinutesCap`, and the `TaskRunner` deadline is anchored on the per-task budget (not the runner-wide default).