### PR TITLE
fix: OAuth callback URL respects PUBLIC_URL env, close popup on re-open

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -21,6 +21,7 @@ These three must be set for any non-development deployment.
 | `HOST` | `0.0.0.0` | Interface the backend binds to. Inside Docker, leave at `0.0.0.0`. |
 | `PORT` | `3000` | Port the backend listens on inside the container. |
 | `HOST_PORT` | `3000` | (Compose-only) Host-side port mapped to the container's `3000`. Set this if `3000` is already taken on the host. |
+| `PUBLIC_URL` | _(unset)_ | External base URL Axiom is reachable under (e.g. `https://axiom.example.com`). When set, the OAuth provider login flow rewrites the `redirect_uri` of the upstream authorization URL to use this origin so reverse-proxied deployments can complete the callback. Leave unset for direct/localhost setups. |
 
 ## Storage
 

--- a/packages/web-backend/src/api/modules/providers/service.ts
+++ b/packages/web-backend/src/api/modules/providers/service.ts
@@ -223,7 +223,7 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
 
     return {
       loginId,
-      authUrl: authInfo.url,
+      authUrl: rewriteAuthUrlWithPublicUrl(authInfo.url),
       instructions: authInfo.instructions,
       usesCallbackServer: oauthProvider.usesCallbackServer ?? false,
     }
@@ -540,6 +540,41 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
     requestOllamaProbePull,
     requestOllamaPull,
     deleteOllamaModel,
+  }
+}
+
+/**
+ * Rewrite the `redirect_uri` query parameter inside an OAuth provider's
+ * authorization URL so that it points at `PUBLIC_URL` (origin only) when set.
+ *
+ * pi-ai builds the auth URL with a hardcoded `http://localhost:<port>/...`
+ * redirect URI tied to its local callback server. When Axiom runs behind a
+ * reverse proxy with a different external hostname, the OAuth provider would
+ * redirect the user's browser to that localhost URL after sign-in, which
+ * fails on the user's machine. By rewriting only the scheme/host/port of
+ * `redirect_uri` to `PUBLIC_URL` (keeping the original callback path), the
+ * proxy can forward the callback request back to the local pi-ai callback
+ * server.
+ *
+ * If `PUBLIC_URL` is unset, malformed, or the auth URL does not contain a
+ * `redirect_uri`, the URL is returned unchanged (fallback to the previous
+ * behaviour).
+ */
+function rewriteAuthUrlWithPublicUrl(authUrl: string): string {
+  const publicUrl = process.env.PUBLIC_URL?.trim()
+  if (!publicUrl) return authUrl
+  try {
+    const parsedAuth = new URL(authUrl)
+    const redirectUri = parsedAuth.searchParams.get('redirect_uri')
+    if (!redirectUri) return authUrl
+    const parsedRedirect = new URL(redirectUri)
+    const parsedPublic = new URL(publicUrl)
+    parsedRedirect.protocol = parsedPublic.protocol
+    parsedRedirect.host = parsedPublic.host
+    parsedAuth.searchParams.set('redirect_uri', parsedRedirect.toString())
+    return parsedAuth.toString()
+  } catch {
+    return authUrl
   }
 }
 

--- a/packages/web-frontend/app/components/ProviderFormDialog.vue
+++ b/packages/web-frontend/app/components/ProviderFormDialog.vue
@@ -586,6 +586,27 @@ const oauthError = ref<string | null>(null)
 const oauthLoginId = ref<string | null>(null)
 const oauthUsesCallback = ref(false)
 const manualCode = ref('')
+// Track the popup window opened for the OAuth flow so we can close it again
+// if the user clicks "New Token" while it is still open instead of stacking
+// up additional popups.
+const oauthPopup = ref<Window | null>(null)
+
+/**
+ * Open the OAuth provider's authorization URL in a popup window. If a popup
+ * from a previous attempt is still open, close it first so we never end up
+ * with two competing popups for the same login.
+ */
+function openOAuthPopup(authUrl: string): void {
+  if (oauthPopup.value && !oauthPopup.value.closed) {
+    try {
+      oauthPopup.value.close()
+    }
+    catch {
+      // ignore: cross-origin popups may refuse close, but reopening is still useful
+    }
+  }
+  oauthPopup.value = window.open(authUrl, '_blank')
+}
 
 // Ollama state
 const ollamaModels = ref<OllamaModel[]>([])
@@ -1047,7 +1068,7 @@ async function startOAuthRenew() {
     oauthUsesCallback.value = response.usesCallbackServer
 
     if (response.authUrl) {
-      window.open(response.authUrl, '_blank')
+      openOAuthPopup(response.authUrl)
     }
 
     pollForCompletion(response.loginId)
@@ -1076,9 +1097,11 @@ async function startOAuth() {
     oauthLoginId.value = response.loginId
     oauthUsesCallback.value = response.usesCallbackServer
 
-    // Open auth URL in new tab
+    // Open auth URL in new tab. If an earlier popup is still open (e.g. the
+    // user clicked "New Token" again without finishing the previous flow),
+    // openOAuthPopup() closes the stale one before opening a fresh popup.
     if (response.authUrl) {
-      window.open(response.authUrl, '_blank')
+      openOAuthPopup(response.authUrl)
     }
 
     // Start polling for completion


### PR DESCRIPTION
## Summary

Fixes two OAuth-related papercuts in the provider login flow.

### Bug 1: OAuth callback URL ignored deployment URL behind reverse proxies
pi-ai builds the upstream authorization URL with a hardcoded `redirect_uri=http://localhost:<port>/...`. When Axiom runs behind a reverse proxy with a different external hostname, the OAuth provider redirects the user's browser to that localhost URL after sign-in, which fails on the user's machine. A new optional `PUBLIC_URL` environment variable lets the operator declare the externally reachable origin; when set, the providers service rewrites only the scheme/host/port of the `redirect_uri` inside the auth URL, keeping the original callback path so the reverse proxy can forward the callback back to pi-ai's local callback server. When `PUBLIC_URL` is unset, behaviour is unchanged.

### Bug 2: Re-clicking "New Token" opened a second OAuth popup
`ProviderFormDialog` called `window.open()` unconditionally for both `startOAuth` and `startOAuthRenew`, so clicking the OAuth button again while a popup was still open stacked a second popup. The popup ref is now tracked, and the previous popup is closed (best-effort, wrapped in try/catch for cross-origin restrictions) before opening a fresh one.

## Changes
- `packages/web-backend/src/api/modules/providers/service.ts` — add `rewriteAuthUrlWithPublicUrl()` and apply it to the auth URL returned from `startOAuthLogin`.
- `packages/web-frontend/app/components/ProviderFormDialog.vue` — track popup in a ref, close stale popup before re-opening.
- `docs/reference/env-vars.md` — document the new `PUBLIC_URL` env var.