### PR TITLE
fix(providers): repair OAuth token renewal flow

### DIFF
--- a/packages/web-backend/src/api/modules/providers/service.ts
+++ b/packages/web-backend/src/api/modules/providers/service.ts
@@ -165,6 +165,31 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
       throw new ProvidersValidationError(`OAuth provider "${preset.oauthProviderId}" not found`)
     }
 
+    // Resume an already-running login for the same target instead of starting
+    // a second one. Callback-server flows (e.g. Anthropic) bind a fixed local
+    // port that stays open until the flow completes; spawning a fresh login
+    // while the previous one is still pending would fail with EADDRINUSE. This
+    // also lets the UI recover the flow after a page refresh.
+    for (const [existingId, existing] of pendingOAuthLogins) {
+      const sameTarget = payload.providerId
+        ? existing.existingProviderId === payload.providerId
+        : existing.existingProviderId == null
+          && existing.providerType === payload.providerType
+          && existing.name === payload.name
+      if (!sameTarget) continue
+      if (existing.status === 'pending' && existing.authUrl) {
+        return {
+          loginId: existingId,
+          authUrl: existing.authUrl,
+          instructions: existing.instructions,
+          usesCallbackServer: oauthProvider.usesCallbackServer ?? false,
+        }
+      }
+      // Stale completed/errored entry for this target — drop it and start fresh.
+      pendingOAuthLogins.delete(existingId)
+    }
+    maybeStopOAuthCleanupTimer()
+
     const loginId = crypto.randomUUID()
     const loginState: PendingOAuthLogin = {
       status: 'pending',

--- a/packages/web-frontend/app/components/ProviderFormDialog.vue
+++ b/packages/web-frontend/app/components/ProviderFormDialog.vue
@@ -379,7 +379,7 @@
         </div>
 
         <!-- OAuth Login Section -->
-        <div v-if="isOAuthProvider && (mode === 'create' || oauthInProgress)" class="flex flex-col gap-3">
+        <div v-if="isOAuthProvider && (mode === 'create' || oauthInProgress || oauthError)" class="flex flex-col gap-3">
           <!-- OAuth status messages -->
           <div v-if="oauthInProgress" class="rounded-md border border-border bg-muted/50 p-4">
             <div class="flex items-center gap-3">
@@ -424,20 +424,28 @@
 
         <DialogFooter class="!flex-row !justify-start items-center">
           <!-- Renew token button (left-aligned, only for OAuth edit mode) -->
-          <Button
-            v-if="isOAuthProvider && mode === 'edit'"
-            type="button"
-            variant="outline"
-            :disabled="oauthInProgress"
-            @click="startOAuthRenew"
-          >
-            <span
-              v-if="oauthInProgress"
-              class="mr-1.5 h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground"
-              aria-hidden="true"
-            />
-            {{ oauthInProgress ? $t('providers.oauthRenewing') : $t('providers.oauthRenewToken') }}
-          </Button>
+          <template v-if="isOAuthProvider && mode === 'edit'">
+            <Button
+              v-if="!oauthInProgress"
+              type="button"
+              variant="outline"
+              @click="startOAuthRenew"
+            >
+              {{ $t('providers.oauthRenewToken') }}
+            </Button>
+            <Button
+              v-else
+              type="button"
+              variant="outline"
+              @click="cancelOAuthRenew"
+            >
+              <span
+                class="mr-1.5 h-4 w-4 animate-spin rounded-full border-2 border-primary/30 border-t-primary"
+                aria-hidden="true"
+              />
+              {{ $t('providers.oauthCancelRenew') }}
+            </Button>
+          </template>
           <div class="flex-1" />
           <div class="flex items-center gap-2">
             <Button type="button" variant="outline" :disabled="oauthInProgress" @click="emit('close')">
@@ -1024,6 +1032,15 @@ function handleSubmit() {
     transport: normalizeTransportPayload(),
     enabledModels,
   })
+}
+
+function cancelOAuthRenew() {
+  // Stop the polling loop (it bails out on the next tick when this is false)
+  // and reset local OAuth state so the user can trigger a fresh renewal.
+  oauthInProgress.value = false
+  oauthLoginId.value = null
+  manualCode.value = ''
+  oauthError.value = null
 }
 
 async function startOAuthRenew() {

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -169,6 +169,7 @@
     "oauthSubmitCode": "Absenden",
     "oauthRenewToken": "Token erneuern",
     "oauthRenewing": "Erneuere...",
+    "oauthCancelRenew": "Abbrechen",
     "statusConnected": "Verbunden",
     "statusError": "Fehler",
     "statusUntested": "Ungetestet",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -169,6 +169,7 @@
     "oauthSubmitCode": "Submit",
     "oauthRenewToken": "Renew Token",
     "oauthRenewing": "Renewing...",
+    "oauthCancelRenew": "Cancel",
     "statusConnected": "Connected",
     "statusError": "Error",
     "statusUntested": "Untested",


### PR DESCRIPTION
Fixes two bugs in the "Renew Token" flow of the Edit Provider dialog for OAuth providers.

### Bug 1: Renew button stuck after closing the auth window
Clicking **Renew Token** set `oauthInProgress = true` and polled for up to 2 minutes. If the user closed the auth tab without completing the flow, nothing ever reset the flag, so the button stayed disabled (`Renewing…`) with no way to retry.

### Bug 2: Renew silently does nothing after a page refresh
The Anthropic OAuth flow binds a **fixed local callback port** that only closes once the flow completes. A stale login from before the refresh kept the port bound, so a fresh `startOAuthLogin` failed with `EADDRINUSE`. On top of that, the frontend only rendered `oauthError` while `oauthInProgress` was active, so in edit mode the error was swallowed entirely — it looked like nothing happened.