### PR TITLE
chore: fix lint baseline

### DIFF
--- a/packages/web-backend/src/api/modules/providers/types.ts
+++ b/packages/web-backend/src/api/modules/providers/types.ts
@@ -1,12 +1,4 @@
 import type { OAuthCredentials } from '@mariozechner/pi-ai/oauth'
-import type {
-  ProviderActivationResponseContract,
-  ProviderContract,
-  ProviderFallbackResponseContract,
-  ProviderTestResultContract,
-  ProvidersListResponseContract,
-  OAuthStatusResponseContract,
-} from '@axiom/core/contracts'
 
 export interface ProvidersRouterOptions {
   onActiveProviderChanged?: () => void
@@ -28,29 +20,6 @@ export interface PendingOAuthLogin {
   createdAt: number
   existingProviderId?: string
 }
-
-interface ProvidersListData {
-  providers: ProvidersListResponseContract['providers']
-  activeProvider: string | null
-  activeModel: string | null
-  fallbackProvider: string | null
-  fallbackModel: string | null
-  presets: ProvidersListResponseContract['presets']
-}
-
-interface ProvidersMutationData {
-  provider: ProviderContract
-}
-
-type ProviderActivationData = ProviderActivationResponseContract
-type ProviderFallbackData = ProviderFallbackResponseContract
-type ProviderTestData = ProviderTestResultContract & {
-  latencyMs?: number
-  status?: string
-  modelId?: string
-}
-
-type OAuthStatusData = OAuthStatusResponseContract
 
 export interface OllamaTagsResponse {
   models?: Array<{

--- a/packages/web-backend/src/api/modules/settings/types.ts
+++ b/packages/web-backend/src/api/modules/settings/types.ts
@@ -30,10 +30,3 @@ export interface SettingsRouterOptions {
   onAgentHeartbeatSettingsChanged?: () => void
   onTelegramSettingsChanged?: () => void
 }
-
-interface SettingsUpdateEffects {
-  healthMonitorChanged: boolean
-  consolidationChanged: boolean
-  agentHeartbeatChanged: boolean
-  telegramChanged: boolean
-}

--- a/packages/web-backend/src/uploads.ts
+++ b/packages/web-backend/src/uploads.ts
@@ -2,11 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import multer from 'multer'
 import type { Request, Response, NextFunction } from 'express'
-import {
-  getUploadsDir,
-  parseUploadsMetadata,
-  type UploadDescriptor,
-} from '@axiom/core'
+import { getUploadsDir } from '@axiom/core'
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024
 
@@ -17,10 +13,6 @@ export const uploadMiddleware = multer({
     files: 5,
   },
 })
-
-function extractUploadsFromMetadata(metadata?: string | null): UploadDescriptor[] {
-  return parseUploadsMetadata(metadata)
-}
 
 export function sendUploadedFile(req: Request, res: Response, next: NextFunction): void {
   try {


### PR DESCRIPTION
## Problem

`npm run lint` fails on `upstream/main` because a few stale backend types/helpers are no longer used.

## Change

Remove the unused provider/settings type aliases and the unused upload metadata helper/imports.

## Testing

- `npm run lint`
- `npm run build`
- `npx vitest run packages/web-backend`