### PR TITLE
fix(web): render backend timestamps in the user's local timezone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - axiom-data:/data
       - axiom-workspace:/workspace
     environment:
+      # Seeds the default agent timezone (system prompt, memory, heartbeat
+      # scheduling) and the container's OS clock. Overridable at runtime via
+      # Settings → Agent → Timezone.
       - TZ=Europe/Vienna
       - NODE_ENV=production
       - DATA_DIR=/data

--- a/packages/core/src/agent-heartbeat.ts
+++ b/packages/core/src/agent-heartbeat.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { ensureConfigTemplates, loadConfig } from './config.js'
+import { ensureConfigTemplates, getDefaultTimezone, loadConfig } from './config.js'
 import type { Task } from './task-store.js'
 import type { ProviderConfig } from './provider-config.js'
 import type { TaskRuntimeTaskBoundary } from './task-runtime.js'
@@ -254,9 +254,9 @@ export class AgentHeartbeatService {
     try {
       ensureConfigTemplates()
       const config = loadConfig<{ timezone?: string }>('settings.json')
-      return config.timezone || 'UTC'
+      return config.timezone || getDefaultTimezone()
     } catch {
-      return 'UTC'
+      return getDefaultTimezone()
     }
   }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,6 +2,27 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+/**
+ * Resolve the default timezone for new installs and runtime fallbacks.
+ *
+ * Seeds from the `TZ` environment variable (e.g. Docker
+ * `environment: - TZ=Europe/Vienna`) so the agent, memory and heartbeat
+ * scheduling inherit the deployment timezone out of the box. Falls back to
+ * `UTC` when `TZ` is unset or not a valid IANA zone. The in-app
+ * `Settings → Agent → timezone` always overrides this.
+ */
+export function getDefaultTimezone(): string {
+  const tz = process.env.TZ?.trim()
+  if (!tz) return 'UTC'
+  try {
+    // Throws RangeError for invalid IANA zone identifiers.
+    new Intl.DateTimeFormat('en-US', { timeZone: tz })
+    return tz
+  } catch {
+    return 'UTC'
+  }
+}
+
 const TEMPLATES: Record<string, object> = {
   'providers.json': {
     providers: [],
@@ -11,7 +32,7 @@ const TEMPLATES: Record<string, object> = {
     sessionTimeoutMinutes: 30,
     sessionSummaryProviderId: '',
     language: 'en',
-    timezone: 'UTC',
+    timezone: getDefaultTimezone(),
     thinkingLevel: 'off',
     heartbeat: {
       intervalMinutes: 5,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,7 @@ export {
   getImageDimensions,
 } from './uploads.js'
 export type { UploadDescriptor, SaveUploadInput, UploadSettings } from './uploads.js'
-export { loadConfig, getConfigDir, ensureConfigTemplates, getProjectRootDir, getReadmePath, getDocsPath, getAgentDocsPath } from './config.js'
+export { loadConfig, getConfigDir, ensureConfigTemplates, getDefaultTimezone, getProjectRootDir, getReadmePath, getDocsPath, getAgentDocsPath } from './config.js'
 export * from './contracts/index.js'
 export {
   normalizeThinkingLevel,

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { getWorkspaceDir } from './workspace.js'
-import { getConfigDir, getDocsPath, getReadmePath } from './config.js'
+import { getConfigDir, getDefaultTimezone, getDocsPath, getReadmePath } from './config.js'
 
 const SOUL_TEMPLATE = `# Soul
 
@@ -1010,7 +1010,7 @@ When you receive a <task_injection> block (signalling a background-task result w
   sections.push(`<workspace>\nYour working directory is ${workspaceDir}. All shell commands execute in this directory by default.\nAll relative paths in read_file, write_file, and list_files resolve against this directory.\nUse this directory for cloning repos, creating files, and all file operations.\n</workspace>`)
 
   // 14. Current date & time
-  const tz = options?.timezone || 'UTC'
+  const tz = options?.timezone || getDefaultTimezone()
   const now = new Date()
   const date = now.toLocaleDateString('en-CA', { timeZone: tz })
   const time = now.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', timeZone: tz })

--- a/packages/web-backend/src/api/modules/settings/mapper.ts
+++ b/packages/web-backend/src/api/modules/settings/mapper.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_HEALTH_MONITOR_NOTIFICATION_TOGGLES, maskApiKey } from '@axiom/core'
+import { DEFAULT_HEALTH_MONITOR_NOTIFICATION_TOGGLES, getDefaultTimezone, maskApiKey } from '@axiom/core'
 import type { HealthMonitorNotificationToggles, SettingsData, TelegramData } from './types.js'
 
 const DEFAULT_NOTIFICATIONS: HealthMonitorNotificationToggles = {
@@ -161,7 +161,7 @@ export function mapSettingsResponse(context: SettingsResponseContext) {
     sessionTimeoutMinutes: context.settings.sessionTimeoutMinutes ?? 30,
     sessionSummaryProviderId: (settingsRaw.sessionSummaryProviderId as string) ?? '',
     language: context.settings.language ?? 'match',
-    timezone: context.settings.timezone ?? 'UTC',
+    timezone: context.settings.timezone ?? getDefaultTimezone(),
     thinkingLevel: (settingsRaw.thinkingLevel as string) ?? 'off',
     healthMonitorIntervalMinutes:
       context.settings.healthMonitorIntervalMinutes

--- a/packages/web-frontend/app/components/MemoryFactsTab.vue
+++ b/packages/web-frontend/app/components/MemoryFactsTab.vue
@@ -113,7 +113,7 @@
                   {{ fact.source }}
                 </TableCell>
                 <TableCell class="whitespace-nowrap text-sm text-muted-foreground">
-                  {{ formatDate(fact.timestamp) }}
+                  {{ formatDateTime(fact.timestamp) }}
                 </TableCell>
                 <TableCell class="text-right">
                   <div class="flex items-center justify-end gap-1">
@@ -190,6 +190,7 @@
 import type { MemoryFact } from '~/composables/useMemoryFacts'
 
 const { t } = useI18n()
+const { formatDateTime } = useFormat()
 
 const { users, error: usersError, fetchUsers } = useUsers()
 const {
@@ -309,15 +310,6 @@ function handleUserFilterChange() {
 function getUserLabel(userId: number | null): string {
   if (userId === null) return '—'
   return usersById.value.get(userId) ?? `#${userId}`
-}
-
-function formatDate(value: string): string {
-  const date = parseBackendTimestamp(value)
-  if (!date) return ''
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(date)
 }
 
 function startEditing(fact: MemoryFact) {

--- a/packages/web-frontend/app/components/MemoryFactsTab.vue
+++ b/packages/web-frontend/app/components/MemoryFactsTab.vue
@@ -312,10 +312,12 @@ function getUserLabel(userId: number | null): string {
 }
 
 function formatDate(value: string): string {
+  const date = parseBackendTimestamp(value)
+  if (!date) return ''
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
-  }).format(new Date(value))
+  }).format(date)
 }
 
 function startEditing(fact: MemoryFact) {

--- a/packages/web-frontend/app/composables/useFormat.ts
+++ b/packages/web-frontend/app/composables/useFormat.ts
@@ -3,22 +3,24 @@ import { parseBackendTimestamp } from '~/utils/datetime'
 /**
  * Shared formatting utilities.
  *
- * Centralises Intl-based formatters so every page uses the same locale-aware
- * output without duplicating the logic. Backend timestamps are parsed via
+ * Centralises Intl-based formatters so every page uses the same output
+ * without duplicating the logic. Backend timestamps are parsed via
  * `parseBackendTimestamp` so naked SQLite UTC strings render in the user's
  * local timezone rather than being misread as local time.
+ *
+ * Formatting follows the user's browser/OS regional settings (the `undefined`
+ * locale), intentionally decoupled from the i18n UI language: the displayed
+ * language and the number/date/time format are separate concerns.
  */
 export function useFormat() {
-  const { locale } = useI18n()
-
-  /** Locale-aware number: 1 234 567 */
+  /** Browser-locale number: 1,234,567 */
   function formatNumber(value: number): string {
-    return new Intl.NumberFormat(locale.value).format(value)
+    return new Intl.NumberFormat(undefined).format(value)
   }
 
-  /** Locale-aware currency (USD): $1,234.56 */
+  /** Browser-locale currency (USD): $1,234.56 */
   function formatCurrency(value: number): string {
-    return new Intl.NumberFormat(locale.value, {
+    return new Intl.NumberFormat(undefined, {
       style: 'currency',
       currency: 'USD',
       minimumFractionDigits: 2,
@@ -30,7 +32,7 @@ export function useFormat() {
   function formatDateTime(value: string): string {
     const date = parseBackendTimestamp(value)
     if (!date) return ''
-    return new Intl.DateTimeFormat(locale.value, {
+    return new Intl.DateTimeFormat(undefined, {
       dateStyle: 'medium',
       timeStyle: 'short',
     }).format(date)
@@ -40,16 +42,37 @@ export function useFormat() {
   function formatDate(value: string): string {
     const date = parseBackendTimestamp(value)
     if (!date) return ''
-    return new Intl.DateTimeFormat(locale.value, {
+    return new Intl.DateTimeFormat(undefined, {
       dateStyle: 'medium',
     }).format(date)
+  }
+
+  /** Time only: "14:30:05" */
+  function formatTime(value: string | undefined): string {
+    const date = parseBackendTimestamp(value)
+    if (!date) return value ?? ''
+    return date.toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  }
+
+  /** Short time without seconds: "14:30" */
+  function formatTimeShort(value: string): string {
+    const date = parseBackendTimestamp(value)
+    if (!date) return ''
+    return date.toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
   }
 
   /** Compact timestamp for log rows: "Mar 28, 14:30:05" */
   function formatTimestamp(ts: string): string {
     const date = parseBackendTimestamp(ts)
     if (!date) return ''
-    return date.toLocaleString(locale.value, {
+    return date.toLocaleString(undefined, {
       month: 'short',
       day: 'numeric',
       hour: '2-digit',
@@ -70,6 +93,8 @@ export function useFormat() {
     formatCurrency,
     formatDateTime,
     formatDate,
+    formatTime,
+    formatTimeShort,
     formatTimestamp,
     formatDuration,
   }

--- a/packages/web-frontend/app/composables/useFormat.ts
+++ b/packages/web-frontend/app/composables/useFormat.ts
@@ -1,8 +1,12 @@
+import { parseBackendTimestamp } from '~/utils/datetime'
+
 /**
  * Shared formatting utilities.
  *
  * Centralises Intl-based formatters so every page uses the same locale-aware
- * output without duplicating the logic.
+ * output without duplicating the logic. Backend timestamps are parsed via
+ * `parseBackendTimestamp` so naked SQLite UTC strings render in the user's
+ * local timezone rather than being misread as local time.
  */
 export function useFormat() {
   const { locale } = useI18n()
@@ -24,24 +28,28 @@ export function useFormat() {
 
   /** Medium date + short time: "Mar 28, 2026, 2:30 PM" */
   function formatDateTime(value: string): string {
+    const date = parseBackendTimestamp(value)
+    if (!date) return ''
     return new Intl.DateTimeFormat(locale.value, {
       dateStyle: 'medium',
       timeStyle: 'short',
-    }).format(new Date(value))
+    }).format(date)
   }
 
   /** Medium date only: "Mar 28, 2026" */
   function formatDate(value: string): string {
+    const date = parseBackendTimestamp(value)
+    if (!date) return ''
     return new Intl.DateTimeFormat(locale.value, {
       dateStyle: 'medium',
-    }).format(new Date(value))
+    }).format(date)
   }
 
   /** Compact timestamp for log rows: "Mar 28, 14:30:05" */
   function formatTimestamp(ts: string): string {
-    if (!ts) return ''
-    const d = new Date(ts + (ts.includes('Z') || ts.includes('+') ? '' : 'Z'))
-    return d.toLocaleString(locale.value, {
+    const date = parseBackendTimestamp(ts)
+    if (!date) return ''
+    return date.toLocaleString(locale.value, {
       month: 'short',
       day: 'numeric',
       hour: '2-digit',

--- a/packages/web-frontend/app/features/memory/components/MemoryWorkspace.vue
+++ b/packages/web-frontend/app/features/memory/components/MemoryWorkspace.vue
@@ -251,7 +251,7 @@
                       @click="openDailyFile(file.date)"
                     >
                       <TableCell class="font-semibold">{{ file.date }}</TableCell>
-                      <TableCell class="text-muted-foreground">{{ formatDate(file.modifiedAt) }}</TableCell>
+                      <TableCell class="text-muted-foreground">{{ formatDateTime(file.modifiedAt) }}</TableCell>
                       <TableCell class="text-right text-muted-foreground">{{ formatSize(file.size) }}</TableCell>
                     </TableRow>
                   </TableBody>
@@ -380,6 +380,6 @@ const {
   openDailyFile,
   closeDailyFile,
   formatSize,
-  formatDate,
 } = useMemoryWorkspace()
+const { formatDateTime } = useFormat()
 </script>

--- a/packages/web-frontend/app/features/memory/composables/useMemoryWorkspace.ts
+++ b/packages/web-frontend/app/features/memory/composables/useMemoryWorkspace.ts
@@ -199,10 +199,12 @@ export function useMemoryWorkspace() {
   }
 
   function formatDate(value: string): string {
+    const date = parseBackendTimestamp(value)
+    if (!date) return ''
     return new Intl.DateTimeFormat(undefined, {
       dateStyle: 'medium',
       timeStyle: 'short',
-    }).format(new Date(value))
+    }).format(date)
   }
 
   async function switchTab(tab: MemoryTab) {

--- a/packages/web-frontend/app/features/memory/composables/useMemoryWorkspace.ts
+++ b/packages/web-frontend/app/features/memory/composables/useMemoryWorkspace.ts
@@ -198,15 +198,6 @@ export function useMemoryWorkspace() {
     return `${(bytes / 1024).toFixed(1)} KB`
   }
 
-  function formatDate(value: string): string {
-    const date = parseBackendTimestamp(value)
-    if (!date) return ''
-    return new Intl.DateTimeFormat(undefined, {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-    }).format(date)
-  }
-
   async function switchTab(tab: MemoryTab) {
     clearMessages()
     activeTab.value = tab
@@ -349,6 +340,5 @@ export function useMemoryWorkspace() {
     openDailyFile,
     closeDailyFile,
     formatSize,
-    formatDate,
   }
 }

--- a/packages/web-frontend/app/features/settings/components/SettingsWorkspace.vue
+++ b/packages/web-frontend/app/features/settings/components/SettingsWorkspace.vue
@@ -446,7 +446,7 @@
                     <div class="flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
                       <div v-if="consolidationStatus" class="text-xs text-muted-foreground">
                         <span class="font-medium">{{ $t('settings.consolidationLastRun') }}:</span>
-                        {{ consolidationStatus.lastRun ? new Date(consolidationStatus.lastRun).toLocaleString() : $t('settings.consolidationNeverRun') }}
+                        {{ consolidationStatus.lastRun ? formatDateTime(consolidationStatus.lastRun) : $t('settings.consolidationNeverRun') }}
                         <template v-if="consolidationStatus.lastResult">
                           · <span :class="consolidationStatus.lastResult.updated ? 'text-green-600 dark:text-green-400' : ''">
                             {{ consolidationStatus.lastResult.updated ? $t('settings.consolidationResultUpdated') : $t('settings.consolidationResultNoChange') }}
@@ -1894,6 +1894,7 @@ import type { MemoryConsolidationSettings, FactExtractionSettings, HealthMonitor
 import type { TelegramUser } from '~/composables/useTelegramUsers'
 
 /* ── Auth ── */
+const { formatDateTime } = useFormat()
 const { user } = useAuth()
 const isAdmin = computed(() => user.value?.role === 'admin')
 

--- a/packages/web-frontend/app/features/tasks/components/TaskEventsViewer.vue
+++ b/packages/web-frontend/app/features/tasks/components/TaskEventsViewer.vue
@@ -565,13 +565,9 @@ function statusVariant(status: string): 'default' | 'success' | 'destructive' | 
 }
 
 function formatTimestamp(ts: string | undefined): string {
-  if (!ts) return ''
-  try {
-    const date = new Date(ts.includes('T') ? ts : ts.replace(' ', 'T') + 'Z')
-    return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-  } catch {
-    return ts
-  }
+  const date = parseBackendTimestamp(ts)
+  if (!date) return ts ?? ''
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
 function formatDurationMs(ms: number): string {

--- a/packages/web-frontend/app/features/tasks/components/TaskEventsViewer.vue
+++ b/packages/web-frontend/app/features/tasks/components/TaskEventsViewer.vue
@@ -168,7 +168,7 @@
             <p class="text-sm text-foreground whitespace-pre-wrap">{{ taskInfo.prompt }}</p>
           </div>
           <span v-if="firstEventTimestamp" class="flex-shrink-0 text-xs text-muted-foreground">
-            {{ formatTimestamp(firstEventTimestamp) }}
+            {{ formatTime(firstEventTimestamp) }}
           </span>
         </div>
       </div>
@@ -200,7 +200,7 @@
             </span>
             <span class="flex-1" />
             <span class="text-xs text-muted-foreground">
-              {{ formatTimestamp(event.timestamp) }}
+              {{ formatTime(event.timestamp) }}
             </span>
             <AppIcon
               :name="expandedItems.has(idx) ? 'chevronDown' : 'chevronRight'"
@@ -273,7 +273,7 @@
                 <div class="prose-chat text-sm" v-html="renderMarkdown(parseStructuredResponse(event.text)!.summary)" />
               </div>
               <span class="flex-shrink-0 text-xs text-muted-foreground">
-                {{ formatTimestamp(event.timestamp) }}
+                {{ formatTime(event.timestamp) }}
               </span>
             </template>
             <template v-else>
@@ -284,7 +284,7 @@
                     {{ $t('taskViewer.agentResponse') }}
                   </span>
                   <span class="text-xs text-muted-foreground">
-                    {{ formatTimestamp(event.timestamp) }}
+                    {{ formatTime(event.timestamp) }}
                   </span>
                 </div>
                 <!-- eslint-disable-next-line vue/no-v-html -->
@@ -306,7 +306,7 @@
             </span>
             <span class="flex-1" />
             <span class="text-xs text-muted-foreground">
-              {{ formatTimestamp(event.timestamp) }}
+              {{ formatTime(event.timestamp) }}
             </span>
           </div>
         </div>
@@ -336,6 +336,7 @@ const emit = defineEmits<{
 }>()
 
 const { renderMarkdown } = useMarkdown()
+const { formatTime } = useFormat()
 const tasksApi = useTasksApi()
 const { providers, fetchProviders } = useProviders()
 
@@ -562,12 +563,6 @@ function statusVariant(status: string): 'default' | 'success' | 'destructive' | 
     case 'paused': return 'warning'
     default: return 'muted'
   }
-}
-
-function formatTimestamp(ts: string | undefined): string {
-  const date = parseBackendTimestamp(ts)
-  if (!date) return ts ?? ''
-  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
 function formatDurationMs(ms: number): string {

--- a/packages/web-frontend/app/features/tasks/components/TasksWorkspace.vue
+++ b/packages/web-frontend/app/features/tasks/components/TasksWorkspace.vue
@@ -423,17 +423,14 @@ function formatDuration(task: Task): string {
 }
 
 function formatCreatedAt(dateStr: string): string {
-  try {
-    const date = new Date(dateStr.replace(' ', 'T') + 'Z')
-    return new Intl.DateTimeFormat(locale.value, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    }).format(date)
-  } catch {
-    return dateStr
-  }
+  const date = parseBackendTimestamp(dateStr)
+  if (!date) return dateStr
+  return new Intl.DateTimeFormat(locale.value, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
 }
 
 onMounted(async () => {

--- a/packages/web-frontend/app/features/tasks/components/TasksWorkspace.vue
+++ b/packages/web-frontend/app/features/tasks/components/TasksWorkspace.vue
@@ -218,7 +218,7 @@
                 {{ formatCurrency(task.estimatedCost) }}
               </TableCell>
               <TableCell class="text-right text-sm text-muted-foreground">
-                {{ formatCreatedAt(task.createdAt) }}
+                {{ formatTimestamp(task.createdAt) }}
               </TableCell>
               <TableCell class="text-right">
                 <Button
@@ -289,8 +289,8 @@ import {
   useTasksList,
 } from '~/features/tasks/composables/useTasksList'
 
-const { locale, t } = useI18n()
-const { formatNumber, formatCurrency } = useFormat()
+const { t } = useI18n()
+const { formatNumber, formatCurrency, formatTimestamp } = useFormat()
 
 const selectedTaskId = ref<string | null>(null)
 
@@ -420,17 +420,6 @@ function formatDuration(task: Task): string {
   const hours = Math.floor(minutes / 60)
   const remainingMinutes = minutes % 60
   return `${hours}h ${remainingMinutes}m`
-}
-
-function formatCreatedAt(dateStr: string): string {
-  const date = parseBackendTimestamp(dateStr)
-  if (!date) return dateStr
-  return new Intl.DateTimeFormat(locale.value, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date)
 }
 
 onMounted(async () => {

--- a/packages/web-frontend/app/pages/cronjobs.vue
+++ b/packages/web-frontend/app/pages/cronjobs.vue
@@ -327,17 +327,14 @@ function lastRunStatusVariant(status: string | null): 'default' | 'success' | 'd
 }
 
 function formatCreatedAt(dateStr: string): string {
-  try {
-    const date = new Date(dateStr.replace(' ', 'T') + 'Z')
-    return new Intl.DateTimeFormat(locale.value, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    }).format(date)
-  } catch {
-    return dateStr
-  }
+  const date = parseBackendTimestamp(dateStr)
+  if (!date) return dateStr
+  return new Intl.DateTimeFormat(locale.value, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
 }
 
 onMounted(async () => {

--- a/packages/web-frontend/app/pages/cronjobs.vue
+++ b/packages/web-frontend/app/pages/cronjobs.vue
@@ -144,7 +144,7 @@
                       {{ cj.lastRunStatus ?? '—' }}
                     </Badge>
                   </div>
-                  <span class="text-xs text-muted-foreground">{{ formatCreatedAt(cj.lastRunAt) }}</span>
+                  <span class="text-xs text-muted-foreground">{{ formatTimestamp(cj.lastRunAt) }}</span>
                 </div>
                 <span v-else class="text-sm text-muted-foreground">—</span>
               </TableCell>
@@ -205,7 +205,8 @@
 <script setup lang="ts">
 import type { Cronjob } from '~/composables/useCronjobs'
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const { formatTimestamp } = useFormat()
 const { user } = useAuth()
 const isAdmin = computed(() => user.value?.role === 'admin')
 
@@ -324,17 +325,6 @@ function lastRunStatusVariant(status: string | null): 'default' | 'success' | 'd
     case 'failed': return 'destructive'
     default: return 'muted'
   }
-}
-
-function formatCreatedAt(dateStr: string): string {
-  const date = parseBackendTimestamp(dateStr)
-  if (!date) return dateStr
-  return new Intl.DateTimeFormat(locale.value, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date)
 }
 
 onMounted(async () => {

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -370,7 +370,7 @@
                   <AppIcon v-else-if="ttsPlayingIndex === i" name="square" size="sm" />
                   <AppIcon v-else name="volume" size="sm" />
                 </button>
-                <span class="text-[10px] leading-none text-muted-foreground/70">{{ formatMessageTime(msg.timestamp) }}</span>
+                <span class="text-[10px] leading-none text-muted-foreground/70">{{ formatTimeShort(msg.timestamp) }}</span>
               </div>
             </div>
           </template>
@@ -541,6 +541,7 @@ import type { ChatMessage, ToolCallData } from '~/composables/useChat'
 import { SETTINGS_THINKING_LEVELS, type SettingsThinkingLevel } from '@axiom/core/contracts'
 import { useSettingsApi } from '~/api/settings'
 const { t } = useI18n()
+const { formatTimeShort } = useFormat()
 const { apiFetch } = useApi()
 const { user } = useAuth()
 const isAdmin = computed(() => user.value?.role === 'admin')
@@ -895,10 +896,5 @@ watch(sttError, (val) => {
     sttErrorTimeout.value = setTimeout(() => { sttError.value = null }, 3000)
   }
 })
-function formatMessageTime(timestamp: string): string {
-  const date = parseBackendTimestamp(timestamp)
-  if (!date) return ''
-  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-}
 
 </script>

--- a/packages/web-frontend/app/pages/index.vue
+++ b/packages/web-frontend/app/pages/index.vue
@@ -895,6 +895,10 @@ watch(sttError, (val) => {
     sttErrorTimeout.value = setTimeout(() => { sttError.value = null }, 3000)
   }
 })
-function formatMessageTime(timestamp: string): string { const d = new Date(timestamp); if (isNaN(d.getTime())) return ''; return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }) }
+function formatMessageTime(timestamp: string): string {
+  const date = parseBackendTimestamp(timestamp)
+  if (!date) return ''
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
 
 </script>

--- a/packages/web-frontend/app/pages/users.vue
+++ b/packages/web-frontend/app/pages/users.vue
@@ -94,7 +94,7 @@
                         </Badge>
                       </div>
                       <span class="text-xs text-muted-foreground">
-                        {{ $t('users.updatedAt', { date: formatDate(entry.updatedAt) }) }}
+                        {{ $t('users.updatedAt', { date: formatDateTime(entry.updatedAt) }) }}
                       </span>
                     </div>
                   </div>
@@ -115,7 +115,7 @@
 
                 <!-- Created -->
                 <TableCell class="text-sm text-muted-foreground">
-                  {{ formatDate(entry.createdAt) }}
+                  {{ formatDateTime(entry.createdAt) }}
                 </TableCell>
 
                 <!-- Row actions (dropdown) -->
@@ -178,6 +178,7 @@
 import type { User } from '~/composables/useUsers'
 
 const { t } = useI18n()
+const { formatDateTime } = useFormat()
 const { user } = useAuth()
 const isAdmin = computed(() => user.value?.role === 'admin')
 const currentUserId = computed(() => user.value?.id ?? -1)
@@ -213,15 +214,6 @@ function clearMessages() {
   localError.value = null
   successMessage.value = null
   error.value = null
-}
-
-function formatDate(value: string): string {
-  const date = parseBackendTimestamp(value)
-  if (!date) return ''
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(date)
 }
 
 function autoHideSuccess() {

--- a/packages/web-frontend/app/pages/users.vue
+++ b/packages/web-frontend/app/pages/users.vue
@@ -216,10 +216,12 @@ function clearMessages() {
 }
 
 function formatDate(value: string): string {
+  const date = parseBackendTimestamp(value)
+  if (!date) return ''
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
-  }).format(new Date(value))
+  }).format(date)
 }
 
 function autoHideSuccess() {

--- a/packages/web-frontend/app/utils/datetime.test.ts
+++ b/packages/web-frontend/app/utils/datetime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { parseBackendTimestamp } from './datetime'
+
+describe('parseBackendTimestamp', () => {
+  it('treats SQLite naked datetime strings as UTC', () => {
+    const date = parseBackendTimestamp('2024-11-04 13:07:42')
+    expect(date).not.toBeNull()
+    expect(date!.toISOString()).toBe('2024-11-04T13:07:42.000Z')
+  })
+
+  it('treats naked ISO strings without offset as UTC', () => {
+    const date = parseBackendTimestamp('2024-11-04T13:07:42')
+    expect(date).not.toBeNull()
+    expect(date!.toISOString()).toBe('2024-11-04T13:07:42.000Z')
+  })
+
+  it('preserves ISO strings with explicit Z', () => {
+    const date = parseBackendTimestamp('2024-11-04T13:07:42Z')
+    expect(date!.toISOString()).toBe('2024-11-04T13:07:42.000Z')
+  })
+
+  it('preserves ISO strings with millisecond precision and Z', () => {
+    const date = parseBackendTimestamp('2024-11-04T13:07:42.123Z')
+    expect(date!.toISOString()).toBe('2024-11-04T13:07:42.123Z')
+  })
+
+  it('preserves ISO strings with explicit positive offset', () => {
+    const date = parseBackendTimestamp('2024-11-04T15:07:42+02:00')
+    expect(date!.toISOString()).toBe('2024-11-04T13:07:42.000Z')
+  })
+
+  it('preserves ISO strings with explicit negative offset', () => {
+    const date = parseBackendTimestamp('2024-11-04T08:07:42-05:00')
+    expect(date!.toISOString()).toBe('2024-11-04T13:07:42.000Z')
+  })
+
+  it('returns null for empty or nullish input', () => {
+    expect(parseBackendTimestamp(null)).toBeNull()
+    expect(parseBackendTimestamp(undefined)).toBeNull()
+    expect(parseBackendTimestamp('')).toBeNull()
+    expect(parseBackendTimestamp('   ')).toBeNull()
+  })
+
+  it('returns null for malformed input', () => {
+    expect(parseBackendTimestamp('not a date')).toBeNull()
+  })
+})

--- a/packages/web-frontend/app/utils/datetime.ts
+++ b/packages/web-frontend/app/utils/datetime.ts
@@ -1,0 +1,25 @@
+/**
+ * Backend timestamps come from SQLite's `datetime('now')`, which returns
+ * a UTC instant formatted as `YYYY-MM-DD HH:MM:SS` with no timezone marker.
+ * Passing such a string directly to `new Date(...)` makes the JS engine
+ * interpret it as **local** time, which shifts every rendered timestamp by
+ * the user's UTC offset (e.g. a message sent at 13:07 UTC shows as 13:07
+ * local instead of 15:07 in Europe/Vienna during CEST).
+ *
+ * This helper normalises both shapes — ISO strings with explicit offset
+ * and SQLite-style naked UTC strings — into a `Date` that represents the
+ * correct instant. Callers then use `toLocaleString` / `toLocaleTimeString`
+ * to render in the browser's local timezone.
+ */
+export function parseBackendTimestamp(value: string | null | undefined): Date | null {
+  if (!value) return null
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const hasExplicitZone = /Z$|[+-]\d{2}:?\d{2}$/.test(trimmed)
+  const normalised = hasExplicitZone ? trimmed : `${trimmed.replace(' ', 'T')}Z`
+
+  const date = new Date(normalised)
+  return Number.isNaN(date.getTime()) ? null : date
+}


### PR DESCRIPTION
## Problem

Chat-message and task-event timestamps were rendered in UTC instead of the user's local timezone. A message stored at `13:07` UTC showed up as `13:07` for a user in Europe/Vienna (CEST) instead of the correct `15:07`.

Root cause: SQLite stores timestamps via `datetime('now')` as `YYYY-MM-DD HH:MM:SS` with no timezone marker. When the frontend passed those strings to `new Date(...)`, V8 parsed them as **local** time, shifting every rendered timestamp by the user's UTC offset.

## Change

- New `parseBackendTimestamp` helper in `app/utils/datetime.ts` that normalises naked SQLite datetimes (and ISO strings without an offset) to UTC before parsing. ISO strings carrying `Z` or an explicit `±HH:MM` offset are passed through unchanged.
- Route every backend-driven timestamp formatter through the helper:
  - chat message time (`pages/index.vue`)
  - shared `useFormat` formatters (`formatDateTime`, `formatDate`, `formatTimestamp`) used by the dashboard log table and log rows
  - task event timestamps (`TaskEventsViewer.vue`)
  - task / cronjob "created at" columns (`TasksWorkspace.vue`, `pages/cronjobs.vue`)
  - memory facts table and memory workspace `formatDate`
  - users page `formatDate`
- Rendering still uses `toLocaleString` / `toLocaleTimeString` without a hardcoded zone, so the browser picks the user's timezone.

## Testing

- New unit tests in `app/utils/datetime.test.ts` cover naked SQLite datetimes, naked ISO strings, `Z`-suffixed ISO, `±HH:MM` offsets, and null/empty/garbage input.
- `npm run baseline:unit` — 1063 tests pass, including the new ones.