### PR TITLE
fix: close existing OAuth popup before opening a new one

### DIFF
--- a/packages/web-frontend/app/components/ProviderFormDialog.vue
+++ b/packages/web-frontend/app/components/ProviderFormDialog.vue
@@ -1049,7 +1049,7 @@ async function startOAuthRenew() {
 
     if (response.authUrl) {
       if (oauthPopup && !oauthPopup.closed) oauthPopup.close()
-      oauthPopup = window.open(response.authUrl, 'axiom_oauth', 'noopener')
+      oauthPopup = window.open(response.authUrl, 'axiom_oauth')
     }
 
     pollForCompletion(response.loginId)
@@ -1080,7 +1080,7 @@ async function startOAuth() {
 
     if (response.authUrl) {
       if (oauthPopup && !oauthPopup.closed) oauthPopup.close()
-      oauthPopup = window.open(response.authUrl, 'axiom_oauth', 'noopener')
+      oauthPopup = window.open(response.authUrl, 'axiom_oauth')
     }
 
     pollForCompletion(response.loginId)

--- a/packages/web-frontend/app/components/ProviderFormDialog.vue
+++ b/packages/web-frontend/app/components/ProviderFormDialog.vue
@@ -585,6 +585,7 @@ const oauthInProgress = ref(false)
 const oauthError = ref<string | null>(null)
 const oauthLoginId = ref<string | null>(null)
 const oauthUsesCallback = ref(false)
+let oauthPopup: Window | null = null
 const manualCode = ref('')
 
 // Ollama state
@@ -1047,7 +1048,8 @@ async function startOAuthRenew() {
     oauthUsesCallback.value = response.usesCallbackServer
 
     if (response.authUrl) {
-      window.open(response.authUrl, '_blank')
+      if (oauthPopup && !oauthPopup.closed) oauthPopup.close()
+      oauthPopup = window.open(response.authUrl, 'axiom_oauth', 'noopener')
     }
 
     pollForCompletion(response.loginId)
@@ -1076,12 +1078,11 @@ async function startOAuth() {
     oauthLoginId.value = response.loginId
     oauthUsesCallback.value = response.usesCallbackServer
 
-    // Open auth URL in new tab
     if (response.authUrl) {
-      window.open(response.authUrl, '_blank')
+      if (oauthPopup && !oauthPopup.closed) oauthPopup.close()
+      oauthPopup = window.open(response.authUrl, 'axiom_oauth', 'noopener')
     }
 
-    // Start polling for completion
     pollForCompletion(response.loginId)
   } catch (err) {
     oauthError.value = (err as Error).message
@@ -1102,6 +1103,7 @@ async function pollForCompletion(loginId: string) {
       if (status.status === 'completed') {
         oauthInProgress.value = false
         oauthLoginId.value = null
+        if (oauthPopup && !oauthPopup.closed) { oauthPopup.close(); oauthPopup = null }
         await fetchProviders()
         emit('oauthComplete')
         emit('close')


### PR DESCRIPTION
When the user clicks the OAuth login button while a popup is already open, the existing window is now closed before a new one is opened.

Both `startOAuth` and `startOAuthRenew` track the popup in a shared `oauthPopup` variable. On successful completion the popup is also closed automatically.