### PR TITLE
fix(web): fix code block copy escapes and improve code block styling

### DIFF
--- a/packages/web-frontend/app/assets/css/tailwind.css
+++ b/packages/web-frontend/app/assets/css/tailwind.css
@@ -408,8 +408,26 @@
     }
 
     /* Code blocks */
+    .code-block-wrapper {
+      @apply my-2 overflow-hidden rounded-lg border border-border/70 bg-muted/40 shadow-sm dark:border-border;
+    }
+    .code-block-header {
+      @apply flex select-none items-center justify-between gap-2 rounded-t-lg border-b border-border/70 bg-muted/70 px-3 py-1.5;
+    }
+    .code-block-language {
+      @apply truncate font-mono text-[0.68rem] font-medium uppercase tracking-wide text-muted-foreground;
+    }
+    .code-block-copy-button {
+      @apply inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring;
+    }
+    .code-block-copy-button svg {
+      @apply h-3.5 w-3.5;
+    }
     pre {
       @apply my-2 overflow-x-auto rounded-lg bg-muted p-3 text-xs leading-relaxed;
+    }
+    .code-block-wrapper pre {
+      @apply my-0 rounded-t-none bg-muted/80;
     }
     pre code {
       @apply bg-transparent p-0;

--- a/packages/web-frontend/app/assets/css/tailwind.css
+++ b/packages/web-frontend/app/assets/css/tailwind.css
@@ -409,10 +409,10 @@
 
     /* Code blocks */
     .code-block-wrapper {
-      @apply my-2 overflow-hidden rounded-lg border border-border/70 bg-muted/40 shadow-sm dark:border-border;
+      @apply my-2 overflow-hidden rounded-lg border border-border/80 bg-muted/60 shadow-sm dark:border-border/90 dark:bg-background/55;
     }
     .code-block-header {
-      @apply flex select-none items-center justify-between gap-2 rounded-t-lg border-b border-border/70 bg-muted/70 px-3 py-1.5;
+      @apply flex select-none items-center justify-between gap-2 rounded-t-lg border-b border-border/80 bg-muted px-3 py-1.5 dark:border-border/90 dark:bg-background/75;
     }
     .code-block-language {
       @apply truncate font-mono text-[0.68rem] font-medium uppercase tracking-wide text-muted-foreground;
@@ -427,7 +427,7 @@
       @apply my-2 overflow-x-auto rounded-lg bg-muted p-3 text-xs leading-relaxed;
     }
     .code-block-wrapper pre {
-      @apply my-0 rounded-t-none bg-muted/80;
+      @apply my-0 rounded-t-none bg-muted/70 dark:bg-background/60;
     }
     pre code {
       @apply bg-transparent p-0;

--- a/packages/web-frontend/app/composables/useMarkdown.ts
+++ b/packages/web-frontend/app/composables/useMarkdown.ts
@@ -1,4 +1,4 @@
-import { marked } from 'marked'
+import { marked, type Tokens } from 'marked'
 import TurndownService from 'turndown'
 
 // Configure marked for clean, minimal output
@@ -8,12 +8,54 @@ marked.setOptions({
 })
 
 const renderer = new marked.Renderer()
+
+function escapeHtml(value: string, encode = false): string {
+  const pattern = encode
+    ? /[&<>"']/g
+    : /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/g
+
+  return value.replace(pattern, (char) => {
+    switch (char) {
+      case '&': return '&amp;'
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '"': return '&quot;'
+      case "'": return '&#39;'
+      default: return char
+    }
+  })
+}
+
+function codeLanguageLabel(lang?: string): string {
+  return lang?.match(/^\S*/)?.[0] || 'code'
+}
+
 renderer.link = ({ href, title, tokens }) => {
   const text = marked.Parser.parseInline(tokens)
   const safeHref = href || ''
   const titleAttr = title ? ` title="${title}"` : ''
 
   return `<a href="${safeHref}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`
+}
+
+renderer.code = ({ text, lang, escaped }: Tokens.Code) => {
+  const language = codeLanguageLabel(lang)
+  const languageAttr = language === 'code' ? '' : ` class="language-${escapeHtml(language)}"`
+  const code = `${text.replace(/\n$/, '')}\n`
+  const escapedCode = escaped ? code : escapeHtml(code, true)
+  const escapedLanguage = escapeHtml(language)
+
+  return `<div class="code-block-wrapper" data-language="${escapedLanguage}">`
+    + '<div class="code-block-header" data-code-block-header="true">'
+    + `<span class="code-block-language">${escapedLanguage}</span>`
+    + '<button type="button" class="code-block-copy-button" data-code-copy-button="true" aria-label="Copy code" title="Copy code">'
+    + '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>'
+    + '</svg>'
+    + '</button>'
+    + '</div>'
+    + `<pre><code${languageAttr}>${escapedCode}</code></pre>`
+    + '</div>\n'
 }
 
 // Configure turndown for HTML → Markdown conversion (used on copy)
@@ -24,6 +66,15 @@ const turndown = new TurndownService({
   emDelimiter: '*',
   strongDelimiter: '**',
 })
+
+function closestPre(container: Node): HTMLPreElement | null {
+  const element = container instanceof HTMLElement ? container : container.parentElement
+  return element?.closest('pre') ?? null
+}
+
+async function writeClipboardText(text: string): Promise<void> {
+  await navigator.clipboard?.writeText(text)
+}
 
 /**
  * Render markdown string to HTML and provide copy-as-markdown support.
@@ -53,10 +104,18 @@ export function useMarkdown() {
 
     if (!proseEl) return // Not inside rendered markdown — let default copy work
 
+    const pre = closestPre(ancestor)
+    if (pre) {
+      event.preventDefault()
+      event.clipboardData?.setData('text/plain', pre.textContent ?? '')
+      return
+    }
+
     // Clone the selected fragment and convert HTML → Markdown
     const fragment = range.cloneContents()
     const wrapper = document.createElement('div')
     wrapper.appendChild(fragment)
+    wrapper.querySelectorAll('[data-code-block-header="true"]').forEach((el) => el.remove())
 
     const md = turndown.turndown(wrapper.innerHTML)
 
@@ -66,5 +125,21 @@ export function useMarkdown() {
     event.clipboardData?.setData('text/html', wrapper.innerHTML)
   }
 
-  return { renderMarkdown, handleCopyAsMarkdown }
+  function handleMarkdownCodeCopy(event: MouseEvent) {
+    const target = event.target
+    if (!(target instanceof Element)) return
+
+    const button = target.closest('[data-code-copy-button="true"]')
+    if (!(button instanceof HTMLButtonElement)) return
+
+    const wrapper = button.closest('.code-block-wrapper')
+    const pre = wrapper?.querySelector('pre')
+    if (!(pre instanceof HTMLPreElement)) return
+
+    event.preventDefault()
+    event.stopPropagation()
+    void writeClipboardText(pre.textContent ?? '')
+  }
+
+  return { renderMarkdown, handleCopyAsMarkdown, handleMarkdownCodeCopy }
 }

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -88,7 +88,7 @@
       </template>
     </PageHeader>
 
-    <div ref="messagesContainer" class="relative flex flex-1 flex-col gap-4 overflow-y-auto p-4" @scroll="onMessagesScroll" @copy="handleCopyAsMarkdown">
+    <div ref="messagesContainer" class="relative flex flex-1 flex-col gap-4 overflow-y-auto p-4" @scroll="onMessagesScroll" @copy="handleCopyAsMarkdown" @click="handleMarkdownCodeCopy">
       <div v-if="loadingHistory" class="flex flex-col gap-3">
         <div class="flex items-start gap-3 self-start"><Skeleton class="h-8 w-8 shrink-0 rounded-full" /><div class="space-y-2"><Skeleton class="h-4 w-48 rounded-xl" /><Skeleton class="h-4 w-64 rounded-xl" /></div></div>
       </div>
@@ -552,7 +552,7 @@ async function handleThinkingLevelChange(level: SettingsThinkingLevel) {
   }
 }
 const { userAvatarUrl, avatarFailed, userInitial, onAvatarError } = useUserAvatar()
-const { renderMarkdown, handleCopyAsMarkdown } = useMarkdown()
+const { renderMarkdown, handleCopyAsMarkdown, handleMarkdownCodeCopy } = useMarkdown()
 const { isSkillLoad, getSkillName } = useSkillDetection()
 function isToolSkillLoad(toolData: ToolCallData): boolean { return isSkillLoad(toolData.toolName, toolData.toolArgs) }
 function getToolMemoryInfo(toolData: ToolCallData) { return detectMemoryFile(toolData.toolName, toolData.toolArgs) }


### PR DESCRIPTION
$## Problem\nCopying selections inside chat code blocks goes through Turndown, which re-fences and escapes code so pasted snippets can break. Code blocks also blend into chat body text.\n\n## Change\n- Bypass Turndown for selections whose common ancestor is inside a `<pre>` and copy the raw `pre.textContent` as `text/plain`.\n- Render markdown code blocks with a language header and copy button.\n- Style code block wrappers/header/pre so blocks are visually distinct in light and dark mode.\n\n## How to test\n- Copy text selected inside a chat code block and paste it into an editor; it should be raw runnable code.\n- Click the code block copy button and paste; it should copy the raw block content.\n- Verify code blocks show a language label, header bar, and clear block styling in light/dark mode.