### PR TITLE
fix: close existing OAuth popup before opening a new one

### DIFF
--- a/packages/web-frontend/app/components/ProviderFormDialog.vue
+++ b/packages/web-frontend/app/components/ProviderFormDialog.vue
@@ -585,6 +585,7 @@ const oauthInProgress = ref(false)
 const oauthError = ref<string | null>(null)
 const oauthLoginId = ref<string | null>(null)
 const oauthUsesCallback = ref(false)
+let oauthPopup: Window | null = null
 const manualCode = ref('')
 
 // Ollama state
@@ -1047,7 +1048,8 @@ async function startOAuthRenew() {
     oauthUsesCallback.value = response.usesCallbackServer
 
     if (response.authUrl) {
-      window.open(response.authUrl, '_blank')
+      if (oauthPopup && !oauthPopup.closed) oauthPopup.close()
+      oauthPopup = window.open(response.authUrl, 'axiom_oauth', 'noopener')
     }
 
     pollForCompletion(response.loginId)
@@ -1076,9 +1078,10 @@ async function startOAuth() {
     oauthLoginId.value = response.loginId
     oauthUsesCallback.value = response.usesCallbackServer
 
-    // Open auth URL in new tab
+    // Open auth URL — close any existing popup first to avoid stale windows.
     if (response.authUrl) {
-      window.open(response.authUrl, '_blank')
+      if (oauthPopup && !oauthPopup.closed) oauthPopup.close()
+      oauthPopup = window.open(response.authUrl, 'axiom_oauth', 'noopener')
     }
 
     // Start polling for completion
@@ -1102,6 +1105,7 @@ async function pollForCompletion(loginId: string) {
       if (status.status === 'completed') {
         oauthInProgress.value = false
         oauthLoginId.value = null
+        if (oauthPopup && !oauthPopup.closed) { oauthPopup.close(); oauthPopup = null }
         await fetchProviders()
         emit('oauthComplete')
         emit('close')


### PR DESCRIPTION
## Problem

When a user clicked the OAuth login button while an OAuth popup was already open (e.g. after navigating away and clicking again), a second popup was opened instead of reusing or replacing the existing one.

## Change

Added an `oauthPopup` variable in `ProviderFormDialog.vue` to track the current OAuth window. Before opening a new popup, any existing non-closed window is closed first. The popup is also closed when OAuth completes successfully.

Both `startOAuth` and `startOAuthRenew` use the same named window (`axiom_oauth`) so the browser reuses the same slot when possible.