### PR TITLE
chore: update Pi AI packages to 0.79.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1304,12 +1304,12 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.78.0.tgz",
-      "integrity": "sha512-xhWd59Qzd8yO88gYQw2S4dEQstJJEiUtxRP01//YzVJ61jCtUASMfcyAmYhgGYR4Onp7GmwEAbBBGOiV6Iwk9g==",
+      "version": "0.79.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.3.tgz",
+      "integrity": "sha512-Ksvnu6CpQLYGbCSgnQEetzliI7yb+QkqtSlmmunJ69QluT45kd3DjQZRNHfRLk++Dd02Y8QvsRKMopSJCcWoWw==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.78.0",
+        "@earendil-works/pi-ai": "^0.79.3",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1328,9 +1328,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.78.0.tgz",
-      "integrity": "sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA==",
+      "version": "0.79.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.3.tgz",
+      "integrity": "sha512-lMSput/haP5uZAGbXhS5rAYd3GB7GYdJkoAUxg3VFummBeqGqGqllaTWrbHFN12kVGyVfWHhdySNXkiqVh65Iw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -18433,8 +18433,8 @@
       "name": "@axiom/core",
       "version": "0.19.0",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.78.0",
-        "@earendil-works/pi-ai": "0.78.0",
+        "@earendil-works/pi-agent-core": "0.79.3",
+        "@earendil-works/pi-ai": "0.79.3",
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^11.0.0",
         "js-yaml": "^4.1.1"
@@ -18459,7 +18459,7 @@
       "dependencies": {
         "@axiom/core": "*",
         "@axiom/telegram": "*",
-        "@earendil-works/pi-ai": "0.78.0",
+        "@earendil-works/pi-ai": "0.79.3",
         "bcrypt": "^6.0.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,8 +20,8 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.78.0",
-    "@earendil-works/pi-ai": "0.78.0",
+    "@earendil-works/pi-agent-core": "0.79.3",
+    "@earendil-works/pi-ai": "0.79.3",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^11.0.0",
     "js-yaml": "^4.1.1"

--- a/packages/web-backend/package.json
+++ b/packages/web-backend/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@axiom/core": "*",
     "@axiom/telegram": "*",
-    "@earendil-works/pi-ai": "0.78.0",
+    "@earendil-works/pi-ai": "0.79.3",
     "bcrypt": "^6.0.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.3",


### PR DESCRIPTION
## Change

- Update `@earendil-works/pi-ai` from `0.78.0` to `0.79.3` in `packages/core` and `packages/web-backend`.
- Update the matching agent harness package `@earendil-works/pi-agent-core` from `0.78.0` to `0.79.3` in `packages/core`.
- Keep the lockfile update scoped to the Pi package entries.

## Breaking changes reviewed

Reviewed npm metadata, GitHub releases, and the package changelogs for `packages/ai` and `packages/agent` from `0.78.1` through `0.79.3`.

No breaking changes were listed for this upgrade range. The relevant changes are provider/model metadata fixes, provider request fixes, and agent-core bug fixes. Axiom does not import the removed stale `./hooks` coding-agent export mentioned in the root `v0.79.0` release notes.

## Code changes

No Axiom code changes were needed.

## Testing

- `npm ci --include=dev`
- `npm run build` ✅
- `npm test` ✅ — 68 files / 1258 tests passed
- `npm run lint` currently fails on existing `no-empty` issues in untouched tests:
  - `packages/core/src/task-runner.test.ts:1728:79`
  - `packages/core/src/task-tools.test.ts:101:38`
