### PR TITLE
perf: keep system prompt cacheable by moving time to user messages

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -8,12 +8,12 @@ This page documents exactly how that prompt is built, what each block contains, 
 
 The prompt is rebuilt from scratch on **every turn** by [`assembleSystemPrompt()` in `packages/core/src/memory.ts`](https://github.com/meteyou/axiom/blob/main/packages/core/src/memory.ts). Each section is wrapped in an XML-style tag (`<personality>`, `<agent_rules>`, `<core_memory>`, …) so the model can clearly distinguish what each block is for.
 
-Most layers come straight from a Markdown file under `/data/memory/` or `/data/config/` (see [Container file paths](./../reference/file-paths)). A few are computed at request time (current datetime, the active tool list, the configured language). All of them are concatenated, separated by blank lines, and handed to the LLM as the `system` message.
+Most layers come straight from a Markdown file under `/data/memory/` or `/data/config/` (see [Container file paths](./../reference/file-paths)). A few are computed at request time (current date, the active tool list, the configured language). All of them are concatenated, separated by blank lines, and handed to the LLM as the `system` message.
 
 Because the prompt is rebuilt every turn:
 
 - **File edits take effect on the next message** — no restart, no reload step.
-- **The current date and time are always accurate** — `<current_datetime>` reflects "now" in the configured timezone.
+- **The current date is always accurate** — `<current_date>` reflects "today" in the configured timezone.
 - **Per-user blocks only appear when that user is talking** — multi-user setups stay clean.
 - **Disabled features drop out entirely** — if you have no skills installed, there is no `<available_skills>` block; if no provider is configured yet, there is no `<available_providers>` block.
 
@@ -118,11 +118,13 @@ See [Tasks & Cronjobs](./tasks-and-cronjobs).
 
 A one-liner declaring `/workspace` as the working directory for shell commands and relative paths. Anchors all file operations so they don't accidentally land in `/data` or the OS root. See [Container file paths → `/workspace`](./../reference/file-paths).
 
-### 16. `<current_datetime>`: current date and time
+### 16. `<current_date>`: current date
 
 *Always present.*
 
-The current date and time, formatted in the configured timezone. Computed at request time, so the agent always knows "now" — useful for cron creation, daily-note naming, "what day is it" questions, and any time-relative reasoning.
+The current **date** (day-granular), formatted in the configured timezone. Computed at request time, so the agent always knows "today" — useful for cron creation, daily-note naming, "what day is it" questions, and any date-relative reasoning.
+
+The minute-level **time** is deliberately *not* in the system prompt. It is appended to each **user message** as a small `<current_time>` block instead. Why: the system prompt is handed to the provider as a single cached prefix (Anthropic / OpenAI prompt caching). A minute-granular timestamp *inside* that prefix would change every minute and invalidate the whole cached block — system prompt, tool definitions, and conversation history — forcing an expensive cache re-write on almost every turn. Keeping the date (which only rolls over once per day) in the prompt and moving the precise time into the always-fresh user message preserves the cache while still giving the agent an accurate "now".
 
 ### 17. `<language>`: reply language
 

--- a/docs/settings/agent.md
+++ b/docs/settings/agent.md
@@ -29,7 +29,7 @@ Applies immediately on the next turn.
 
 ## Timezone
 
-The current date and time in this timezone are injected into the system prompt so the agent always knows "now". Also used for cron evaluation (Tasks & Heartbeat) and the naming of `memory/daily/<date>.md` files.
+The current date in this timezone is injected into the system prompt, and the minute-level time is appended to each user message, so the agent always knows "now" (the time is kept out of the system prompt to avoid invalidating provider prompt caches every minute — see [System Prompt → layer 16](../concepts/system-prompt#_16-current-date-current-date)). Also used for cron evaluation (Tasks & Heartbeat) and the naming of `memory/daily/<date>.md` files.
 
 Default: `UTC`. Mirrors the container's `TZ` env var if set.
 

--- a/packages/core/src/agent-runtime.ts
+++ b/packages/core/src/agent-runtime.ts
@@ -12,7 +12,7 @@ import type { ProviderConfig } from './provider-config.js'
 import type { ProviderManager } from './provider-manager.js'
 import type { SettingsThinkingLevel } from './contracts/settings.js'
 import { normalizeThinkingLevel } from './thinking-level.js'
-import { assembleSystemPrompt, ensureMemoryStructure, ensureConfigStructure } from './memory.js'
+import { assembleSystemPrompt, ensureMemoryStructure, ensureConfigStructure, formatCurrentTimeContext } from './memory.js'
 import type { SkillPromptEntry } from './memory.js'
 import { getWorkspaceDir } from './workspace.js'
 import { loadConfig, ensureConfigTemplates } from './config.js'
@@ -79,6 +79,7 @@ export interface AgentRuntimeOptions {
 export interface AgentRuntimeBoundary {
   streamPrompt(text: string, sessionId: string, images?: ImageContent[]): AsyncIterable<ResponseChunk>
   refreshSystemPrompt(channel?: string, currentUser?: { username: string }): void
+  getCurrentTimeContext(): string
   swapProvider(provider: ProviderConfig, apiKey: string, modelId?: string): void
   getProviderManager(): ProviderManager | undefined
   clearMessages(): void
@@ -502,6 +503,11 @@ class PiAgentRuntime implements AgentRuntimeBoundary, AgentRuntimePiAgentAccess 
 
   refreshSystemPrompt(channel?: string, currentUser?: { username: string }): void {
     this.agent.state.systemPrompt = this.buildSystemPrompt(channel, currentUser)
+  }
+
+  getCurrentTimeContext(): string {
+    const { timezone } = this.readRuntimeSettings()
+    return formatCurrentTimeContext(timezone)
   }
 
   setThinkingLevel(level: SettingsThinkingLevel | string): void {

--- a/packages/core/src/agent-task-injection.test.ts
+++ b/packages/core/src/agent-task-injection.test.ts
@@ -25,6 +25,7 @@ vi.mock('./agent-runtime.js', () => ({
   createAgentRuntime: vi.fn(() => ({
     streamPrompt: streamPromptMock,
     refreshSystemPrompt: vi.fn(),
+    getCurrentTimeContext: vi.fn(() => '<current_time>Current time: 12:00 (UTC)</current_time>'),
     swapProvider: vi.fn(),
     getProviderManager: vi.fn(() => undefined),
     clearMessages: vi.fn(),

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -262,7 +262,9 @@ export class AgentCore {
       }
     }
 
-    const enrichedText = fileHints.length > 0 ? `${text}\n\n${fileHints.join('\n')}` : text
+    const timeContext = this.runtime.getCurrentTimeContext()
+    const baseText = fileHints.length > 0 ? `${text}\n\n${fileHints.join('\n')}` : text
+    const enrichedText = `${baseText}\n\n${timeContext}`
     const parsedUserId = Number.parseInt(userId, 10)
     this.currentToolUserId = Number.isFinite(parsedUserId) ? parsedUserId : undefined
 

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -745,7 +745,7 @@ export function readRecentDailyFiles(days: number = 3, memoryDir?: string): stri
  * minute. The minute-level time is appended to each user message instead (see
  * `formatCurrentTimeContext`).
  */
-export function getCurrentDateTimeParts(timezone?: string): { date: string; time: string; tz: string } {
+function getCurrentDateTimeParts(timezone?: string): { date: string; time: string; tz: string } {
   const tz = timezone || getDefaultTimezone()
   const now = new Date()
   const date = now.toLocaleDateString('en-CA', { timeZone: tz })

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -737,6 +737,34 @@ export function readRecentDailyFiles(days: number = 3, memoryDir?: string): stri
 }
 
 /**
+ * Compute the current date, time and timezone for prompt injection.
+ *
+ * Split intentionally: the `date` is day-granular and safe to embed in the
+ * cached system-prompt prefix, whereas `time` is minute-granular and must NOT
+ * go into the system prompt — it would invalidate provider prompt caches every
+ * minute. The minute-level time is appended to each user message instead (see
+ * `formatCurrentTimeContext`).
+ */
+export function getCurrentDateTimeParts(timezone?: string): { date: string; time: string; tz: string } {
+  const tz = timezone || getDefaultTimezone()
+  const now = new Date()
+  const date = now.toLocaleDateString('en-CA', { timeZone: tz })
+  const time = now.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', timeZone: tz })
+  return { date, time, tz }
+}
+
+/**
+ * Build the per-message current-time context appended to each user message.
+ * Kept out of the (cached) system prompt so the prompt-cache prefix stays
+ * stable across turns — only this small, always-fresh block changes per turn,
+ * which the providers treat as new (uncached) content anyway.
+ */
+export function formatCurrentTimeContext(timezone?: string): string {
+  const { time, tz } = getCurrentDateTimeParts(timezone)
+  return `<current_time>Current time: ${time} (${tz})</current_time>`
+}
+
+/**
  * Assemble the full system prompt from all memory tiers
  */
 /**
@@ -1009,12 +1037,12 @@ When you receive a <task_injection> block (signalling a background-task result w
   const workspaceDir = getWorkspaceDir()
   sections.push(`<workspace>\nYour working directory is ${workspaceDir}. All shell commands execute in this directory by default.\nAll relative paths in read_file, write_file, and list_files resolve against this directory.\nUse this directory for cloning repos, creating files, and all file operations.\n</workspace>`)
 
-  // 14. Current date & time
-  const tz = options?.timezone || getDefaultTimezone()
-  const now = new Date()
-  const date = now.toLocaleDateString('en-CA', { timeZone: tz })
-  const time = now.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', timeZone: tz })
-  sections.push(`<current_datetime>\nCurrent date: ${date}\nCurrent time: ${time} (${tz})\n</current_datetime>`)
+  // 14. Current date (date only — kept at day-granularity so the cached
+  // system-prompt prefix stays stable across turns. The precise minute-level
+  // time is appended to each user message instead via formatCurrentTimeContext(),
+  // which avoids invalidating provider prompt caches every minute.)
+  const { date, tz } = getCurrentDateTimeParts(options?.timezone)
+  sections.push(`<current_date>\nCurrent date: ${date} (${tz})\n</current_date>`)
 
   // 15. Language setting (placed near the end for recency: "respond in X" hits
   // the model right before it processes the user message).


### PR DESCRIPTION
The minute-level timestamp in the `<current_datetime>` block invalidated the provider prompt cache (system prompt + tool defs + history) on nearly every turn.

Now only the day-granular date stays in the system prompt (`<current_date>`); the precise time is appended to each user message instead, keeping the cached prefix stable while the agent still knows "now".