### PR TITLE
feat: add Anthropic subscriber quota

### DIFF
--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -29,8 +29,8 @@ Providers are sorted alphabetically by display name; sub-rows follow the order c
 |-------------|------------------------------------------------------------------------------------------------------|
 | **Name**    | Bold display name; below it, the provider type label (e.g. *"Anthropic"*, *"Anthropic (Claude Pro/Max) · OAuth"*). |
 | **Cost**    | Empty — costs live on the model rows.                                                                |
-| **Status**  | Empty — status lives on the model rows.                                                              |
-| **⋮**       | Edit, Delete. *Delete* is disabled for the provider that owns the currently active model.            |
+| **Status**  | Empty for most providers (status lives on the model rows). For **Anthropic Claude Pro/Max (OAuth)** providers it shows the live [subscriber usage quota](#subscriber-usage-quota-claude-pro-max). |
+| **⋮**       | Edit, Delete, and — for Anthropic OAuth providers — **Refresh quota**. *Delete* is disabled for the provider that owns the currently active model. |
 
 Clicking anywhere on a header row opens the [Edit dialog](#add-edit-dialog).
 
@@ -215,6 +215,33 @@ The full flow:
 4. Once the redirect comes back, the dialog closes and the provider appears in the list.
 
 **Remote server fallback.** If your Axiom instance runs on a remote box where the OAuth callback URL can't reach you, a manual-code field appears below the spinner: *"Or paste the redirect URL here (for remote servers)"*. Complete the login locally, copy the full redirect URL from the browser, paste it in, and click **Submit**.
+
+### Subscriber usage quota (Claude Pro/Max)
+
+For **Anthropic Claude Pro/Max (OAuth)** providers, the provider header row's **Status** column shows how much of your subscription allowance is left, polled in the background (no manual action needed). Other provider types never show quota — the endpoint only exists for Anthropic subscriptions.
+
+Each configured bucket appears on its own line as `<bucket> <utilization>% (<reset>)`:
+
+| Bucket | Meaning                                              | Reset shown as                        |
+|--------|------------------------------------------------------|---------------------------------------|
+| `5h`   | Rolling 5-hour usage window.                         | Relative countdown, e.g. `2h 14m`.    |
+| `7d`   | Rolling 7-day usage window.                          | Weekday + time, e.g. `Mon 3:00PM`.    |
+| `Opus` | 7-day Opus-specific window (when your plan has one). | —                                     |
+
+The percentage is colour-coded: green below 70%, amber at 70–89%, red at 90%+. Reset times follow your browser's regional settings.
+
+The same active-provider quota is mirrored in the **top bar** next to the health status — but only on wide (`lg`) viewports, and only for the *active* provider. It is hidden on smaller screens and for non-active providers.
+
+#### Refresh quota
+
+The ⋮ menu on an Anthropic OAuth provider header carries a **Refresh quota** item that forces an immediate, on-demand fetch (bypassing the background poll's backoff). While it runs, the Status column shows a spinner with *"Refreshing…"*; on success a *"Quota updated"* banner appears briefly.
+
+#### When quota is unavailable
+
+The Anthropic usage endpoint is aggressively rate-limited. Axiom applies a per-provider backoff on `429` responses and **keeps the last good snapshot** during transient failures instead of flapping to "unavailable". When there is no usable data, the Status column shows:
+
+- *"Rate-limited — try again shortly"* — a `429` was hit and no earlier snapshot exists yet. Wait a bit, or use **Refresh quota** later.
+- *"Quota unavailable"* — any other failure (auth error, network, …). Hover the text for the underlying error.
 
 ### Renewing OAuth tokens
 

--- a/packages/core/src/anthropic-quota.ts
+++ b/packages/core/src/anthropic-quota.ts
@@ -1,0 +1,149 @@
+import type { ProviderConfig } from './provider-config.js'
+import { CLAUDE_CODE_VERSION, getApiKeyForProvider } from './provider-config.js'
+
+const USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage'
+
+// OAuth beta header expected by the Anthropic usage endpoint (matches the
+// header pi-ai sends for OAuth inference requests).
+const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
+
+interface RawUsageBucket {
+  utilization: number
+  resets_at: string | null
+}
+
+/** Shape returned by /api/oauth/usage (only the fields we consume). */
+interface RawUsageLimits {
+  five_hour?: RawUsageBucket | null
+  seven_day?: RawUsageBucket | null
+  seven_day_opus?: RawUsageBucket | null
+  seven_day_sonnet?: RawUsageBucket | null
+}
+
+export interface AnthropicQuotaBucket {
+  utilization: number
+  resetsAt: string | null
+}
+
+export interface AnthropicQuota {
+  fiveHour: AnthropicQuotaBucket | null
+  sevenDay: AnthropicQuotaBucket | null
+  sevenDayOpus: AnthropicQuotaBucket | null
+  sevenDaySonnet: AnthropicQuotaBucket | null
+  fetchedAt: string
+}
+
+export interface AnthropicQuotaFetchResult {
+  quota: AnthropicQuota | null
+  status?: number
+  retryAfterMs?: number
+  error?: string
+}
+
+/** Only Anthropic subscriber (OAuth) credentials can query the usage endpoint. */
+export function isAnthropicOAuthProvider(provider: ProviderConfig): boolean {
+  return (
+    provider.providerType === 'anthropic-oauth' &&
+    provider.authMethod === 'oauth' &&
+    !!provider.oauthCredentials
+  )
+}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) return undefined
+
+  const seconds = Number(header)
+  if (!Number.isNaN(seconds) && seconds > 0) {
+    return Math.round(seconds * 1000)
+  }
+
+  const retryAt = new Date(header).getTime()
+  if (!Number.isNaN(retryAt)) {
+    const diff = retryAt - Date.now()
+    if (diff > 0) return diff
+  }
+
+  return undefined
+}
+
+function toBucket(bucket: RawUsageBucket | null | undefined): AnthropicQuotaBucket | null {
+  if (!bucket || typeof bucket.utilization !== 'number') return null
+  return { utilization: bucket.utilization, resetsAt: bucket.resets_at ?? null }
+}
+
+/**
+ * Fetch Anthropic usage limits using a raw OAuth access token.
+ *
+ * Headers mirror what pi-ai sends for OAuth Anthropic requests so the usage
+ * call is attributed to the same client identity as inference and token
+ * refresh — a single consistent caller for Anthropic.
+ */
+export async function fetchAnthropicQuota(
+  accessToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AnthropicQuotaFetchResult> {
+  try {
+    const response = await fetchImpl(USAGE_ENDPOINT, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'User-Agent': `claude-cli/${CLAUDE_CODE_VERSION}`,
+        Authorization: `Bearer ${accessToken}`,
+        'anthropic-beta': OAUTH_BETA_HEADER,
+        'anthropic-dangerous-direct-browser-access': 'true',
+        'x-app': 'cli',
+      },
+    })
+
+    if (!response.ok) {
+      return {
+        quota: null,
+        status: response.status,
+        retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
+        error: `HTTP ${response.status}`,
+      }
+    }
+
+    const data = (await response.json()) as RawUsageLimits
+    return {
+      quota: {
+        fiveHour: toBucket(data.five_hour),
+        sevenDay: toBucket(data.seven_day),
+        sevenDayOpus: toBucket(data.seven_day_opus),
+        sevenDaySonnet: toBucket(data.seven_day_sonnet),
+        fetchedAt: new Date().toISOString(),
+      },
+      status: response.status,
+    }
+  } catch (err) {
+    return { quota: null, error: (err as Error).message || 'Network error' }
+  }
+}
+
+/**
+ * Resolve an OAuth access token for an Anthropic subscriber provider and fetch
+ * its usage. Works regardless of whether the provider is the active one — the
+ * usage endpoint is read-only and does not affect provider activation.
+ */
+export async function getAnthropicQuotaForProvider(
+  provider: ProviderConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AnthropicQuotaFetchResult> {
+  if (!isAnthropicOAuthProvider(provider)) {
+    return { quota: null, error: 'Provider is not an Anthropic OAuth subscriber' }
+  }
+
+  let accessToken: string
+  try {
+    accessToken = await getApiKeyForProvider(provider)
+  } catch (err) {
+    return { quota: null, error: (err as Error).message || 'Failed to resolve OAuth token' }
+  }
+
+  if (!accessToken) {
+    return { quota: null, error: 'No OAuth access token available' }
+  }
+
+  return fetchAnthropicQuota(accessToken, fetchImpl)
+}

--- a/packages/core/src/contracts/index.ts
+++ b/packages/core/src/contracts/index.ts
@@ -57,6 +57,8 @@ export type {
 export type {
   ProviderStatusContract,
   ProviderAuthMethodContract,
+  AnthropicQuotaBucketContract,
+  AnthropicQuotaContract,
   ProviderContract,
   ProviderTypePresetContract,
   AvailableModelContract,
@@ -64,6 +66,7 @@ export type {
   OllamaPullEventContract,
   ProvidersListResponseContract,
   ProviderMutationResponseContract,
+  ProviderQuotaRefreshResponseContract,
   ProviderTestResultContract,
   ProviderActivationResponseContract,
   ProviderFallbackResponseContract,

--- a/packages/core/src/contracts/providers.ts
+++ b/packages/core/src/contracts/providers.ts
@@ -1,6 +1,20 @@
 import type { ProviderType } from '../provider-config.js'
 
 export type ProviderStatusContract = 'connected' | 'error' | 'untested'
+
+export interface AnthropicQuotaBucketContract {
+  utilization: number
+  resetsAt: string | null
+}
+
+export interface AnthropicQuotaContract {
+  fiveHour: AnthropicQuotaBucketContract | null
+  sevenDay: AnthropicQuotaBucketContract | null
+  sevenDayOpus: AnthropicQuotaBucketContract | null
+  sevenDaySonnet: AnthropicQuotaBucketContract | null
+  fetchedAt: string
+  error?: string
+}
 export type ProviderAuthMethodContract = 'api-key' | 'oauth'
 export type ProviderTextVerbosityContract = 'low' | 'medium' | 'high'
 export type ProviderTransportContract = 'sse' | 'websocket' | 'websocket-cached' | 'auto'
@@ -25,6 +39,8 @@ export interface ProviderContract {
   oauthCredentials?: { expires: number }
   cost?: { input: number; output: number } | null
   modelCosts?: Record<string, { input: number; output: number }>
+  /** Anthropic subscriber usage snapshot (only for anthropic-oauth providers). */
+  quota?: AnthropicQuotaContract | null
 }
 
 export interface ProviderTypePresetContract {
@@ -82,6 +98,10 @@ export interface ProvidersListResponseContract {
 
 export interface ProviderMutationResponseContract {
   provider: ProviderContract
+}
+
+export interface ProviderQuotaRefreshResponseContract {
+  quota: AnthropicQuotaContract | null
 }
 
 export interface ProviderTestResultContract {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,8 +90,15 @@ export {
   getConfiguredPriceTable,
   PROVIDER_TYPE_PRESETS,
   PROVIDER_TYPE_MODEL_OVERRIDES,
+  CLAUDE_CODE_VERSION,
 } from './provider-config.js'
 export type { ProviderConfig, ProviderModelConfig, ProvidersFile, ProviderType, ProviderTypePreset, AuthMethod, TextVerbosity, AvailableModel, OAuthCredentialsStored, TokenPriceTable } from './provider-config.js'
+export {
+  fetchAnthropicQuota,
+  getAnthropicQuotaForProvider,
+  isAnthropicOAuthProvider,
+} from './anthropic-quota.js'
+export type { AnthropicQuota, AnthropicQuotaBucket, AnthropicQuotaFetchResult } from './anthropic-quota.js'
 export { encrypt, decrypt, isEncrypted, maskApiKey } from './encryption.js'
 export {
   logTokenUsage,

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -12,7 +12,7 @@ import { encrypt, decrypt, isEncrypted, maskApiKey } from './encryption.js'
  * Claude Code CLI version to advertise in the user-agent header for Anthropic requests.
  * This ensures Anthropic treats requests as coming from a Claude Code client.
  */
-const CLAUDE_CODE_VERSION = '2.1.96'
+export const CLAUDE_CODE_VERSION = '2.1.96'
 
 /**
  * Supported provider types with presets

--- a/packages/web-backend/src/api/modules/providers/controller.ts
+++ b/packages/web-backend/src/api/modules/providers/controller.ts
@@ -50,6 +50,7 @@ export interface ProvidersController {
   deleteProvider: (req: AuthenticatedRequest, res: ExpressResponse) => void
   postProviderTest: (req: AuthenticatedRequest, res: ExpressResponse) => Promise<void>
   postProviderActivate: (req: AuthenticatedRequest, res: ExpressResponse) => void
+  postRefreshQuota: (req: AuthenticatedRequest, res: ExpressResponse) => Promise<void>
 }
 
 export function createProvidersController(options: ProvidersRouterOptions = {}): ProvidersController {
@@ -84,7 +85,7 @@ export function createProvidersController(options: ProvidersRouterOptions = {}):
     getProviders(_req, res) {
       try {
         const data = service.listProviders()
-        res.json(mapProvidersListResponse(data.masked, data.decrypted))
+        res.json(mapProvidersListResponse(data.masked, data.decrypted, options.getQuotaSnapshot?.()))
       } catch (err) {
         res.status(500).json({ error: `Failed to load providers: ${(err as Error).message}` })
       }
@@ -396,6 +397,20 @@ export function createProvidersController(options: ProvidersRouterOptions = {}):
           return
         }
 
+        res.status(500).json({ error: (err as Error).message })
+      }
+    },
+
+    async postRefreshQuota(req, res) {
+      if (!options.refreshQuota) {
+        res.status(501).json({ error: 'Quota refresh is not available' })
+        return
+      }
+
+      try {
+        const quota = await options.refreshQuota(String(req.params.id ?? ''))
+        res.json({ quota })
+      } catch (err) {
         res.status(500).json({ error: (err as Error).message })
       }
     },

--- a/packages/web-backend/src/api/modules/providers/mapper.ts
+++ b/packages/web-backend/src/api/modules/providers/mapper.ts
@@ -5,6 +5,7 @@ import type {
   ProvidersFile,
 } from '@axiom/core'
 import type {
+  AnthropicQuotaContract,
   OllamaModelContract,
   ProviderActivationResponseContract,
   ProviderContract,
@@ -48,7 +49,11 @@ function resolveModelCost(provider: ProviderConfig, modelId: string): { input: n
   return null
 }
 
-export function mapProvidersListResponse(masked: ProvidersFile, decrypted: ProvidersFile): ProvidersListResponseContract {
+export function mapProvidersListResponse(
+  masked: ProvidersFile,
+  decrypted: ProvidersFile,
+  quotaSnapshot?: Record<string, AnthropicQuotaContract>,
+): ProvidersListResponseContract {
   const providers = masked.providers.map((provider) => {
     const fullProvider = decrypted.providers.find((candidate) => candidate.id === provider.id)
     let cost: { input: number; output: number } | null = null
@@ -71,6 +76,7 @@ export function mapProvidersListResponse(masked: ProvidersFile, decrypted: Provi
       apiKeyMasked: (provider as unknown as { apiKeyMasked?: string }).apiKeyMasked ?? provider.apiKey,
       cost,
       modelCosts,
+      quota: quotaSnapshot?.[provider.id] ?? null,
     } as ProviderContract
   })
 

--- a/packages/web-backend/src/api/modules/providers/route.ts
+++ b/packages/web-backend/src/api/modules/providers/route.ts
@@ -42,6 +42,7 @@ export function createProvidersRouter(options: ProvidersRouterOptions = {}): Rou
   router.delete('/:id', controller.deleteProvider)
   router.post('/:id/test', controller.postProviderTest)
   router.post('/:id/activate', controller.postProviderActivate)
+  router.post('/:id/refresh-quota', controller.postRefreshQuota)
 
   return router
 }

--- a/packages/web-backend/src/api/modules/providers/types.ts
+++ b/packages/web-backend/src/api/modules/providers/types.ts
@@ -1,8 +1,11 @@
 import type { OAuthCredentials } from '@earendil-works/pi-ai/oauth'
+import type { AnthropicQuotaContract } from '@axiom/core/contracts'
 
 export interface ProvidersRouterOptions {
   onActiveProviderChanged?: () => void
   onFallbackProviderChanged?: () => void
+  getQuotaSnapshot?: () => Record<string, AnthropicQuotaContract>
+  refreshQuota?: (providerId: string) => Promise<AnthropicQuotaContract | null>
 }
 
 export interface PendingOAuthLogin {

--- a/packages/web-backend/src/app.ts
+++ b/packages/web-backend/src/app.ts
@@ -23,6 +23,7 @@ import { createTtsRouter } from './routes/tts.js'
 import { createSttRouter } from './routes/stt.js'
 import { createDeepgramRouter } from './routes/deepgram.js'
 import type { ProviderConfig, TaskRuntimeBoundary, TaskEventBus, AgentHeartbeatService } from '@axiom/core'
+import type { AnthropicQuotaContract } from '@axiom/core/contracts'
 import { ensureAdminUser } from './auth.js'
 import type { HealthMonitorService } from './health-monitor.js'
 import type { RuntimeMetrics } from './runtime-metrics.js'
@@ -62,6 +63,13 @@ export interface AppOptions {
    */
   getBackgroundTaskToolNames?: () => string[]
   taskEventBus?: TaskEventBus | null
+  /**
+   * Returns the latest cached Anthropic subscriber usage snapshots keyed by
+   * provider id. Used by the providers list endpoint to surface quota in the
+   * UI without blocking the request on a live usage fetch.
+   */
+  getQuotaSnapshot?: () => Record<string, AnthropicQuotaContract>
+  refreshQuota?: (providerId: string) => Promise<AnthropicQuotaContract | null>
 }
 
 export function createApp(options?: AppOptions): express.Express {
@@ -107,6 +115,8 @@ export function createApp(options?: AppOptions): express.Express {
     app.use('/api/chat', createChatRouter({ db: options.db, getAgentCore }))
     app.use('/api/logs', createLogsRouter(options.db))
     app.use('/api/providers', createProvidersRouter({
+      getQuotaSnapshot: options.getQuotaSnapshot,
+      refreshQuota: options.refreshQuota,
       onActiveProviderChanged: () => {
         options.healthMonitorService?.restart({ resetState: true })
         options.onActiveProviderChanged?.()
@@ -163,6 +173,7 @@ export function createApp(options?: AppOptions): express.Express {
         db: options.db,
         healthMonitorService: options.healthMonitorService,
         runtimeMetrics: options.runtimeMetrics,
+        getQuotaSnapshot: options.getQuotaSnapshot,
       }))
     }
   }

--- a/packages/web-backend/src/bootstrap/http-boundary.ts
+++ b/packages/web-backend/src/bootstrap/http-boundary.ts
@@ -28,6 +28,8 @@ export async function startHttpBoundary(
     db: runtimeComposition.db,
     getAgentCore: runtimeComposition.getAgentCore,
     healthMonitorService: runtimeComposition.healthMonitorService,
+    getQuotaSnapshot: () => runtimeComposition.quotaMonitorService.getSnapshot(),
+    refreshQuota: (providerId) => runtimeComposition.quotaMonitorService.refreshProvider(providerId),
     runtimeMetrics: runtimeComposition.runtimeMetrics,
     consolidationScheduler: runtimeComposition.consolidationScheduler,
     agentHeartbeatService: runtimeComposition.agentHeartbeatService,

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -52,6 +52,7 @@ import { ChatEventBus } from '../chat-event-bus.js'
 import { triggerFactExtractionForSessionEnd } from '../fact-extraction-session-end.js'
 import { HealthMonitorService } from '../health-monitor.js'
 import { MemoryConsolidationScheduler } from '../memory-consolidation-scheduler.js'
+import { QuotaMonitorService } from '../quota-monitor.js'
 import { RuntimeMetrics } from '../runtime-metrics.js'
 import { UploadCleanupService } from '../upload-cleanup.js'
 
@@ -104,6 +105,7 @@ export interface RuntimeComposition {
   db: Database
   runtimeMetrics: RuntimeMetrics
   healthMonitorService: HealthMonitorService
+  quotaMonitorService: QuotaMonitorService
   consolidationScheduler: MemoryConsolidationScheduler
   agentHeartbeatService: AgentHeartbeatService
   uploadCleanupService: UploadCleanupService
@@ -883,6 +885,9 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   const healthMonitorService = new HealthMonitorService({ db, providerManager: null })
   healthMonitorService.start()
 
+  const quotaMonitorService = new QuotaMonitorService()
+  quotaMonitorService.start()
+
   const consolidationScheduler = new MemoryConsolidationScheduler({
     db,
     agentCore: null,
@@ -1229,6 +1234,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
     db,
     runtimeMetrics,
     healthMonitorService,
+    quotaMonitorService,
     consolidationScheduler,
     agentHeartbeatService,
     uploadCleanupService,
@@ -1255,6 +1261,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
     },
     stopBackgroundServices: async () => {
       healthMonitorService.stop()
+      quotaMonitorService.stop()
       consolidationScheduler.stop()
       agentHeartbeatService.stop()
       uploadCleanupService.stop()

--- a/packages/web-backend/src/quota-monitor.ts
+++ b/packages/web-backend/src/quota-monitor.ts
@@ -1,0 +1,179 @@
+import {
+  getAnthropicQuotaForProvider,
+  isAnthropicOAuthProvider,
+  loadProvidersDecrypted,
+} from '@axiom/core'
+import type { AnthropicQuotaContract } from '@axiom/core/contracts'
+import type { ProviderConfig } from '@axiom/core'
+
+const DEFAULT_POLL_INTERVAL_MS = 10 * 60 * 1000
+const INITIAL_BACKOFF_MS = 15 * 60 * 1000
+const MAX_BACKOFF_MS = 2 * 60 * 60 * 1000
+
+interface ProviderBackoff {
+  rateLimitedUntil: number
+  currentBackoffMs: number
+}
+
+export interface QuotaMonitorServiceOptions {
+  pollIntervalMs?: number
+  fetchImpl?: typeof fetch
+  now?: () => number
+  logger?: Pick<typeof console, 'error'>
+}
+
+/**
+ * Background poller for Anthropic subscriber (OAuth) usage quotas.
+ *
+ * Polls every `anthropic-oauth` provider on an interval and caches the latest
+ * usage snapshot in memory keyed by provider id. This is independent of which
+ * provider is "active" — the usage endpoint is read-only and works for any
+ * provider that holds OAuth credentials.
+ */
+export class QuotaMonitorService {
+  private pollIntervalMs: number
+  private fetchImpl: typeof fetch
+  private now: () => number
+  private logger: Pick<typeof console, 'error'>
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private running = false
+  private cache = new Map<string, AnthropicQuotaContract>()
+  private backoff = new Map<string, ProviderBackoff>()
+
+  constructor(options: QuotaMonitorServiceOptions = {}) {
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    this.fetchImpl = options.fetchImpl ?? fetch
+    this.now = options.now ?? (() => Date.now())
+    this.logger = options.logger ?? console
+  }
+
+  start(): void {
+    if (this.running) return
+    this.running = true
+    this.scheduleNext(0)
+  }
+
+  stop(): void {
+    this.running = false
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  getSnapshot(): Record<string, AnthropicQuotaContract> {
+    return Object.fromEntries(this.cache)
+  }
+
+  /**
+   * Force an immediate, on-demand usage fetch for a single provider, bypassing
+   * the rate-limit backoff. Returns the resulting cached snapshot (or null if
+   * the provider no longer exists / is not an Anthropic OAuth subscriber).
+   */
+  async refreshProvider(providerId: string): Promise<AnthropicQuotaContract | null> {
+    const provider = this.loadOAuthProviders().find((p) => p.id === providerId)
+    if (!provider) return null
+    await this.pollProvider(provider, { force: true })
+    return this.cache.get(providerId) ?? null
+  }
+
+  private scheduleNext(delayMs: number): void {
+    if (!this.running) return
+
+    if (this.timer) {
+      clearTimeout(this.timer)
+    }
+
+    this.timer = setTimeout(() => {
+      this.runPoll()
+        .catch((err) => {
+          this.logger.error('[axiom] Quota monitor poll failed:', err)
+        })
+        .finally(() => {
+          this.scheduleNext(this.pollIntervalMs)
+        })
+    }, Math.max(0, delayMs))
+
+    if (typeof this.timer === 'object' && 'unref' in this.timer) {
+      this.timer.unref()
+    }
+  }
+
+  private loadOAuthProviders() {
+    try {
+      return loadProvidersDecrypted().providers.filter(isAnthropicOAuthProvider)
+    } catch (err) {
+      this.logger.error('[axiom] Quota monitor failed to load providers:', err)
+      return []
+    }
+  }
+
+  private async runPoll(): Promise<void> {
+    const providers = this.loadOAuthProviders()
+    const liveIds = new Set(providers.map((p) => p.id))
+
+    // Drop cache/backoff for providers that no longer exist or lost OAuth.
+    for (const id of [...this.cache.keys()]) {
+      if (!liveIds.has(id)) this.cache.delete(id)
+    }
+    for (const id of [...this.backoff.keys()]) {
+      if (!liveIds.has(id)) this.backoff.delete(id)
+    }
+
+    await Promise.all(providers.map((provider) => this.pollProvider(provider)))
+  }
+
+  private async pollProvider(provider: ProviderConfig, opts: { force?: boolean } = {}): Promise<void> {
+    const now = this.now()
+    const state = this.backoff.get(provider.id)
+
+    // Respect per-provider rate-limit backoff (unless forced by a manual
+    // refresh); keep the stale cached value in the meantime.
+    if (!opts.force && state && now < state.rateLimitedUntil) return
+
+    const result = await getAnthropicQuotaForProvider(provider, this.fetchImpl)
+
+    if (result.quota) {
+      this.backoff.delete(provider.id)
+      this.cache.set(provider.id, {
+        fiveHour: result.quota.fiveHour,
+        sevenDay: result.quota.sevenDay,
+        sevenDayOpus: result.quota.sevenDayOpus,
+        sevenDaySonnet: result.quota.sevenDaySonnet,
+        fetchedAt: result.quota.fetchedAt,
+      })
+      return
+    }
+
+    if (result.status === 429) {
+      const previous = state?.currentBackoffMs ?? INITIAL_BACKOFF_MS
+      const backoffMs = result.retryAfterMs ?? previous
+      this.backoff.set(provider.id, {
+        rateLimitedUntil: now + backoffMs,
+        currentBackoffMs: result.retryAfterMs ? previous : Math.min(previous * 2, MAX_BACKOFF_MS),
+      })
+    }
+
+    // Preserve a previously successful snapshot on transient failures (429
+    // rate-limit, network errors, 5xx) so the UI keeps showing the last known
+    // usage instead of flapping to "unavailable" — the Anthropic usage endpoint
+    // is aggressively rate-limited. Only surface an error entry when there is no
+    // good data yet, or for hard failures (e.g. 401/403) the user must act on.
+    const existing = this.cache.get(provider.id)
+    const hasGoodData = !!existing && !existing.error
+    const isTransient =
+      result.status === 429 ||
+      result.status === undefined ||
+      (typeof result.status === 'number' && result.status >= 500)
+    if (!hasGoodData || !isTransient) {
+      this.cache.set(provider.id, {
+        fiveHour: null,
+        sevenDay: null,
+        sevenDayOpus: null,
+        sevenDaySonnet: null,
+        fetchedAt: new Date(now).toISOString(),
+        error: result.error ?? 'Failed to fetch usage',
+      })
+    }
+  }
+}

--- a/packages/web-backend/src/quota-monitor.ts
+++ b/packages/web-backend/src/quota-monitor.ts
@@ -61,6 +61,8 @@ export class QuotaMonitorService {
     }
   }
 
+  // Consumed via the http-boundary `getQuotaSnapshot` arrow wrapper, which Fallow cannot trace statically.
+  // fallow-ignore-next-line unused-class-member
   getSnapshot(): Record<string, AnthropicQuotaContract> {
     return Object.fromEntries(this.cache)
   }
@@ -69,7 +71,10 @@ export class QuotaMonitorService {
    * Force an immediate, on-demand usage fetch for a single provider, bypassing
    * the rate-limit backoff. Returns the resulting cached snapshot (or null if
    * the provider no longer exists / is not an Anthropic OAuth subscriber).
+   *
+   * Consumed via the http-boundary `refreshQuota` arrow wrapper, which Fallow cannot trace statically.
    */
+  // fallow-ignore-next-line unused-class-member
   async refreshProvider(providerId: string): Promise<AnthropicQuotaContract | null> {
     const provider = this.loadOAuthProviders().find((p) => p.id === providerId)
     if (!provider) return null

--- a/packages/web-backend/src/routes/health.ts
+++ b/packages/web-backend/src/routes/health.ts
@@ -5,11 +5,30 @@ import { jwtMiddleware } from '../auth.js'
 import type { AuthenticatedRequest } from '../auth.js'
 import type { HealthMonitorService } from '../health-monitor.js'
 import type { RuntimeMetrics } from '../runtime-metrics.js'
+import type { AnthropicQuotaContract } from '@axiom/core/contracts'
 
 export interface HealthRouterOptions {
   db: Database
   healthMonitorService: HealthMonitorService
   runtimeMetrics: RuntimeMetrics
+  getQuotaSnapshot?: () => Record<string, AnthropicQuotaContract>
+}
+
+/**
+ * Pick the most relevant Anthropic subscriber quota for the global top-bar
+ * indicator: prefer the active provider's quota, then any provider with valid
+ * (non-error) data, then any available entry. The snapshot only ever contains
+ * anthropic-oauth providers (the quota monitor filters them).
+ */
+function selectTopBarQuota(
+  snapshot: Record<string, AnthropicQuotaContract>,
+  activeProviderId: string | null | undefined,
+): AnthropicQuotaContract | null {
+  if (activeProviderId && snapshot[activeProviderId] && !snapshot[activeProviderId].error) {
+    return snapshot[activeProviderId]
+  }
+  const entries = Object.values(snapshot)
+  return entries.find((entry) => !entry.error) ?? entries[0] ?? null
 }
 
 export function createHealthRouter(options: HealthRouterOptions): Router {
@@ -28,6 +47,10 @@ export function createHealthRouter(options: HealthRouterOptions): Router {
     try {
       const snapshot = options.healthMonitorService.getSnapshot()
       const activity = getActivitySummary(options.db)
+      const quota = selectTopBarQuota(
+        options.getQuotaSnapshot?.() ?? {},
+        snapshot.activeProvider?.id,
+      )
 
       res.json({
         agent: {
@@ -42,6 +65,7 @@ export function createHealthRouter(options: HealthRouterOptions): Router {
         queueDepth: options.runtimeMetrics.getQueueDepth(),
         activity,
         intervalMinutes: snapshot.intervalMinutes,
+        quota,
       })
     } catch (err) {
       res.status(500).json({ error: `Failed to load health snapshot: ${(err as Error).message}` })

--- a/packages/web-backend/src/routes/health.ts
+++ b/packages/web-backend/src/routes/health.ts
@@ -15,20 +15,18 @@ export interface HealthRouterOptions {
 }
 
 /**
- * Pick the most relevant Anthropic subscriber quota for the global top-bar
- * indicator: prefer the active provider's quota, then any provider with valid
- * (non-error) data, then any available entry. The snapshot only ever contains
- * anthropic-oauth providers (the quota monitor filters them).
+ * Resolve the Anthropic subscriber quota for the global top-bar indicator.
+ *
+ * Only the active provider's own snapshot is returned: the indicator sits next
+ * to the active provider's health, so falling back to another provider would
+ * show a different subscription's usage and mislead the user.
  */
 function selectTopBarQuota(
   snapshot: Record<string, AnthropicQuotaContract>,
   activeProviderId: string | null | undefined,
 ): AnthropicQuotaContract | null {
-  if (activeProviderId && snapshot[activeProviderId] && !snapshot[activeProviderId].error) {
-    return snapshot[activeProviderId]
-  }
-  const entries = Object.values(snapshot)
-  return entries.find((entry) => !entry.error) ?? entries[0] ?? null
+  if (!activeProviderId) return null
+  return snapshot[activeProviderId] ?? null
 }
 
 export function createHealthRouter(options: HealthRouterOptions): Router {

--- a/packages/web-frontend/app/api/providers.ts
+++ b/packages/web-frontend/app/api/providers.ts
@@ -9,6 +9,7 @@ import type {
   ProviderCreatePayloadContract,
   ProviderFallbackResponseContract,
   ProviderMutationResponseContract,
+  ProviderQuotaRefreshResponseContract,
   ProviderTestResultContract,
   ProviderTypePresetContract,
   ProviderUpdatePayloadContract,
@@ -58,6 +59,11 @@ export function useProvidersApi() {
     apiFetch<ProviderActivationResponseContract>(`/api/providers/${id}/activate`, {
       method: 'POST',
       body: JSON.stringify({ modelId }),
+    })
+
+  const refreshQuota = (id: string) =>
+    apiFetch<ProviderQuotaRefreshResponseContract>(`/api/providers/${id}/refresh-quota`, {
+      method: 'POST',
     })
 
   const setFallbackProvider = (providerId: string | null, modelId?: string | null) =>
@@ -158,6 +164,7 @@ export function useProvidersApi() {
     removeProvider,
     testProvider,
     activateProvider,
+    refreshQuota,
     setFallbackProvider,
     getModels,
     getOllamaModels,

--- a/packages/web-frontend/app/composables/useConnectionStatus.ts
+++ b/packages/web-frontend/app/composables/useConnectionStatus.ts
@@ -8,6 +8,8 @@
  *   - 'healthy'   → backend OK and provider healthy (green dot)
  */
 
+import type { AnthropicQuotaContract } from '@axiom/core/contracts'
+
 export type GlobalStatus = 'offline' | 'degraded' | 'healthy'
 type OperatingMode = 'normal' | 'fallback'
 
@@ -22,6 +24,7 @@ interface HealthSnapshot {
     name: string
     model: string
   } | null
+  quota?: AnthropicQuotaContract | null
 }
 
 const POLL_INTERVAL_MS = 30_000
@@ -35,6 +38,7 @@ export function useConnectionStatus() {
   const operatingMode = useState<OperatingMode>('global_operating_mode', () => 'normal')
   const fallbackProviderName = useState<string | null>('global_fallback_provider_name', () => null)
   const healthMonitorEnabled = useState<boolean>('global_health_monitor_enabled', () => true)
+  const quota = useState<AnthropicQuotaContract | null>('global_quota', () => null)
 
   let timer: ReturnType<typeof setInterval> | null = null
   let polling = false
@@ -45,6 +49,7 @@ export function useConnectionStatus() {
       providerName.value = null
       operatingMode.value = 'normal'
       fallbackProviderName.value = null
+      quota.value = null
       return
     }
 
@@ -54,6 +59,7 @@ export function useConnectionStatus() {
       healthMonitorEnabled.value = data.enabled ?? true
       operatingMode.value = data.operatingMode ?? 'normal'
       fallbackProviderName.value = data.fallbackProvider?.name ?? null
+      quota.value = data.quota ?? null
 
       if (!data.provider) {
         // Backend reachable but no provider configured
@@ -80,6 +86,7 @@ export function useConnectionStatus() {
       providerName.value = null
       operatingMode.value = 'normal'
       fallbackProviderName.value = null
+      quota.value = null
     }
   }
 
@@ -104,6 +111,7 @@ export function useConnectionStatus() {
     operatingMode: readonly(operatingMode),
     fallbackProviderName: readonly(fallbackProviderName),
     healthMonitorEnabled: readonly(healthMonitorEnabled),
+    quota: readonly(quota),
     start,
     stop,
     poll,

--- a/packages/web-frontend/app/composables/useQuotaFormat.ts
+++ b/packages/web-frontend/app/composables/useQuotaFormat.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared formatting helpers for Anthropic subscriber quota display.
+ *
+ * Centralises the colour thresholds and reset-time formatting used by both the
+ * providers table and the global top bar so the two views stay consistent.
+ * Date/time output follows the user's browser/OS regional settings (the
+ * `undefined` locale), matching `useFormat`.
+ */
+export function useQuotaFormat() {
+  function quotaColorClass(utilization: number): string {
+    if (utilization >= 90) return 'text-destructive'
+    if (utilization >= 70) return 'text-amber-600 dark:text-amber-500'
+    return 'text-emerald-600 dark:text-emerald-500'
+  }
+
+  function formatQuotaResetRelative(resetsAt: string | null): string {
+    if (!resetsAt) return ''
+    const diffMs = new Date(resetsAt).getTime() - Date.now()
+    if (Number.isNaN(diffMs) || diffMs <= 0) return 'now'
+
+    const hours = Math.floor(diffMs / (1000 * 60 * 60))
+    const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))
+    if (hours >= 24) return `${Math.floor(hours / 24)}d ${hours % 24}h`
+    if (hours > 0) return `${hours}h ${minutes}m`
+    return `${minutes}m`
+  }
+
+  function formatQuotaResetNice(resetsAt: string | null): string {
+    if (!resetsAt) return ''
+    const reset = new Date(resetsAt)
+    if (Number.isNaN(reset.getTime())) return ''
+
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const weekday = reset.toLocaleDateString(undefined, { weekday: 'short', timeZone })
+    const time = reset
+      .toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit', timeZone })
+      .replace(' ', '')
+    return `${weekday} ${time}`
+  }
+
+  return {
+    quotaColorClass,
+    formatQuotaResetRelative,
+    formatQuotaResetNice,
+  }
+}

--- a/packages/web-frontend/app/features/providers/components/ProvidersWorkspace.vue
+++ b/packages/web-frontend/app/features/providers/components/ProvidersWorkspace.vue
@@ -92,7 +92,36 @@
                     </div>
                   </TableCell>
                   <TableCell />
-                  <TableCell />
+                  <TableCell>
+                    <div v-if="isRefreshingQuota(provider.id)" class="flex items-center gap-1.5">
+                      <span
+                        class="h-3.5 w-3.5 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent"
+                        aria-hidden="true"
+                      />
+                      <span class="text-xs text-muted-foreground">{{ $t('providers.quota.refreshing') }}</span>
+                    </div>
+                    <div v-else-if="getQuota(provider)" class="flex flex-col gap-0.5 text-xs">
+                      <span
+                        v-if="getQuota(provider)!.error"
+                        class="text-muted-foreground"
+                        :title="getQuota(provider)!.error ?? undefined"
+                      >
+                        {{ quotaErrorLabel(getQuota(provider)!.error) }}
+                      </span>
+                      <template v-else>
+                        <div
+                          v-for="part in quotaParts(getQuota(provider)!)"
+                          :key="part.label"
+                          class="flex items-center gap-1 whitespace-nowrap"
+                        >
+                          <span class="font-medium" :class="quotaColorClass(part.utilization)">
+                            {{ part.label }} {{ part.utilization }}%
+                          </span>
+                          <span v-if="part.reset" class="text-muted-foreground">({{ part.reset }})</span>
+                        </div>
+                      </template>
+                    </div>
+                  </TableCell>
                   <TableCell class="text-right" @click.stop>
                     <DropdownMenu>
                       <DropdownMenuTrigger as-child>
@@ -104,6 +133,14 @@
                         <DropdownMenuItem @click="openEdit(provider)">
                           <AppIcon name="edit" class="h-4 w-4" />
                           {{ $t('users.edit') }}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                            v-if="isAnthropicOAuth(provider)"
+                            :disabled="isRefreshingQuota(provider.id)"
+                            @click="handleRefreshQuota(provider.id)"
+                        >
+                          <AppIcon name="refresh" class="h-4 w-4" />
+                          {{ $t('providers.quota.refresh') }}
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
@@ -263,6 +300,7 @@ import type { ProviderFormPayload } from '~/components/ProviderFormDialog.vue'
 import { useProviders } from '~/features/providers/composables/useProviders'
 
 const { t } = useI18n()
+const { quotaColorClass, formatQuotaResetRelative, formatQuotaResetNice } = useQuotaFormat()
 
 const {
   providers,
@@ -280,8 +318,11 @@ const {
   deleteProvider,
   testProvider,
   activateProvider,
+  refreshQuota,
   setFallbackProvider,
 } = useProviders()
+
+const refreshingQuotaIds = ref<Set<string>>(new Set())
 
 /* ── State ── */
 const showForm = ref(false)
@@ -295,14 +336,91 @@ const sortedProviders = computed(() =>
   [...providers.value].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
 )
 
+const QUOTA_REFRESH_MS = 60_000
+let quotaRefreshTimer: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
   fetchProviders()
+  quotaRefreshTimer = setInterval(() => {
+    fetchProviders()
+  }, QUOTA_REFRESH_MS)
+})
+
+onUnmounted(() => {
+  if (quotaRefreshTimer) {
+    clearInterval(quotaRefreshTimer)
+    quotaRefreshTimer = null
+  }
 })
 
 /* ── Helpers ── */
 function getTypeLabel(providerType: string): string {
   const preset = presets.value[providerType]
   return preset?.label ?? providerType
+}
+
+type QuotaBucket = { utilization: number; resetsAt: string | null }
+type ProviderQuota = NonNullable<Provider['quota']>
+
+function isAnthropicOAuth(provider: Provider): boolean {
+  return provider.authMethod === 'oauth' && provider.providerType === 'anthropic-oauth'
+}
+
+function getQuota(provider: Provider): ProviderQuota | null {
+  if (!isAnthropicOAuth(provider)) {
+    return null
+  }
+  return provider.quota ?? null
+}
+
+function isRefreshingQuota(providerId: string): boolean {
+  return refreshingQuotaIds.value.has(providerId)
+}
+
+function quotaErrorLabel(rawError?: string): string {
+  if (rawError && /\b429\b/.test(rawError)) {
+    return t('providers.quota.rateLimited')
+  }
+  return t('providers.quota.unavailable')
+}
+
+async function handleRefreshQuota(providerId: string) {
+  if (refreshingQuotaIds.value.has(providerId)) return
+  refreshingQuotaIds.value = new Set(refreshingQuotaIds.value).add(providerId)
+  try {
+    const ok = await refreshQuota(providerId)
+    if (ok) {
+      const refreshed = providers.value.find(p => p.id === providerId)
+      const quotaError = refreshed?.quota?.error
+      if (quotaError) {
+        error.value = quotaErrorLabel(quotaError)
+      } else {
+        successMessage.value = t('providers.quota.refreshSuccess')
+        autoHideSuccess()
+      }
+    }
+  } finally {
+    const next = new Set(refreshingQuotaIds.value)
+    next.delete(providerId)
+    refreshingQuotaIds.value = next
+  }
+}
+
+type QuotaBucketSpec = { label: string; bucket: QuotaBucket | null; format: (resetsAt: string | null) => string }
+
+function quotaParts(quota: ProviderQuota): Array<{ label: string; utilization: number; reset: string }> {
+  const buckets: QuotaBucketSpec[] = [
+    { label: '5h:', bucket: quota.fiveHour, format: formatQuotaResetRelative },
+    { label: '7d:', bucket: quota.sevenDay, format: formatQuotaResetNice },
+    { label: 'Opus:', bucket: quota.sevenDayOpus, format: () => '' },
+  ]
+  return buckets
+    .filter((entry): entry is QuotaBucketSpec & { bucket: QuotaBucket } => entry.bucket != null)
+    .map((entry) => ({
+      label: entry.label,
+      utilization: entry.bucket.utilization,
+      reset: entry.format(entry.bucket.resetsAt),
+    }))
 }
 
 function getStatusVariant(status?: string): 'success' | 'destructive' | 'muted' {

--- a/packages/web-frontend/app/features/providers/composables/useProviders.ts
+++ b/packages/web-frontend/app/features/providers/composables/useProviders.ts
@@ -103,6 +103,18 @@ export function useProviders() {
     }
   }
 
+  async function refreshQuota(id: string): Promise<boolean> {
+    error.value = null
+    try {
+      await providersApi.refreshQuota(id)
+      await fetchProviders()
+      return true
+    } catch (err) {
+      error.value = (err as Error).message
+      return false
+    }
+  }
+
   async function activateProvider(id: string, modelId?: string): Promise<boolean> {
     error.value = null
     try {
@@ -212,6 +224,7 @@ export function useProviders() {
     deleteProvider,
     testProvider,
     activateProvider,
+    refreshQuota,
     setFallbackProvider,
     startOAuthLogin,
     pollOAuthStatus,

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -173,6 +173,13 @@
     "statusConnected": "Verbunden",
     "statusError": "Fehler",
     "statusUntested": "Ungetestet",
+    "quota": {
+      "unavailable": "Kontingent nicht verfügbar",
+      "rateLimited": "Rate-Limit — bitte gleich erneut versuchen",
+      "refresh": "Kontingent aktualisieren",
+      "refreshing": "Aktualisiere...",
+      "refreshSuccess": "Kontingent aktualisiert"
+    },
     "testConnection": "Verbindung testen",
     "testing": "Teste...",
     "testSuccess": "Verbindung erfolgreich",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -173,6 +173,13 @@
     "statusConnected": "Connected",
     "statusError": "Error",
     "statusUntested": "Untested",
+    "quota": {
+      "unavailable": "Quota unavailable",
+      "rateLimited": "Rate-limited — try again shortly",
+      "refresh": "Refresh quota",
+      "refreshing": "Refreshing...",
+      "refreshSuccess": "Quota updated"
+    },
     "testConnection": "Test Connection",
     "testing": "Testing...",
     "testSuccess": "Connection successful",

--- a/packages/web-frontend/app/layouts/default.vue
+++ b/packages/web-frontend/app/layouts/default.vue
@@ -272,6 +272,17 @@
           </TooltipContent>
         </Tooltip>
 
+        <!-- Anthropic quota (desktop, wide viewports only) -->
+        <div v-if="quotaTopBarParts.length > 0" class="hidden items-center gap-2 lg:flex">
+          <template v-for="(part, idx) in quotaTopBarParts" :key="part.label">
+            <span v-if="idx > 0" class="text-muted-foreground/40">·</span>
+            <span class="text-xs">
+              <span class="font-medium" :class="part.colorClass">{{ part.label }}: {{ part.utilization }}%</span>
+              <span v-if="part.reset" class="text-muted-foreground"> ({{ part.reset }})</span>
+            </span>
+          </template>
+        </div>
+
         <!-- Spacer -->
         <div class="flex-1" />
 
@@ -318,7 +329,7 @@ const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
 const appVersion = runtimeConfig.public.appVersion as string
 const { user, logout } = useAuth()
-const { status: globalStatus, providerName: globalProviderName, operatingMode: globalOperatingMode, fallbackProviderName: globalFallbackProviderName, healthMonitorEnabled: globalHealthMonitorEnabled, start: startStatusPolling, stop: stopStatusPolling } = useConnectionStatus()
+const { status: globalStatus, providerName: globalProviderName, operatingMode: globalOperatingMode, fallbackProviderName: globalFallbackProviderName, healthMonitorEnabled: globalHealthMonitorEnabled, quota: globalQuota, start: startStatusPolling, stop: stopStatusPolling } = useConnectionStatus()
 
 const isInFallbackMode = computed(() => globalOperatingMode.value === 'fallback')
 const { isDark, toggle: toggleTheme, mode: themeMode } = useTheme()
@@ -363,6 +374,26 @@ const statusText = computed(() => {
     default:
       return t('status.offline')
   }
+})
+
+const { quotaColorClass, formatQuotaResetRelative, formatQuotaResetNice } = useQuotaFormat()
+
+const quotaTopBarParts = computed(() => {
+  const q = globalQuota.value
+  if (!q || q.error) return []
+  const specs = [
+    { label: '5h', bucket: q.fiveHour, format: formatQuotaResetRelative },
+    { label: '7d', bucket: q.sevenDay, format: formatQuotaResetNice },
+    { label: 'Opus', bucket: q.sevenDayOpus, format: formatQuotaResetNice },
+  ]
+  return specs
+    .filter((s) => s.bucket != null)
+    .map((s) => ({
+      label: s.label,
+      utilization: s.bucket!.utilization,
+      reset: s.format(s.bucket!.resetsAt),
+      colorClass: quotaColorClass(s.bucket!.utilization),
+    }))
 })
 
 onMounted(() => {


### PR DESCRIPTION
Surfaces Claude Pro/Max (anthropic-oauth) usage limits in the UI, polled in the background.

### What's new
   - **Providers page** — each `anthropic-oauth` provider shows its usage per bucket (5h / 7d) with reset times in the status column, plus a **Refresh quota** action in the provider menu.
   - **Top bar** — the active provider's quota is shown next to the health status (wide viewports only, hidden on smaller devices).
   - The Anthropic usage endpoint is aggressively rate-limited; per-provider 429 backoff is applied and a previously valid snapshot is **kept on transient failures** instead of flapping to "unavailable". Rate-limit errors are shown distinctly from hard errors.