### PR TITLE
fix: hot-reload web_search provider settings without restart

### DIFF
--- a/packages/core/src/agent-runtime.ts
+++ b/packages/core/src/agent-runtime.ts
@@ -18,7 +18,7 @@ import { getWorkspaceDir } from './workspace.js'
 import { loadConfig, ensureConfigTemplates } from './config.js'
 import { loadSkills, getSkillDecrypted } from './skill-config.js'
 import { createBuiltinWebTools } from './web-tools.js'
-import type { BuiltinToolsConfig } from './web-tools.js'
+import type { BuiltinToolsConfig, BuiltinToolsConfigSource } from './web-tools.js'
 import { createTranscribeAudioTool } from './stt-tool.js'
 import { loadSttSettings } from './stt.js'
 import { createAgentSkillTools, getAgentSkillsForPrompt, getAgentSkillsCount, getAgentSkillsDir, trackAgentSkillUsage, currentPlatform } from './agent-skills.js'
@@ -33,7 +33,14 @@ import type { AgentRuntimeStateSnapshot, ResponseChunk } from './agent-runtime-t
  */
 export interface BaseAgentToolsOptions {
   db: Database
-  builtinToolsConfig?: BuiltinToolsConfig
+  /**
+   * Built-in tools (web_search / web_fetch) config. Pass a function to enable
+   * hot-reload of the web_search provider/API-keys after Settings > Built-in
+   * Tools is saved — the getter is called on every `web_search` invocation,
+   * so the next tool call uses the freshly persisted provider without a
+   * server restart.
+   */
+  builtinToolsConfig?: BuiltinToolsConfigSource
   sttEnabled?: boolean
   /** Called by search_memories to scope results to the current user. */
   getCurrentUserId?: () => number | undefined
@@ -449,7 +456,7 @@ class PiAgentRuntime implements AgentRuntimeBoundary, AgentRuntimePiAgentAccess 
     ensureMemoryStructure(options.memoryDir)
     ensureConfigStructure()
 
-    const { builtinToolsConfig, sttEnabled, thinkingLevel: storedThinkingLevel } = this.readRuntimeSettings()
+    const { sttEnabled, thinkingLevel: storedThinkingLevel } = this.readRuntimeSettings()
     const effectiveThinkingLevel = normalizeThinkingLevel(options.thinkingLevel) ?? storedThinkingLevel ?? 'off'
 
     const systemPrompt = options.systemPrompt ?? this.buildSystemPrompt()
@@ -458,7 +465,7 @@ class PiAgentRuntime implements AgentRuntimeBoundary, AgentRuntimePiAgentAccess 
       ...(options.tools ?? []),
       ...createBaseAgentTools({
         db: this.db,
-        builtinToolsConfig,
+        builtinToolsConfig: () => this.readRuntimeSettings().builtinToolsConfig,
         sttEnabled,
         getCurrentUserId: () => this.getCurrentToolUserId(),
       }),

--- a/packages/core/src/agent-runtime.ts
+++ b/packages/core/src/agent-runtime.ts
@@ -33,13 +33,6 @@ import type { AgentRuntimeStateSnapshot, ResponseChunk } from './agent-runtime-t
  */
 export interface BaseAgentToolsOptions {
   db: Database
-  /**
-   * Built-in tools (web_search / web_fetch) config. Pass a function to enable
-   * hot-reload of the web_search provider/API-keys after Settings > Built-in
-   * Tools is saved — the getter is called on every `web_search` invocation,
-   * so the next tool call uses the freshly persisted provider without a
-   * server restart.
-   */
   builtinToolsConfig?: BuiltinToolsConfigSource
   sttEnabled?: boolean
   /** Called by search_memories to scope results to the current user. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -177,7 +177,7 @@ export {
   BraveSearchError,
   TavilySearchError,
 } from './web-tools.js'
-export type { WebSearchResult, WebSearchConfig, WebFetchConfig, BuiltinToolsConfig, SearchProvider, ResolvedSearchProvider, BraveErrorCategory, TavilyErrorCategory, RetryOptions } from './web-tools.js'
+export type { WebSearchResult, WebSearchConfig, WebSearchConfigSource, WebFetchConfig, BuiltinToolsConfig, BuiltinToolsConfigSource, SearchProvider, ResolvedSearchProvider, BraveErrorCategory, TavilyErrorCategory, RetryOptions } from './web-tools.js'
 export {
   listAgentSkills,
   trackAgentSkillUsage,

--- a/packages/core/src/web-tools.test.ts
+++ b/packages/core/src/web-tools.test.ts
@@ -1530,4 +1530,56 @@ describe('createBuiltinWebTools', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Falling back to DuckDuckGo'))
     warnSpy.mockRestore()
   })
+
+  it('re-resolves web_search provider on every call when config is a getter (hot-reload)', async () => {
+    let currentProvider: 'duckduckgo' | 'tavily' = 'duckduckgo'
+    const tools = createBuiltinWebTools(() => ({
+      webSearch: {
+        enabled: true,
+        provider: currentProvider,
+        tavilyApiKey: 'tvly-test-key',
+      },
+      webFetch: { enabled: true },
+    }))
+    const webSearch = tools.find(t => t.name === 'web_search')!
+
+    const originalFetch = globalThis.fetch
+    const calls: string[] = []
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+      calls.push(typeof url === 'string' ? url : String(url))
+      if (typeof url === 'string' && url.includes('api.tavily.com')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            results: [
+              { title: 'Tavily Hit', url: 'https://example.com/tav', content: 'tav snippet' },
+            ],
+          }),
+        })
+      }
+      // DuckDuckGo HTML lite response
+      return Promise.resolve({
+        ok: true,
+        text: async () => `
+          <a rel="nofollow" href="https://example.com/ddg" class="result-link">DDG Hit</a>
+          <td class="result-snippet">ddg snippet</td>
+        `,
+      })
+    }) as unknown as typeof fetch
+
+    try {
+      const r1 = await webSearch.execute('id-1', { query: 'test' })
+      expect(r1.details.provider).toBe('duckduckgo')
+      expect(calls.some(u => u.includes('duckduckgo.com'))).toBe(true)
+
+      // User "saves" a new provider in Settings.
+      currentProvider = 'tavily'
+
+      const r2 = await webSearch.execute('id-2', { query: 'test' })
+      expect(r2.details.provider).toBe('tavily')
+      expect(calls.some(u => u.includes('api.tavily.com'))).toBe(true)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })

--- a/packages/core/src/web-tools.ts
+++ b/packages/core/src/web-tools.ts
@@ -564,12 +564,6 @@ function resolveWebSearchConfig(source?: WebSearchConfigSource): WebSearchConfig
 /**
  * Create the web_search AgentTool.
  * Supports DuckDuckGo, Brave Search, SearXNG, and Tavily providers.
- *
- * `config` may be a static object (snapshot at construction time) or a getter
- * function. When a getter is supplied, the provider, API keys, and retry
- * settings are resolved fresh on every `execute()` call — so saving a new
- * provider in Settings > Built-in Tools takes effect on the next tool call
- * without a server restart.
  */
 export function createWebSearchTool(config?: WebSearchConfigSource): AgentTool {
   const isDynamic = typeof config === 'function'
@@ -760,11 +754,6 @@ export function createWebFetchTool(_config?: WebFetchConfig): AgentTool {
  * config on each invocation. When a getter is supplied, `web_search` resolves
  * its provider/API-keys fresh on every call — enabling hot-reload of
  * Settings > Built-in Tools without a server restart.
- *
- * Note: the `enabled` flags are still read once at registration time, because
- * adding/removing a tool changes the agent's tool inventory and requires a
- * separate rebuild path. Provider switching is the common case and is what
- * this hot-reload path supports.
  */
 export type BuiltinToolsConfigSource = BuiltinToolsConfig | (() => BuiltinToolsConfig | undefined)
 
@@ -775,9 +764,6 @@ function resolveBuiltinToolsConfig(source?: BuiltinToolsConfigSource): BuiltinTo
 /**
  * Create all enabled built-in web tools based on config.
  * This is the main entry point for AgentCore integration.
- *
- * Pass a function as `config` to make `web_search` re-read provider settings
- * on every invocation (hot-reload after Settings save).
  */
 export function createBuiltinWebTools(config?: BuiltinToolsConfigSource): AgentTool[] {
   const isDynamic = typeof config === 'function'

--- a/packages/core/src/web-tools.ts
+++ b/packages/core/src/web-tools.ts
@@ -549,15 +549,35 @@ export function resolveSearchProvider(config?: WebSearchConfig): ResolvedSearchP
 // ─── Tool Factories ──────────────────────────────────────────────────────────
 
 /**
- * Create the web_search AgentTool.
- * Supports DuckDuckGo, Brave Search, and SearXNG providers.
+ * Either a static `WebSearchConfig` or a getter that returns the current
+ * config on each invocation. The getter form lets callers wire the tool to a
+ * live settings source so that provider/API-key changes from Settings → Built-in
+ * Tools take effect on the next `web_search` call without requiring a server
+ * restart.
  */
-export function createWebSearchTool(config?: WebSearchConfig): AgentTool {
-  const resolved = resolveSearchProvider(config)
+export type WebSearchConfigSource = WebSearchConfig | (() => WebSearchConfig | undefined)
 
-  // Log warning if provider fallback occurred
-  if (resolved.warning) {
-    console.warn(`[web_search] ${resolved.warning}`)
+function resolveWebSearchConfig(source?: WebSearchConfigSource): WebSearchConfig | undefined {
+  return typeof source === 'function' ? source() : source
+}
+
+/**
+ * Create the web_search AgentTool.
+ * Supports DuckDuckGo, Brave Search, SearXNG, and Tavily providers.
+ *
+ * `config` may be a static object (snapshot at construction time) or a getter
+ * function. When a getter is supplied, the provider, API keys, and retry
+ * settings are resolved fresh on every `execute()` call — so saving a new
+ * provider in Settings > Built-in Tools takes effect on the next tool call
+ * without a server restart.
+ */
+export function createWebSearchTool(config?: WebSearchConfigSource): AgentTool {
+  const isDynamic = typeof config === 'function'
+
+  const staticConfig = isDynamic ? undefined : config
+  const staticResolved = isDynamic ? null : resolveSearchProvider(staticConfig)
+  if (staticResolved?.warning) {
+    console.warn(`[web_search] ${staticResolved.warning}`)
   }
 
   return {
@@ -574,13 +594,19 @@ export function createWebSearchTool(config?: WebSearchConfig): AgentTool {
       const { query, count: rawCount } = params as { query: string; count?: number }
       const count = Math.min(Math.max(rawCount ?? 5, 1), 20)
 
+      const currentConfig = isDynamic ? resolveWebSearchConfig(config) : staticConfig
+      const resolved = isDynamic ? resolveSearchProvider(currentConfig) : staticResolved!
+      if (isDynamic && resolved.warning) {
+        console.warn(`[web_search] ${resolved.warning}`)
+      }
+
       const retryOpts: RetryOptions = {
-        maxRetries: resolved.provider !== 'duckduckgo' ? (config?.retry?.maxRetries ?? 2) : 0,
-        baseDelayMs: config?.retry?.baseDelayMs ?? 500,
+        maxRetries: resolved.provider !== 'duckduckgo' ? (currentConfig?.retry?.maxRetries ?? 2) : 0,
+        baseDelayMs: currentConfig?.retry?.baseDelayMs ?? 500,
         shouldRetry: (err: unknown) =>
           (err instanceof BraveSearchError && err.retryable) ||
           (err instanceof TavilySearchError && err.retryable),
-        delayFn: config?.retry?.delayFn,
+        delayFn: currentConfig?.retry?.delayFn,
       }
 
       let results: WebSearchResult[]
@@ -730,25 +756,62 @@ export function createWebFetchTool(_config?: WebFetchConfig): AgentTool {
 // ─── Builtin Tools Factory ───────────────────────────────────────────────────
 
 /**
+ * Either a static `BuiltinToolsConfig` or a getter that returns the current
+ * config on each invocation. When a getter is supplied, `web_search` resolves
+ * its provider/API-keys fresh on every call — enabling hot-reload of
+ * Settings > Built-in Tools without a server restart.
+ *
+ * Note: the `enabled` flags are still read once at registration time, because
+ * adding/removing a tool changes the agent's tool inventory and requires a
+ * separate rebuild path. Provider switching is the common case and is what
+ * this hot-reload path supports.
+ */
+export type BuiltinToolsConfigSource = BuiltinToolsConfig | (() => BuiltinToolsConfig | undefined)
+
+function resolveBuiltinToolsConfig(source?: BuiltinToolsConfigSource): BuiltinToolsConfig | undefined {
+  return typeof source === 'function' ? source() : source
+}
+
+/**
  * Create all enabled built-in web tools based on config.
  * This is the main entry point for AgentCore integration.
+ *
+ * Pass a function as `config` to make `web_search` re-read provider settings
+ * on every invocation (hot-reload after Settings save).
  */
-export function createBuiltinWebTools(config?: BuiltinToolsConfig): AgentTool[] {
+export function createBuiltinWebTools(config?: BuiltinToolsConfigSource): AgentTool[] {
+  const isDynamic = typeof config === 'function'
+  const initialConfig = resolveBuiltinToolsConfig(config)
+
   const tools: AgentTool[] = []
 
   // web_search — enabled by default
-  if (config?.webSearch?.enabled !== false) {
-    const provider = (config?.webSearch?.provider ?? 'duckduckgo') as SearchProvider
-    tools.push(createWebSearchTool({
-      provider,
-      braveSearchApiKey: config?.webSearch?.braveSearchApiKey,
-      searxngUrl: config?.webSearch?.searxngUrl,
-      tavilyApiKey: config?.webSearch?.tavilyApiKey,
-    }))
+  if (initialConfig?.webSearch?.enabled !== false) {
+    if (isDynamic) {
+      const getter = (): WebSearchConfig | undefined => {
+        const current = resolveBuiltinToolsConfig(config)
+        const provider = (current?.webSearch?.provider ?? 'duckduckgo') as SearchProvider
+        return {
+          provider,
+          braveSearchApiKey: current?.webSearch?.braveSearchApiKey,
+          searxngUrl: current?.webSearch?.searxngUrl,
+          tavilyApiKey: current?.webSearch?.tavilyApiKey,
+        }
+      }
+      tools.push(createWebSearchTool(getter))
+    } else {
+      const provider = (initialConfig?.webSearch?.provider ?? 'duckduckgo') as SearchProvider
+      tools.push(createWebSearchTool({
+        provider,
+        braveSearchApiKey: initialConfig?.webSearch?.braveSearchApiKey,
+        searxngUrl: initialConfig?.webSearch?.searxngUrl,
+        tavilyApiKey: initialConfig?.webSearch?.tavilyApiKey,
+      }))
+    }
   }
 
   // web_fetch — enabled by default
-  if (config?.webFetch?.enabled !== false) {
+  if (initialConfig?.webFetch?.enabled !== false) {
     tools.push(createWebFetchTool())
   }
 

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -305,7 +305,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   injectSecretsIntoEnv()
 
   const runtimeMetrics = new RuntimeMetrics()
-  const { sessionTimeoutMinutes, taskSettings, builtinToolsConfig } = loadRuntimeSettings()
+  const { sessionTimeoutMinutes, taskSettings } = loadRuntimeSettings()
 
   function getCurrentTaskSettings(): TaskSettings {
     return loadRuntimeSettings().taskSettings
@@ -639,7 +639,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   // so adding a new base tool in one place automatically covers both paths.
   const backgroundTaskTools: AgentTool[] = createBaseAgentTools({
     db,
-    builtinToolsConfig,
+    builtinToolsConfig: () => loadRuntimeSettings().builtinToolsConfig,
     sttEnabled: backgroundSttEnabled,
     // Background tasks have no interactive session; search_memories will fall
     // back to the lowest-id user when getCurrentUserId is undefined.


### PR DESCRIPTION
## Problem

Changing the **web_search** provider (or its API key / SearXNG URL) under **Settings > Built-in Tools** and clicking *Save* did not take effect until the server was restarted: the next `web_search` tool call in the same chat session still went to the previously configured backend.

## Root cause

`createWebSearchTool(config)` calls `resolveSearchProvider(config)` **once** at construction time and binds the resolved `searchFn` in a closure. The tool is instantiated at server startup via `createBuiltinWebTools(builtinToolsConfig)` (in `agent-runtime.ts` for the interactive agent, and in `runtime-composition.ts` for background task agents) using a snapshot of `settings.json`. The `PATCH /api/skills/builtin` handler writes the new config to disk and calls `agentCore.refreshSkills()`, but that only rebuilds the system prompt — the tools array (and the closed-over `searchFn`) keeps pointing at the old provider.

## Change

- `createWebSearchTool` and `createBuiltinWebTools` now accept either a static config (existing behaviour, backwards compatible) or a getter `() => Config | undefined`. When a getter is passed, the provider, API keys, and retry settings are re-resolved on every `execute()` call.
- `createBaseAgentTools` propagates the getter form.
- Both call sites — `PiAgentRuntime` (interactive agent) and `runtime-composition.ts` (background task tool set) — now pass a getter that reads `settings.json` fresh, so the next `web_search` call after Save uses the freshly persisted provider with no restart.
- Static-config callers (notably the existing test suite and any external consumers) keep their previous semantics — a single resolution at construction time, including the constructor-time fallback warning log.

## Testing

- Added a regression test in `web-tools.test.ts` (`createBuiltinWebTools`): flip the provider from `duckduckgo` to `tavily` between two `execute()` calls on the same tool instance and assert the second call hits `api.tavily.com` and reports `provider: 'tavily'`.
- Full suites green: `vitest run packages/core` (978 tests) and `vitest run packages/web-backend` (187 tests).
- `npm run build` succeeds for `@axiom/core`, `@axiom/telegram`, and `@axiom/web-backend`.
- `npm run lint:boundaries` is clean. (The repo's `npm run lint` reports 2 pre-existing `no-empty` errors in test files unrelated to this change.)

## Notes / scope

- Hot-reload covers the **provider switch** and **API key / SearXNG URL** changes — the common case described in the issue.
- The `webSearch.enabled` / `webFetch.enabled` toggles are still evaluated at registration time. Enabling or disabling a built-in tool changes the agent's tool inventory and requires a separate rebuild of `agent.state.tools` — left out of scope here to keep the diff minimal.