### PR TITLE
fix: reload task default provider settings

### DIFF
--- a/packages/web-backend/src/bootstrap/runtime-composition.test.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.test.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { loadRuntimeSettings } from './runtime-composition.js'
+
+let tempDataDir: string
+let previousDataDir: string | undefined
+
+function writeSettings(settings: unknown) {
+  const configDir = path.join(tempDataDir, 'config')
+  fs.mkdirSync(configDir, { recursive: true })
+  fs.writeFileSync(path.join(configDir, 'settings.json'), JSON.stringify(settings, null, 2))
+}
+
+describe('runtime composition settings', () => {
+  beforeEach(() => {
+    previousDataDir = process.env.DATA_DIR
+    tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axiom-runtime-settings-'))
+    process.env.DATA_DIR = tempDataDir
+  })
+
+  afterEach(() => {
+    if (previousDataDir === undefined) {
+      delete process.env.DATA_DIR
+    } else {
+      process.env.DATA_DIR = previousDataDir
+    }
+    fs.rmSync(tempDataDir, { recursive: true, force: true })
+  })
+
+  it('reloads task defaults from settings.json on each call', () => {
+    writeSettings({ tasks: { defaultProvider: 'openai-oauth:gpt-5.3-codex' } })
+    expect(loadRuntimeSettings().taskSettings.defaultProvider).toBe('openai-oauth:gpt-5.3-codex')
+
+    writeSettings({ tasks: { defaultProvider: 'openai-oauth:gpt-5.5' } })
+    expect(loadRuntimeSettings().taskSettings.defaultProvider).toBe('openai-oauth:gpt-5.5')
+  })
+
+  it('falls back to an empty task default when settings no longer define one', () => {
+    writeSettings({ tasks: { defaultProvider: 'openai-oauth:gpt-5.3-codex' } })
+    expect(loadRuntimeSettings().taskSettings.defaultProvider).toBe('openai-oauth:gpt-5.3-codex')
+
+    writeSettings({ tasks: {} })
+    expect(loadRuntimeSettings().taskSettings.defaultProvider).toBe('')
+  })
+})

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -139,7 +139,7 @@ export interface RuntimeCompositionOptions {
   logger?: Pick<typeof console, 'log' | 'warn' | 'error'>
 }
 
-function loadRuntimeSettings(): RuntimeSettings {
+export function loadRuntimeSettings(): RuntimeSettings {
   let sessionTimeoutMinutes = 30
   const taskSettings: TaskSettings = {
     defaultProvider: '',
@@ -307,6 +307,10 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   const runtimeMetrics = new RuntimeMetrics()
   const { sessionTimeoutMinutes, taskSettings, builtinToolsConfig } = loadRuntimeSettings()
 
+  function getCurrentTaskSettings(): TaskSettings {
+    return loadRuntimeSettings().taskSettings
+  }
+
   function resolveProvider(nameOrId: string): ProviderConfig | null {
     try {
       const file = loadProvidersDecrypted()
@@ -319,8 +323,9 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   }
 
   function getTaskDefaultProvider(): ProviderConfig {
-    if (taskSettings.defaultProvider) {
-      const { providerId, modelId } = parseProviderModelId(taskSettings.defaultProvider)
+    const currentTaskSettings = getCurrentTaskSettings()
+    if (currentTaskSettings.defaultProvider) {
+      const { providerId, modelId } = parseProviderModelId(currentTaskSettings.defaultProvider)
       if (providerId) {
         let resolved = resolveProvider(providerId)
         if (resolved && modelId) {


### PR DESCRIPTION
## Problem
Changing the default provider/model in Settings → Tasks was not reflected by task operations that relied on the configured task default. The runtime loaded task settings once during startup and kept using that stale value.

## Change
Reload task settings when resolving the task default provider so provider/model changes in `settings.json` are picked up without restarting the backend.

Added regression coverage for re-reading `settings.json` and clearing the task default when the setting is removed.

## Testing
- `npx vitest run packages/web-backend/src/bootstrap/runtime-composition.test.ts`
- `npm run baseline:parity`