### PR TITLE
feat: non-blocking new session with background summary

### DIFF
--- a/docs/web-ui/chat.md
+++ b/docs/web-ui/chat.md
@@ -21,7 +21,7 @@ The top of the page has a slim toolbar (`PageHeader`). On mobile its action butt
 **Right side — actions:**
 
 - **Stop** — aborts whatever the agent is currently doing (only enabled while a response is streaming). Equivalent to typing `/stop` in chat or hitting the Kill button on the parent task.
-- **New Session** — closes the current chat session and starts a fresh one. A *Session Summary* may be generated before the divider appears (see [Memory System → session summaries](../concepts/memory) for how that works). The next message you send opens a new session.
+- **New Session** — closes the current chat session and starts a fresh one. The divider appears immediately; a *Session Summary* card may fill in shortly after once background generation completes (see [Memory System → session summaries](../concepts/memory) for how that works). The next message you send opens a new session.
 - **Settings (gear icon)** — display filters, see below.
 
 ## Display filters

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -33,8 +33,20 @@ export interface AgentCoreOptions {
   baseInstructions?: string
   providerConfig?: ProviderConfig // For OAuth token refresh
   providerManager?: ProviderManager // For fallback retry support
-  /** Called when a session ends (timeout or /new command) with the summary text */
-  onSessionEnd?: (userId: string, sessionId: string, summary: string | null) => void
+  /**
+   * Called when a session ends (timeout, /new command, or provider change)
+   * with the summary text. `options.background` is true when the session
+   * was ended non-blockingly (`resetSessionAsync`) and the summary became
+   * available asynchronously after the new session had already been
+   * announced — listeners can use this to emit a follow-up update event
+   * rather than a duplicate session_end divider.
+   */
+  onSessionEnd?: (
+    userId: string,
+    sessionId: string,
+    summary: string | null,
+    options?: { background?: boolean },
+  ) => void
 }
 
 // Re-export for backward compatibility
@@ -49,7 +61,12 @@ export class AgentCore {
   private sessionManager: SessionManager
   private memoryDir?: string
   private baseInstructions?: string
-  private onSessionEndCallback?: (userId: string, sessionId: string, summary: string | null) => void
+  private onSessionEndCallback?: (
+    userId: string,
+    sessionId: string,
+    summary: string | null,
+    options?: { background?: boolean },
+  ) => void
   private onTaskInjectionChunkCallback?: (chunk: ResponseChunk) => void
   private messageQueue: MessageQueue
   private currentToolUserId?: number
@@ -86,13 +103,16 @@ export class AgentCore {
       onSummarize: async (_sessionId: string, userId: string, conversationHistory?: string) => {
         return this.generateSessionSummary(userId, conversationHistory)
       },
-      onSessionEnd: (session: SessionInfo, summary: string | null) => {
-        this.runtime.clearMessages()
-        this.refreshSystemPrompt()
-
-        // Notify external listener (e.g. ws-chat)
+      onSessionEnd: (session: SessionInfo, summary: string | null, opts) => {
+        // For background ends (resetSessionAsync), runtime state was already
+        // cleared synchronously when the new session was created — skip here
+        // to avoid wiping the new session's accumulated messages.
+        if (!opts?.background) {
+          this.runtime.clearMessages()
+          this.refreshSystemPrompt()
+        }
         if (this.onSessionEndCallback) {
-          this.onSessionEndCallback(session.userId, session.id, summary)
+          this.onSessionEndCallback(session.userId, session.id, summary, opts)
         }
       },
     })
@@ -570,7 +590,12 @@ Do NOT add this section if everything discussed was resolved or if there is noth
    */
   // Used by backend runtime composition to stream session-end events to clients.
   // fallow-ignore-next-line unused-class-member
-  setOnSessionEnd(callback: (userId: string, sessionId: string, summary: string | null) => void): void {
+  setOnSessionEnd(callback: (
+    userId: string,
+    sessionId: string,
+    summary: string | null,
+    options?: { background?: boolean },
+  ) => void): void {
     this.onSessionEndCallback = callback
   }
 
@@ -592,13 +617,37 @@ Do NOT add this section if everything discussed was resolved or if there is noth
   }
 
   /**
-   * Reset a user's session (async - generates summary before reset).
+   * Reset a user's session (blocking — awaits summary generation before
+   * returning). Prefer `resetSessionAsync` for interactive UIs where
+   * users should not wait for the LLM summary call to finish.
    */
-  // Used by the websocket chat /new command handler.
   // fallow-ignore-next-line unused-class-member
   async resetSession(userId: string): Promise<string | null> {
     const summary = await this.sessionManager.handleNewCommand(userId)
     return summary
+  }
+
+  /**
+   * Non-blocking variant: detaches the current session synchronously and
+   * returns the freshly minted session. Summary generation runs in the
+   * background; when it completes, the configured `onSessionEnd`
+   * callback fires with `options.background = true`.
+   *
+   * Also clears the runtime's in-memory message buffer synchronously so
+   * the new session starts clean, without waiting for the (slow)
+   * summary LLM call.
+   */
+  // Used by the websocket chat /new command handler for instant session switch.
+  // fallow-ignore-next-line unused-class-member
+  resetSessionAsync(userId: string, source: string = 'web'): SessionInfo {
+    // Clear the in-memory agent messages immediately so the new session
+    // is not contaminated by the previous session's context. The DB-side
+    // summary still uses `buildConversationHistory()` (sourced from the
+    // `chat_messages` table), so we don't lose anything by clearing the
+    // in-memory copy here.
+    this.runtime.clearMessages()
+    this.refreshSystemPrompt()
+    return this.sessionManager.handleNewCommandAsync(userId, source)
   }
 
   /**

--- a/packages/core/src/session-manager.test.ts
+++ b/packages/core/src/session-manager.test.ts
@@ -393,6 +393,10 @@ describe('SessionManager', () => {
       await manager.init()
 
       const oldSession = manager.getOrCreateSession('user1')
+      // 3 messages so we cross MIN_MESSAGES_FOR_SUMMARY and exercise the
+      // real summary path (not the short-session placeholder shortcut).
+      manager.recordMessage('user1')
+      manager.recordMessage('user1')
       manager.recordMessage('user1')
 
       const before = Date.now()
@@ -435,6 +439,10 @@ describe('SessionManager', () => {
       await manager.init()
 
       manager.getOrCreateSession('user1')
+      // 3 messages so the session crosses MIN_MESSAGES_FOR_SUMMARY and
+      // actually triggers the summarizer + daily-file write.
+      manager.recordMessage('user1')
+      manager.recordMessage('user1')
       manager.recordMessage('user1')
 
       manager.handleNewCommandAsync('user1')
@@ -456,6 +464,95 @@ describe('SessionManager', () => {
       expect(newSession).toBeDefined()
       expect(manager.hasActiveSession('user1')).toBe(true)
       expect(onSummarize).not.toHaveBeenCalled()
+    })
+
+    it('uses a placeholder divider and skips the summarizer for short ping/pong sessions', async () => {
+      const onSummarize = vi.fn().mockResolvedValue('SHOULD NOT BE USED')
+      const onSessionEnd = vi.fn()
+      const manager = new SessionManager({
+        db,
+        memoryDir,
+        timeoutMinutes: 15,
+        onSummarize,
+        onSessionEnd,
+      })
+      await manager.init()
+
+      manager.getOrCreateSession('user1')
+      // 2 messages = classic ping/pong (one user turn + one assistant reply).
+      // Calling the summarizer here would just yield "Empty session." — we
+      // expect the manager to short-circuit with an em-dash placeholder.
+      manager.recordMessage('user1')
+      manager.recordMessage('user1')
+
+      manager.handleNewCommandAsync('user1')
+      await manager.awaitBackgroundJobs()
+
+      expect(onSummarize).not.toHaveBeenCalled()
+      expect(onSessionEnd).toHaveBeenCalledTimes(1)
+      const [, summary, opts] = onSessionEnd.mock.calls[0] as [
+        SessionInfo,
+        string | null,
+        { background?: boolean } | undefined,
+      ]
+      expect(summary).toBe('—')
+      expect(opts?.background).toBe(true)
+
+      // No daily-log entry should be written for a short session.
+      const today = new Date().toISOString().split('T')[0]
+      const dailyPath = path.join(memoryDir, 'daily', `${today}.md`)
+      expect(fs.existsSync(dailyPath)).toBe(false)
+    })
+
+    it('writes divider + summary against the OLD session id, even after a new session was minted', async () => {
+      // Regression test for the bug where a slow background summary
+      // resolved AFTER the new session had become "the current session",
+      // causing the divider to be associated with the new session id.
+      let resolveSummary: ((value: string) => void) | undefined
+      const summaryPromise = new Promise<string>((resolve) => {
+        resolveSummary = resolve
+      })
+      const onSummarize = vi.fn().mockReturnValue(summaryPromise)
+      const onSessionEnd = vi.fn()
+      const manager = new SessionManager({
+        db,
+        memoryDir,
+        timeoutMinutes: 15,
+        onSummarize,
+        onSessionEnd,
+      })
+      await manager.init()
+
+      const oldSession = manager.getOrCreateSession('user1')
+      manager.recordMessage('user1')
+      manager.recordMessage('user1')
+      manager.recordMessage('user1')
+
+      const newSession = manager.handleNewCommandAsync('user1')
+      // User keeps chatting in the new session while the summary is in flight.
+      manager.recordMessage('user1')
+      manager.recordMessage('user1')
+
+      // Only NOW does the slow summary resolve.
+      resolveSummary!('Old session summary.')
+      await manager.awaitBackgroundJobs()
+
+      expect(onSessionEnd).toHaveBeenCalledTimes(1)
+      const [endedSession, summary] = onSessionEnd.mock.calls[0] as [
+        SessionInfo,
+        string | null,
+        { background?: boolean } | undefined,
+      ]
+      // The callback MUST see the OLD session's id, not the freshly-minted
+      // new session that is now sitting under the same userId key.
+      expect(endedSession.id).toBe(oldSession.id)
+      expect(endedSession.id).not.toBe(newSession.id)
+      expect(summary).toBe('Old session summary.')
+
+      // And the summarizer must have been asked to summarize the OLD
+      // session's transcript — not the new one.
+      expect(onSummarize).toHaveBeenCalledTimes(1)
+      expect(onSummarize.mock.calls[0][0]).toBe(oldSession.id)
     })
   })
 

--- a/packages/core/src/session-manager.test.ts
+++ b/packages/core/src/session-manager.test.ts
@@ -495,7 +495,7 @@ describe('SessionManager', () => {
         string | null,
         { background?: boolean } | undefined,
       ]
-      expect(summary).toBe('—')
+      expect(summary).toBe('Empty session.')
       expect(opts?.background).toBe(true)
 
       // No daily-log entry should be written for a short session.

--- a/packages/core/src/session-manager.test.ts
+++ b/packages/core/src/session-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
-import { SessionManager, generateSessionId } from './session-manager.js'
+import { SessionManager, generateSessionId, type SessionInfo } from './session-manager.js'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 import { initDatabase } from './database.js'
@@ -369,6 +369,93 @@ describe('SessionManager', () => {
       expect(fs.existsSync(dailyPath)).toBe(true)
       const content = fs.readFileSync(dailyPath, 'utf-8')
       expect(content).toContain('Discussed Docker setup.')
+    })
+  })
+
+  describe('/new command (async / non-blocking)', () => {
+    it('returns the new session synchronously without waiting for the summary', async () => {
+      // Block the summarizer for 500ms so we can prove the call site
+      // never awaits it.
+      let resolveSummary: ((value: string) => void) | undefined
+      const summaryPromise = new Promise<string>((resolve) => {
+        resolveSummary = resolve
+      })
+      const onSummarize = vi.fn().mockReturnValue(summaryPromise)
+      const onSessionEnd = vi.fn()
+
+      const manager = new SessionManager({
+        db,
+        memoryDir,
+        timeoutMinutes: 15,
+        onSummarize,
+        onSessionEnd,
+      })
+      await manager.init()
+
+      const oldSession = manager.getOrCreateSession('user1')
+      manager.recordMessage('user1')
+
+      const before = Date.now()
+      const newSession = manager.handleNewCommandAsync('user1')
+      const elapsed = Date.now() - before
+
+      // Must be effectively synchronous (well under the artificial summary delay).
+      expect(elapsed).toBeLessThan(50)
+      expect(newSession.id).not.toBe(oldSession.id)
+      expect(manager.hasActiveSession('user1')).toBe(true)
+      // Summary callback has not fired yet — summary is still pending.
+      expect(onSessionEnd).not.toHaveBeenCalled()
+
+      // Now let the background summary finish and confirm onSessionEnd fires
+      // with options.background === true so listeners can route the late
+      // arrival to an update event rather than a fresh divider.
+      resolveSummary!('Background summary text.')
+      await manager.awaitBackgroundJobs()
+
+      expect(onSessionEnd).toHaveBeenCalledTimes(1)
+      const [endedSession, summary, opts] = onSessionEnd.mock.calls[0] as [
+        SessionInfo,
+        string | null,
+        { background?: boolean } | undefined,
+      ]
+      expect(endedSession.id).toBe(oldSession.id)
+      expect(summary).toBe('Background summary text.')
+      expect(opts?.background).toBe(true)
+      expect(onSummarize).toHaveBeenCalledTimes(1)
+    })
+
+    it('writes the background summary to the daily file after completion', async () => {
+      const onSummarize = vi.fn().mockResolvedValue('Async daily entry.')
+      const manager = new SessionManager({
+        db,
+        memoryDir,
+        timeoutMinutes: 15,
+        onSummarize,
+      })
+      await manager.init()
+
+      manager.getOrCreateSession('user1')
+      manager.recordMessage('user1')
+
+      manager.handleNewCommandAsync('user1')
+      await manager.awaitBackgroundJobs()
+
+      const today = new Date().toISOString().split('T')[0]
+      const dailyPath = path.join(memoryDir, 'daily', `${today}.md`)
+      expect(fs.existsSync(dailyPath)).toBe(true)
+      const content = fs.readFileSync(dailyPath, 'utf-8')
+      expect(content).toContain('Async daily entry.')
+    })
+
+    it('returns a fresh session when there was no active session before', async () => {
+      const onSummarize = vi.fn()
+      const manager = new SessionManager({ db, memoryDir, onSummarize })
+      await manager.init()
+
+      const newSession = manager.handleNewCommandAsync('user1')
+      expect(newSession).toBeDefined()
+      expect(manager.hasActiveSession('user1')).toBe(true)
+      expect(onSummarize).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -47,8 +47,21 @@ export interface SessionManagerOptions {
    * conversationHistory is built from chat_messages in the DB (single source of truth).
    */
   onSummarize?: (sessionId: string, userId: string, conversationHistory?: string) => Promise<string>
-  /** Called when a session is disposed (after summary if applicable) */
-  onSessionEnd?: (session: SessionInfo, summary: string | null) => void
+  /**
+   * Called when a session is disposed (after summary if applicable).
+   *
+   * `options.background` is true when the session was ended via
+   * `handleNewCommandAsync()` and the summary was generated asynchronously
+   * after the new session had already been announced to the client.
+   * Listeners use this to deliver the summary as a *late* update event
+   * instead of a fresh session_end divider that would duplicate the one
+   * already rendered when the new session was opened.
+   */
+  onSessionEnd?: (
+    session: SessionInfo,
+    summary: string | null,
+    options?: { background?: boolean },
+  ) => void
 }
 
 export type SessionEndReason = 'timeout' | 'manual' | 'provider_change'
@@ -66,7 +79,18 @@ export class SessionManager {
   private timeoutMs: number
   private memoryDir?: string
   private onSummarize?: (sessionId: string, userId: string, conversationHistory?: string) => Promise<string>
-  private onSessionEnd?: (session: SessionInfo, summary: string | null) => void
+  private onSessionEnd?: (
+    session: SessionInfo,
+    summary: string | null,
+    options?: { background?: boolean },
+  ) => void
+  /**
+   * Tracks pending background summary jobs spawned by
+   * `handleNewCommandAsync` so `dispose()` can drain them on shutdown
+   * and tests can deterministically await completion via
+   * `awaitBackgroundJobs()`.
+   */
+  private backgroundJobs: Set<Promise<void>> = new Set()
 
   constructor(options: SessionManagerOptions) {
     this.db = options.db
@@ -502,7 +526,12 @@ export class SessionManager {
   }
 
   /**
-   * Handle /new command: immediately summarize and reset
+   * Handle /new command: immediately summarize and reset (blocking).
+   *
+   * The returned Promise resolves only AFTER the summary has been
+   * generated and persisted. Prefer `handleNewCommandAsync()` for
+   * interactive UIs where blocking on summary generation is
+   * user-visible.
    */
   async handleNewCommand(userId: string): Promise<string | null> {
     const session = this.sessions.get(userId)
@@ -511,6 +540,122 @@ export class SessionManager {
     }
 
     return this.endSession(userId, 'manual')
+  }
+
+  /**
+   * Non-blocking variant of `handleNewCommand`. Detaches the current
+   * interactive session synchronously (clears the timer + removes it
+   * from the active-session map + clears in-memory agent state via the
+   * onSessionEnd callback in the next tick), creates a fresh session
+   * for the user, and returns it immediately.
+   *
+   * Summary generation and persistence (daily log + DB UPDATE + tool
+   * call log + onSessionEnd callback) run in the background. When the
+   * summary is ready, `onSessionEnd` fires with `options.background = true`
+   * so the listener can deliver the summary as a follow-up event without
+   * duplicating the divider that was already rendered when the new
+   * session was opened.
+   */
+  // Used by the websocket chat /new command handler for instant session switch.
+  // fallow-ignore-next-line unused-class-member
+  handleNewCommandAsync(userId: string, source: string = 'web'): SessionInfo {
+    const oldSession = this.sessions.get(userId)
+
+    if (oldSession) {
+      this.clearTimer(userId)
+      this.sessions.delete(userId)
+
+      const job = this.finalizeDetachedSession(oldSession, userId, 'manual').catch((err) => {
+        console.error(
+          `[session] Background finalize failed for session ${oldSession.id}:`,
+          err,
+        )
+      })
+      this.backgroundJobs.add(job)
+      job.finally(() => {
+        this.backgroundJobs.delete(job)
+      })
+    }
+
+    return this.getOrCreateSession(userId, source)
+  }
+
+  /**
+   * Run the summary-and-persist tail of a session that has already been
+   * detached from `this.sessions` (timer cleared, map entry removed).
+   * Mirrors `endSession`'s tail but is callable without holding the
+   * session in the active map.
+   */
+  private async finalizeDetachedSession(
+    session: SessionInfo,
+    userId: string,
+    reason: SessionEndReason,
+  ): Promise<void> {
+    console.log(
+      `[session] Finalizing detached session ${session.id} for user ${userId} `
+      + `(${session.messageCount} messages, background)`,
+    )
+
+    let summary: string | null = null
+
+    if (session.messageCount > 0 && this.onSummarize) {
+      try {
+        const history = this.buildConversationHistory(session.id) ?? undefined
+        summary = await this.onSummarize(session.id, userId, history)
+        if (summary) {
+          this.writeSummaryToDailyFile(summary, session.lastActivity)
+          session.summaryWritten = true
+          console.log(
+            `[session] Background summary written to daily log for session ${session.id}`,
+          )
+        }
+      } catch (err) {
+        console.error('[session] Failed to generate background session summary:', err)
+      }
+    } else {
+      console.log(
+        `[session] Skipping background summary: messageCount=${session.messageCount}, `
+        + `onSummarize=${!!this.onSummarize}`,
+      )
+    }
+
+    this.db.prepare(
+      `UPDATE sessions SET ended_at = datetime('now'), message_count = ?, summary_written = ? WHERE id = ?`
+    ).run(session.messageCount, session.summaryWritten ? 1 : 0, session.id)
+
+    const durationMs = Date.now() - session.startedAt
+    logToolCall(this.db, {
+      sessionId: session.id,
+      toolName: reason === 'timeout' ? 'session_timeout' : 'session_end',
+      input: JSON.stringify({
+        userId,
+        reason,
+        messageCount: session.messageCount,
+        durationMinutes: Math.round(durationMs / 60000),
+        background: true,
+      }),
+      output: JSON.stringify({
+        summaryWritten: session.summaryWritten,
+        summary: summary ?? null,
+      }),
+      durationMs,
+      status: 'success',
+    })
+
+    if (this.onSessionEnd) {
+      this.onSessionEnd(session, summary, { background: true })
+    }
+  }
+
+  /**
+   * Await all in-flight background summary jobs. Useful for tests that
+   * need to deterministically observe the post-summary state after
+   * calling `handleNewCommandAsync`.
+   */
+  // fallow-ignore-next-line unused-class-member
+  async awaitBackgroundJobs(): Promise<void> {
+    if (this.backgroundJobs.size === 0) return
+    await Promise.allSettled(Array.from(this.backgroundJobs))
   }
 
   /**
@@ -634,11 +779,17 @@ export class SessionManager {
   }
 
   /**
-   * Dispose all sessions and timers (for shutdown)
+   * Dispose all sessions and timers (for shutdown). Drains any
+   * fire-and-forget background summary jobs first so daily-log writes
+   * and DB updates settle before we tear down.
    */
   async dispose(): Promise<void> {
     for (const [userId] of this.timers) {
       this.clearTimer(userId)
+    }
+
+    if (this.backgroundJobs.size > 0) {
+      await Promise.allSettled(Array.from(this.backgroundJobs))
     }
 
     // End all active sessions without summarizing

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -99,7 +99,7 @@ export class SessionManager {
    * (which would just return "Empty session." anyway and waste a model call).
    */
   private static readonly MIN_MESSAGES_FOR_SUMMARY = 3
-  private static readonly SHORT_SESSION_PLACEHOLDER = '—'
+  private static readonly SHORT_SESSION_PLACEHOLDER = 'Empty session.'
 
   constructor(options: SessionManagerOptions) {
     this.db = options.db

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -91,6 +91,15 @@ export class SessionManager {
    * `awaitBackgroundJobs()`.
    */
   private backgroundJobs: Set<Promise<void>> = new Set()
+  /**
+   * Sessions with fewer than this many messages are too short to be worth
+   * a summary LLM round-trip (typical: ping/pong = 2 messages). For these
+   * we still emit a divider so the user sees a visual session boundary,
+   * but we use an em-dash placeholder instead of calling the summarizer
+   * (which would just return "Empty session." anyway and waste a model call).
+   */
+  private static readonly MIN_MESSAGES_FOR_SUMMARY = 3
+  private static readonly SHORT_SESSION_PLACEHOLDER = '—'
 
   constructor(options: SessionManagerOptions) {
     this.db = options.db
@@ -559,14 +568,28 @@ export class SessionManager {
   // Used by the websocket chat /new command handler for instant session switch.
   handleNewCommandAsync(userId: string, source: string = 'web'): SessionInfo {
     const oldSession = this.sessions.get(userId)
+    // Snapshot the OLD session's id as a primitive *before* we mint the new
+    // one, so every downstream write (daily-log, chat_messages divider,
+    // tool_calls row, onSessionEnd callback) is unambiguously bound to the
+    // session the user just left — never to the freshly-created session
+    // that replaces it. The previous code threaded the captured object
+    // reference through, but it's easier to reason about (and impossible
+    // to accidentally re-resolve via `this.sessions.get(userId)` at
+    // callback time) when the id is also passed explicitly.
+    const oldSessionId = oldSession?.id
 
-    if (oldSession) {
+    if (oldSession && oldSessionId) {
       this.clearTimer(userId)
       this.sessions.delete(userId)
 
-      const job = this.finalizeDetachedSession(oldSession, userId, 'manual').catch((err) => {
+      const job = this.finalizeDetachedSession(
+        oldSession,
+        oldSessionId,
+        userId,
+        'manual',
+      ).catch((err) => {
         console.error(
-          `[session] Background finalize failed for session ${oldSession.id}:`,
+          `[session] Background finalize failed for session ${oldSessionId}:`,
           err,
         )
       })
@@ -587,25 +610,50 @@ export class SessionManager {
    */
   private async finalizeDetachedSession(
     session: SessionInfo,
+    oldSessionId: string,
     userId: string,
     reason: SessionEndReason,
   ): Promise<void> {
+    // `oldSessionId` is the primitive id captured at trigger time in
+    // `handleNewCommandAsync` (or wherever this method is called from).
+    // We deliberately do NOT re-resolve the session via
+    // `this.sessions.get(userId)` here — by the time the awaited summary
+    // resolves, the user is already chatting in a new session under that
+    // map key, and writing the divider / daily-log entry against the
+    // current session would clobber the new session instead of the one
+    // that actually ended.
     console.log(
-      `[session] Finalizing detached session ${session.id} for user ${userId} `
+      `[session] Finalizing detached session ${oldSessionId} for user ${userId} `
       + `(${session.messageCount} messages, background)`,
     )
 
     let summary: string | null = null
 
-    if (session.messageCount > 0 && this.onSummarize) {
+    if (
+      session.messageCount > 0
+      && session.messageCount < SessionManager.MIN_MESSAGES_FOR_SUMMARY
+    ) {
+      // Ping/pong session (typically 2 messages: one user turn + one
+      // assistant reply). Calling the summarizer for this just produces
+      // "Empty session." — wasting an LLM round-trip and cluttering the
+      // daily activity log. Substitute an em-dash placeholder so the
+      // divider still renders in place of the old session, but don't
+      // write a daily-log entry.
+      summary = SessionManager.SHORT_SESSION_PLACEHOLDER
+      console.log(
+        `[session] Skipping summary for short session ${oldSessionId} `
+        + `(${session.messageCount} < ${SessionManager.MIN_MESSAGES_FOR_SUMMARY} messages); `
+        + `using placeholder divider`,
+      )
+    } else if (session.messageCount > 0 && this.onSummarize) {
       try {
-        const history = this.buildConversationHistory(session.id) ?? undefined
-        summary = await this.onSummarize(session.id, userId, history)
+        const history = this.buildConversationHistory(oldSessionId) ?? undefined
+        summary = await this.onSummarize(oldSessionId, userId, history)
         if (summary) {
           this.writeSummaryToDailyFile(summary, session.lastActivity)
           session.summaryWritten = true
           console.log(
-            `[session] Background summary written to daily log for session ${session.id}`,
+            `[session] Background summary written to daily log for session ${oldSessionId}`,
           )
         }
       } catch (err) {
@@ -620,11 +668,11 @@ export class SessionManager {
 
     this.db.prepare(
       `UPDATE sessions SET ended_at = datetime('now'), message_count = ?, summary_written = ? WHERE id = ?`
-    ).run(session.messageCount, session.summaryWritten ? 1 : 0, session.id)
+    ).run(session.messageCount, session.summaryWritten ? 1 : 0, oldSessionId)
 
     const durationMs = Date.now() - session.startedAt
     logToolCall(this.db, {
-      sessionId: session.id,
+      sessionId: oldSessionId,
       toolName: reason === 'timeout' ? 'session_timeout' : 'session_end',
       input: JSON.stringify({
         userId,
@@ -642,7 +690,16 @@ export class SessionManager {
     })
 
     if (this.onSessionEnd) {
-      this.onSessionEnd(session, summary, { background: true })
+      // Defensive: ensure the session object handed to the callback
+      // carries the captured old id, in case anything later in the
+      // callback chain reads `session.id` instead of the explicit
+      // sessionId argument. The captured object reference IS already
+      // the old session, but pinning the id here makes the intent
+      // impossible to misread.
+      const endedSession: SessionInfo = session.id === oldSessionId
+        ? session
+        : { ...session, id: oldSessionId }
+      this.onSessionEnd(endedSession, summary, { background: true })
     }
   }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -557,7 +557,6 @@ export class SessionManager {
    * session was opened.
    */
   // Used by the websocket chat /new command handler for instant session switch.
-  // fallow-ignore-next-line unused-class-member
   handleNewCommandAsync(userId: string, source: string = 'web'): SessionInfo {
     const oldSession = this.sessions.get(userId)
 
@@ -652,7 +651,6 @@ export class SessionManager {
    * need to deterministically observe the post-summary state after
    * calling `handleNewCommandAsync`.
    */
-  // fallow-ignore-next-line unused-class-member
   async awaitBackgroundJobs(): Promise<void> {
     if (this.backgroundJobs.size === 0) return
     await Promise.allSettled(Array.from(this.backgroundJobs))

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -582,12 +582,19 @@ export class SessionManager {
       this.clearTimer(userId)
       this.sessions.delete(userId)
 
-      const job = this.finalizeDetachedSession(
+      // Defer the finalize one microtask so that `onSessionEnd` (and any
+      // resulting broadcast) NEVER fires on the synchronous stack of this
+      // call. The short-session placeholder branch has no `await` before
+      // `onSessionEnd`, so without this it would fire synchronously here —
+      // before the caller (ws-chat) has had a chance to emit the immediate
+      // `session_end`, causing the late `session_summary` to overtake it and
+      // render a duplicate divider on the originating client.
+      const job = Promise.resolve().then(() => this.finalizeDetachedSession(
         oldSession,
         oldSessionId,
         userId,
         'manual',
-      ).catch((err) => {
+      )).catch((err) => {
         console.error(
           `[session] Background finalize failed for session ${oldSessionId}:`,
           err,

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -924,15 +924,23 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   function wireAgentCoreEvents(): void {
     if (!agentCore) return
 
-    agentCore.setOnSessionEnd((userId: string, sessionId: string, summary: string | null) => {
+    agentCore.setOnSessionEnd((
+      userId: string,
+      sessionId: string,
+      summary: string | null,
+      opts,
+    ) => {
       const numericUserId = parseNumericUserId(userId)
+      const isBackground = !!opts?.background
 
       const dividerMetadata = JSON.stringify({ type: 'session_divider', summary: summary ?? null })
       db.prepare(
         'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
       ).run(sessionId, numericUserId, 'system', summary ?? '', dividerMetadata)
 
-      if (numericUserId !== null) {
+      // Skip re-broadcasting for background-path ends: the originating client already
+      // received a session_end divider when it clicked "New Session".
+      if (numericUserId !== null && !isBackground) {
         chatEventBus.broadcast({
           type: 'session_end',
           userId: numericUserId,

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -933,6 +933,14 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
       const numericUserId = parseNumericUserId(userId)
       const isBackground = !!opts?.background
 
+      // CRITICAL: `sessionId` is the id of the session that just ENDED,
+      // explicitly captured by SessionManager.handleNewCommandAsync at the
+      // moment the user clicked "New Session". Do NOT replace it with any
+      // "current session" lookup (e.g. `sessionManager.getSession(userId)`)
+      // — by the time a background summary lands, the user is already
+      // chatting in the new session and that lookup would return the
+      // wrong id, causing the divider row + summary to be written into
+      // the NEW session's transcript instead of the OLD one.
       const dividerMetadata = JSON.stringify({ type: 'session_divider', summary: summary ?? null })
       db.prepare(
         'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -938,15 +938,39 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
         'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
       ).run(sessionId, numericUserId, 'system', summary ?? '', dividerMetadata)
 
-      // Skip re-broadcasting for background-path ends: the originating client already
-      // received a session_end divider when it clicked "New Session".
-      if (numericUserId !== null && !isBackground) {
-        chatEventBus.broadcast({
-          type: 'session_end',
-          userId: numericUserId,
-          source: 'web',
-          text: summary ?? undefined,
-        })
+      if (numericUserId !== null) {
+        if (isBackground) {
+          // Background path: the originating client already received a
+          // `session_end` (without text) the moment it clicked
+          // "New Session". Re-broadcasting `session_end` here would
+          // render a duplicate divider, so we instead emit a dedicated
+          // `session_summary` event. The carried `sessionId` is the
+          // *ended* session's id so clients can match it back to the
+          // empty divider they already rendered and fill in the
+          // summary in place. Clients that hadn't seen the immediate
+          // `session_end` (e.g. another browser tab) treat the event
+          // as a signal to render a fresh divider for the old
+          // session.
+          if (summary) {
+            chatEventBus.broadcast({
+              type: 'session_summary',
+              userId: numericUserId,
+              source: 'web',
+              sessionId,
+              text: summary,
+            })
+          }
+        } else {
+          // Synchronous path (timeout, provider_change): broadcast
+          // `session_end` with the summary so every connected client
+          // renders a divider in one shot.
+          chatEventBus.broadcast({
+            type: 'session_end',
+            userId: numericUserId,
+            source: 'web',
+            text: summary ?? undefined,
+          })
+        }
       }
 
       triggerFactExtractionForSessionEnd({

--- a/packages/web-backend/src/chat-event-bus.ts
+++ b/packages/web-backend/src/chat-event-bus.ts
@@ -7,7 +7,7 @@ import type { UploadDescriptor } from '@axiom/core'
  */
 export interface ChatEvent {
   /** The kind of event being broadcast */
-  type: 'user_message' | 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error' | 'system' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'reminder' | 'attachment'
+  type: 'user_message' | 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'done' | 'error' | 'system' | 'session_end' | 'session_summary' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'reminder' | 'attachment'
   /** The Axiom user ID (integer) this event belongs to */
   userId: number
   /** Where the event originated */

--- a/packages/web-backend/src/ws-chat.test.ts
+++ b/packages/web-backend/src/ws-chat.test.ts
@@ -196,6 +196,74 @@ describe('setupWebSocketChat kill switch', () => {
     }
   })
 
+  it('forwards a late session_summary chat-event-bus broadcast to the connected client', async () => {
+    const db = initDatabase(':memory:')
+    const chatEventBus = new ChatEventBus()
+    const newSession = {
+      id: 'new-session-id',
+      userId: '1',
+      source: 'web',
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+      messageCount: 0,
+      summaryWritten: false,
+      restored: false,
+    }
+    const mockSessionManager = {
+      getOrCreateSession: vi.fn(() => newSession),
+    }
+    const agentCore = {
+      sendMessage: vi.fn(),
+      abort: vi.fn(),
+      resetSessionAsync: vi.fn(() => newSession),
+      getSessionManager: vi.fn(() => mockSessionManager),
+    } as unknown as AgentCore
+
+    const app = createApp({ db })
+    const server = http.createServer(app)
+    const { wss } = setupWebSocketChat(server, db, agentCore, undefined, chatEventBus)
+
+    await new Promise<void>((resolve) => server.listen(0, resolve))
+    const port = (server.address() as { port: number }).port
+    const token = generateAccessToken({ userId: 1, username: 'admin', role: 'admin' })
+
+    try {
+      const { ws, waitForMessage } = await connectWs(port, token)
+      await waitForMessage() // authenticated
+
+      // Trigger /new so the client switches to the new session.
+      ws.send(JSON.stringify({ type: 'command', content: '/new' }))
+      const sessionEnd = await waitForMessage()
+      expect(sessionEnd.type).toBe('session_end')
+      expect(sessionEnd.sessionId).toBe('new-session-id')
+      expect(sessionEnd.text).toBeUndefined()
+
+      // Simulate the background summary completing and being broadcast
+      // by runtime-composition's onSessionEnd handler.
+      chatEventBus.broadcast({
+        type: 'session_summary',
+        userId: 1,
+        source: 'web',
+        sessionId: 'old-session-id',
+        text: 'Late-arriving background summary.',
+      })
+
+      const summaryEvent = await waitForMessage()
+      expect(summaryEvent.type).toBe('session_summary')
+      expect(summaryEvent.sessionId).toBe('old-session-id')
+      expect(summaryEvent.text).toBe('Late-arriving background summary.')
+      ws.close()
+    } finally {
+      for (const client of wss.clients) {
+        client.terminate()
+      }
+      wss.close()
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      )
+    }
+  })
+
   it('streams thinking chunks, persists them with metadata.kind=thinking, and broadcasts them', async () => {
     const db = initDatabase(':memory:')
     const chatEventBus = new ChatEventBus()

--- a/packages/web-backend/src/ws-chat.test.ts
+++ b/packages/web-backend/src/ws-chat.test.ts
@@ -174,15 +174,12 @@ describe('setupWebSocketChat kill switch', () => {
       const elapsed = Date.now() - before
 
       expect(sessionEnd.type).toBe('session_end')
-      // The new session id is delivered immediately…
       expect(sessionEnd.sessionId).toBe('session-new-async')
-      // …but the summary is not (it will arrive later via a separate event).
       expect(sessionEnd.text).toBeUndefined()
       // The response must arrive synchronously, well before the simulated
       // background summary completes.
       expect(elapsed).toBeLessThan(500)
       expect(summaryResolved).toBe(false)
-      // Exactly one session_end is emitted for the /new command itself.
       await expectNoMessageWithin(30)
       ws.close()
     } finally {
@@ -231,7 +228,6 @@ describe('setupWebSocketChat kill switch', () => {
       const { ws, waitForMessage } = await connectWs(port, token)
       await waitForMessage() // authenticated
 
-      // Trigger /new so the client switches to the new session.
       ws.send(JSON.stringify({ type: 'command', content: '/new' }))
       const sessionEnd = await waitForMessage()
       expect(sessionEnd.type).toBe('session_end')

--- a/packages/web-backend/src/ws-chat.test.ts
+++ b/packages/web-backend/src/ws-chat.test.ts
@@ -123,23 +123,35 @@ describe('setupWebSocketChat kill switch', () => {
     }
   })
 
-  it('emits only one session_end for /new when the backend broadcasts the divider', async () => {
+  it('immediately announces the new session on /new without waiting for the background summary', async () => {
     const db = initDatabase(':memory:')
     const chatEventBus = new ChatEventBus()
+    const newSession = {
+      id: 'session-new-async',
+      userId: '1',
+      source: 'web',
+      startedAt: Date.now(),
+      lastActivity: Date.now(),
+      messageCount: 0,
+      summaryWritten: false,
+      restored: false,
+    }
+    let summaryResolved = false
     const mockSessionManager = {
-      getOrCreateSession: vi.fn(() => ({ id: 'session-1-mock', userId: '1', source: 'web', startedAt: Date.now(), lastActivity: Date.now(), messageCount: 0, summaryWritten: false, restored: false })),
+      getOrCreateSession: vi.fn(() => newSession),
     }
     const agentCore = {
       sendMessage: vi.fn(),
       abort: vi.fn(),
-      resetSession: vi.fn(async () => {
-        chatEventBus.broadcast({
-          type: 'session_end',
-          userId: 1,
-          source: 'web',
-          text: 'Summary once.',
-        })
-        return 'Summary once.'
+      // The new code path: resetSessionAsync returns synchronously with the
+      // newly minted session. It must NOT block on summary generation.
+      resetSessionAsync: vi.fn(() => {
+        // Pretend the background summary completes 1 second later. The
+        // /new handler must respond well before that.
+        setTimeout(() => {
+          summaryResolved = true
+        }, 1000)
+        return newSession
       }),
       getSessionManager: vi.fn(() => mockSessionManager),
     } as unknown as AgentCore
@@ -156,10 +168,21 @@ describe('setupWebSocketChat kill switch', () => {
       const { ws, waitForMessage, expectNoMessageWithin } = await connectWs(port, token)
       await waitForMessage() // authenticated
 
+      const before = Date.now()
       ws.send(JSON.stringify({ type: 'command', content: '/new' }))
       const sessionEnd = await waitForMessage()
+      const elapsed = Date.now() - before
+
       expect(sessionEnd.type).toBe('session_end')
-      expect(sessionEnd.text).toBe('Summary once.')
+      // The new session id is delivered immediately…
+      expect(sessionEnd.sessionId).toBe('session-new-async')
+      // …but the summary is not (it will arrive later via a separate event).
+      expect(sessionEnd.text).toBeUndefined()
+      // The response must arrive synchronously, well before the simulated
+      // background summary completes.
+      expect(elapsed).toBeLessThan(500)
+      expect(summaryResolved).toBe(false)
+      // Exactly one session_end is emitted for the /new command itself.
       await expectNoMessageWithin(30)
       ws.close()
     } finally {

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -53,6 +53,14 @@ interface ChatResponse {
   toolIsError?: boolean
   error?: string
   sessionId?: string
+  /**
+   * For `session_end`: the id of the session that just ended. The frontend
+   * tags the rendered divider with this so a late-arriving `session_summary`
+   * (background /new flow) can be matched back to the correct divider. Sent
+   * explicitly because the frontend cannot reliably know the active session
+   * id on its own (it is not updated by normal messages or history load).
+   */
+  endedSessionId?: string
   /** The source channel (for external_user_message) */
   source?: string
   /** Sender display name (for external_user_message) */
@@ -275,11 +283,17 @@ export function setupWebSocketChat(
           const agentCore = resolveAgentCore()
 
           if (agentCore) {
+            // Capture the session id that is about to end BEFORE we reset.
+            // `clientSessions` is the authoritative active-session id for this
+            // connection (set on every message), so it stays correct across
+            // reloads where the frontend's own session id would be null.
+            const endedSessionId = clientSessions.get(ws)
             const newSession = agentCore.resetSessionAsync(String(currentUser.userId), 'web')
             clientSessions.set(ws, newSession.id)
             sendMessage(ws, {
               type: 'session_end',
               sessionId: newSession.id,
+              endedSessionId,
             })
           } else {
             // No agent core: clear any cached session ID; next message will resolve a new one.

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -274,34 +274,13 @@ export function setupWebSocketChat(
 
           const agentCore = resolveAgentCore()
 
-          // Reset session (generates summary + writes daily log).
-          // When a chat event bus is available, the resulting session_end event is
-          // emitted centrally via onSessionEnd and broadcast from there to avoid
-          // duplicate dividers. Otherwise, emit the divider directly here.
           if (agentCore) {
-            try {
-              const summary = await agentCore.resetSession(String(currentUser.userId))
-              if (!chatEventBus) {
-                // After resetSession, the next getOrCreateSession() returns a fresh UUID.
-                const newSession = agentCore.getSessionManager().getOrCreateSession(String(currentUser.userId), 'web')
-                clientSessions.set(ws, newSession.id)
-                sendMessage(ws, {
-                  type: 'session_end',
-                  text: summary ?? undefined,
-                  sessionId: newSession.id,
-                })
-              }
-            } catch (err) {
-              console.error('Failed to reset session:', err)
-              if (!chatEventBus) {
-                const newSession = agentCore.getSessionManager().getOrCreateSession(String(currentUser.userId), 'web')
-                clientSessions.set(ws, newSession.id)
-                sendMessage(ws, {
-                  type: 'session_end',
-                  sessionId: newSession.id,
-                })
-              }
-            }
+            const newSession = agentCore.resetSessionAsync(String(currentUser.userId), 'web')
+            clientSessions.set(ws, newSession.id)
+            sendMessage(ws, {
+              type: 'session_end',
+              sessionId: newSession.id,
+            })
           } else {
             // No agent core: clear any cached session ID; next message will resolve a new one.
             clientSessions.delete(ws)

--- a/packages/web-backend/src/ws-chat.ts
+++ b/packages/web-backend/src/ws-chat.ts
@@ -32,7 +32,7 @@ interface ChatMessage {
 }
 
 interface ChatResponse {
-  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'reminder' | 'pong' | 'attachment'
+  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'session_summary' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'reminder' | 'pong' | 'attachment'
   text?: string
   /**
    * Interactive picker payload (slash-command driven). When present on a
@@ -612,6 +612,17 @@ export function setupWebSocketChat(
           clientSessions.delete(client)
           sendMessage(client, {
             type: 'session_end',
+            text: event.text,
+          })
+        } else if (event.type === 'session_summary') {
+          // Late-arriving summary for a session that was ended
+          // non-blockingly (e.g. via /new). The carried `sessionId` is
+          // the id of the session that just got summarized so the
+          // client can match it to the previously rendered (empty)
+          // divider and fill it in.
+          sendMessage(client, {
+            type: 'session_summary',
+            sessionId: event.sessionId,
             text: event.text,
           })
         } else if (event.type === 'task_completed' || event.type === 'task_failed' || event.type === 'task_question') {

--- a/packages/web-frontend/app/composables/useChat.ts
+++ b/packages/web-frontend/app/composables/useChat.ts
@@ -98,10 +98,17 @@ export interface ChatMessage {
   picker?: ChatPicker
   /** The picker option command the user picked (disables the buttons). */
   pickerResolvedCommand?: string
+  /**
+   * For `role: 'divider'` messages: the id of the session that ended at
+   * this divider. Used to match late-arriving `session_summary` events
+   * (from the non-blocking /new flow) to the right divider so its
+   * `content` can be filled in in place.
+   */
+  endedSessionId?: string
 }
 
 interface WsMessage {
-  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'reminder' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'pong' | 'attachment'
+  type: 'text' | 'thinking' | 'tool_call_start' | 'tool_call_end' | 'error' | 'done' | 'system' | 'external_user_message' | 'session_end' | 'session_summary' | 'reminder' | 'task_completed' | 'task_failed' | 'task_question' | 'task_status_update' | 'pong' | 'attachment'
   text?: string
   /** Picker payload for interactive slash-command replies (e.g. /model). */
   picker?: ChatPicker
@@ -361,7 +368,11 @@ export function useChat() {
         isStreaming.value = false
         break
 
-      case 'session_end':
+      case 'session_end': {
+        // Capture the session id that just ended BEFORE we mutate
+        // sessionId.value, so the divider can be tagged with it and
+        // matched against a later `session_summary` event.
+        const endedSessionId = sessionId.value ?? undefined
         if (msg.sessionId) {
           sessionId.value = msg.sessionId
         }
@@ -370,9 +381,50 @@ export function useChat() {
           role: 'divider',
           content: msg.text ?? '',
           timestamp: new Date().toISOString(),
+          endedSessionId,
         }]
         isStreaming.value = false
         break
+      }
+
+      case 'session_summary': {
+        // Late-arriving summary for a session that was ended
+        // non-blockingly via /new. Find the matching divider (by
+        // endedSessionId) and fill in its content in place, so the
+        // user sees the same divider expand from "— New Session —" to
+        // include the collapsible summary card without spawning a new
+        // divider. Falls back to appending a divider if no match exists
+        // (e.g. another browser tab that never received the immediate
+        // session_end).
+        if (!msg.text) break
+        const list = messages.value
+        let realIdx = -1
+        if (msg.sessionId) {
+          for (let k = list.length - 1; k >= 0; k--) {
+            const m = list[k]
+            if (m && m.role === 'divider' && m.endedSessionId === msg.sessionId) {
+              realIdx = k
+              break
+            }
+          }
+        }
+        if (realIdx >= 0) {
+          const updated = [...list]
+          const target = updated[realIdx]
+          if (target) {
+            updated[realIdx] = { ...target, content: msg.text }
+            messages.value = updated
+          }
+        } else {
+          messages.value = [...list, {
+            role: 'divider',
+            content: msg.text,
+            timestamp: new Date().toISOString(),
+            endedSessionId: msg.sessionId,
+          }]
+        }
+        break
+      }
 
       case 'external_user_message':
         // A message from another channel (e.g. Telegram) for the same user

--- a/packages/web-frontend/app/composables/useChat.ts
+++ b/packages/web-frontend/app/composables/useChat.ts
@@ -123,6 +123,13 @@ interface WsMessage {
   toolIsError?: boolean
   error?: string
   sessionId?: string
+  /**
+   * For `session_end`: the id of the session that just ended (sent explicitly
+   * by the backend). Used to tag the divider so a late `session_summary` can
+   * be matched to it, since the frontend's own `sessionId` is not reliably
+   * up to date (not set by normal messages or history load).
+   */
+  endedSessionId?: string
   /** The source channel */
   source?: string
   /** Sender display name */
@@ -369,10 +376,12 @@ export function useChat() {
         break
 
       case 'session_end': {
-        // Capture the session id that just ended BEFORE we mutate
-        // sessionId.value, so the divider can be tagged with it and
-        // matched against a later `session_summary` event.
-        const endedSessionId = sessionId.value ?? undefined
+        // Prefer the ended session id the backend sent explicitly
+        // (`clientSessions`-backed, reliable across reloads). Fall back to
+        // our own tracked sessionId only if absent, then mutate
+        // sessionId.value. The divider is tagged with this so a later
+        // `session_summary` event can be matched against it.
+        const endedSessionId = msg.endedSessionId ?? sessionId.value ?? undefined
         if (msg.sessionId) {
           sessionId.value = msg.sessionId
         }

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -744,10 +744,15 @@ async function loadHistory() {
           } as ChatMessage
         }
 
-        // Parse system messages with session_divider metadata as dividers
+        // Parse system messages with session_divider metadata as dividers.
+        // The chat_messages row is inserted with the ended session as
+        // `session_id`; tag the divider with `endedSessionId` so a
+        // late-arriving `session_summary` event can locate and update
+        // it in place after a reload.
         if (m.role === 'system' && meta.type === 'session_divider') {
           return {
             id: m.id, role: 'divider' as const, content: meta.summary ?? '', timestamp: m.timestamp, source,
+            endedSessionId: m.session_id,
           } as ChatMessage
         }
 


### PR DESCRIPTION
## Summary

Currently, clicking **"New Session"** in the web chat blocks the user until the
LLM-generated summary of the old session has been written. With long
conversations and slow providers, this round-trip can easily take several
seconds during which the UI sits unresponsive — clicking the button feels
sluggish even though the actual work the user wants ("give me a fresh
session") is essentially free.

This PR makes "New Session" feel instant:

1. **User clicks "New Session"** → a fresh session is opened immediately
   (synchronously). The user can type and send messages right away.
2. **The summary of the old session is generated in the background** while
   the user is already chatting in the new session.
3. **When the summary is ready, it appears in the UI** — the empty
   `— New Session —` divider is filled in in place with the collapsible
   session-summary card, with no second divider added.

## Implementation

### Commit 1 — `feat: create new session immediately without waiting for summary`

Backend-only changes that detach the user-visible session switch from
summary generation.

- **`packages/core/src/session-manager.ts`**
  - New `handleNewCommandAsync(userId, source)`: detaches the previous
    interactive session **synchronously** (clears its timeout timer and
    removes it from the active-session map), then returns a freshly
    minted `SessionInfo` immediately. The old session's summary
    generation, daily-log write, DB `UPDATE`, tool-call log row and
    `onSessionEnd` callback all run on a tracked background `Promise`.
  - `onSessionEnd` callback signature extended with an optional
    `{ background: true }` so listeners can distinguish a late-arriving
    summary (from the non-blocking flow) from a fresh `session_end`.
  - New `awaitBackgroundJobs()` and updated `dispose()` drain pending
    background summaries on shutdown / in tests so daily-log writes and
    DB updates settle before teardown.

- **`packages/core/src/agent.ts`**
  - New `AgentCore.resetSessionAsync(userId, source)`: clears the
    runtime's in-memory message buffer synchronously (so the new
    session isn't contaminated by the previous turn's context) and
    delegates to `SessionManager.handleNewCommandAsync()`.
  - Internal `onSessionEnd` wiring no longer re-clears runtime
    messages on background completion — they were already cleared
    synchronously when the new session was minted, and re-clearing
    later would wipe messages already accumulating for the new
    session.

- **`packages/web-backend/src/ws-chat.ts`**
  - The `/new` command handler now calls `resetSessionAsync` and emits a
    `session_end` message to the originating client right away, carrying
    the new sessionId and **no** summary text. The follow-up summary
    delivery is wired up in commit 2.

- **`packages/web-backend/src/bootstrap/runtime-composition.ts`**
  - The `setOnSessionEnd` handler now skips the chat-event-bus
    `session_end` broadcast in background mode so the originator
    doesn't render a duplicate divider when the background summary
    later triggers the callback. The `session_divider` row in
    `chat_messages` is still inserted so a future page reload
    rebuilds the divider in the right place.

### Commit 2 — `feat: show session summary in UI when background generation completes`

End-to-end plumbing for a new **`session_summary`** chat event that
delivers the late-arriving summary back to connected clients.

- **`packages/web-backend/src/chat-event-bus.ts`**: add `session_summary`
  to `ChatEvent`'s union. Carries `sessionId` (the *ended* session's id)
  + the generated summary in `text`.

- **`packages/web-backend/src/bootstrap/runtime-composition.ts`**: in
  background mode, broadcast `session_summary` instead of `session_end`
  when the summary lands.

- **`packages/web-backend/src/ws-chat.ts`**: extend the `ChatResponse`
  union with `session_summary` and forward the event to every connected
  client of the same user.

- **`packages/web-frontend/app/composables/useChat.ts`**:
  - Tag dividers created from `session_end` with `endedSessionId` (the
    session that just ended) so we can match a later
    `session_summary` event against the right divider.
  - New handler for `session_summary`: walks the message list
    backwards, finds the divider whose `endedSessionId` matches the
    event's `sessionId`, and updates its `content` in place. Falls
    back to appending a new divider when no match exists (e.g.
    another browser tab that never received the immediate
    `session_end`).

- **`packages/web-frontend/app/pages/index.vue`**: when reconstructing
  dividers from chat history, also tag them with
  `endedSessionId = m.session_id` so the same late-summary update logic
  works after a page reload too.

## Visible behaviour

| | Before | After |
| --- | --- | --- |
| Time from clicking "New Session" until chat input is usable | Several seconds (summary LLM call blocks) | Instant (~0ms) |
| Summary card on divider | Appears together with the new-session divider | Appears in place on the existing divider as soon as the background summary is ready |
| Multi-tab UX | Other tabs got a single `session_end` with summary | Other tabs that hadn't seen the immediate `session_end` render a divider from the `session_summary` fallback path |

## Tests

- **`packages/core/src/session-manager.test.ts`** — 3 new tests covering
  `handleNewCommandAsync`:
  - returns the new session synchronously without waiting for the
    summary, fires `onSessionEnd` with `{ background: true }` only after
    `awaitBackgroundJobs()` resolves;
  - writes the background summary to the daily file;
  - degenerates safely when there's no active session.
- **`packages/web-backend/src/ws-chat.test.ts`**
  - Updated `/new` test asserts the immediate `session_end` arrives in
    < 500ms with the new sessionId and **no** summary text, and that no
    second `session_end` is emitted.
  - New test verifies `session_summary` broadcasts are forwarded to
    connected clients with both `sessionId` + `text` intact.

Full suite: **`1244 / 1244` passing** (`npx vitest run packages/`).

## Files changed

- `packages/core/src/agent.ts`
- `packages/core/src/session-manager.ts`
- `packages/core/src/session-manager.test.ts`
- `packages/web-backend/src/bootstrap/runtime-composition.ts`
- `packages/web-backend/src/chat-event-bus.ts`
- `packages/web-backend/src/ws-chat.ts`
- `packages/web-backend/src/ws-chat.test.ts`
- `packages/web-frontend/app/composables/useChat.ts`
- `packages/web-frontend/app/pages/index.vue`
