### PR TITLE
feat: add OpenAI Codex quota and generalize quota system

### DIFF
--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -29,8 +29,8 @@ Providers are sorted alphabetically by display name; sub-rows follow the order c
 |-------------|------------------------------------------------------------------------------------------------------|
 | **Name**    | Bold display name; below it, the provider type label (e.g. *"Anthropic"*, *"Anthropic (Claude Pro/Max) · OAuth"*). |
 | **Cost**    | Empty — costs live on the model rows.                                                                |
-| **Status**  | Empty for most providers (status lives on the model rows). For **Anthropic Claude Pro/Max (OAuth)** providers it shows the live [subscriber usage quota](#subscriber-usage-quota-claude-pro-max). |
-| **⋮**       | Edit, Delete, and — for Anthropic OAuth providers — **Refresh quota**. *Delete* is disabled for the provider that owns the currently active model. |
+| **Status**  | Empty for most providers (status lives on the model rows). For **subscription (OAuth)** providers it shows the live [subscriber usage quota](#subscriber-usage-quota-oauth-plans). |
+| **⋮**       | Edit, Delete, and — for quota-capable OAuth providers — **Refresh quota**. *Delete* is disabled for the provider that owns the currently active model. |
 
 Clicking anywhere on a header row opens the [Edit dialog](#add-edit-dialog).
 
@@ -216,17 +216,21 @@ The full flow:
 
 **Remote server fallback.** If your Axiom instance runs on a remote box where the OAuth callback URL can't reach you, a manual-code field appears below the spinner: *"Or paste the redirect URL here (for remote servers)"*. Complete the login locally, copy the full redirect URL from the browser, paste it in, and click **Submit**.
 
-### Subscriber usage quota (Claude Pro/Max)
+### Subscriber usage quota (OAuth plans)
 
-For **Anthropic Claude Pro/Max (OAuth)** providers, the provider header row's **Status** column shows how much of your subscription allowance is left, polled in the background (no manual action needed). Other provider types never show quota — the endpoint only exists for Anthropic subscriptions.
+For **subscription (OAuth)** providers that expose a usage endpoint, the provider header row's **Status** column shows how much of your subscription allowance is left, polled in the background (no manual action needed). Quota is currently supported for:
 
-Each configured bucket appears on its own line as `<bucket> <utilization>% (<reset>)`:
+- **Anthropic Claude Pro/Max** (`anthropic-oauth`)
+- **OpenAI ChatGPT Plus/Pro (Codex)** (`openai-codex`)
 
-| Bucket | Meaning                                              | Reset shown as                        |
-|--------|------------------------------------------------------|---------------------------------------|
-| `5h`   | Rolling 5-hour usage window.                         | Relative countdown, e.g. `2h 14m`.    |
-| `7d`   | Rolling 7-day usage window.                          | Weekday + time, e.g. `Mon 3:00PM`.    |
-| `Opus` | 7-day Opus-specific window (when your plan has one). | —                                     |
+Other provider types never show quota — they have no usage endpoint.
+
+Each usage window appears on its own line as `<window>: <utilization>% (<reset>)`. The exact windows depend on the provider:
+
+| Provider              | Windows                                                                 | Reset shown as                          |
+|-----------------------|------------------------------------------------------------------------|-----------------------------------------|
+| Anthropic Claude      | `5h` (rolling 5h), `7d` (rolling 7d), `Opus` (7d Opus, when your plan has one). | `5h` relative (e.g. `2h 14m`); `7d`/`Opus` weekday + time (e.g. `Mon 3:00PM`). |
+| OpenAI ChatGPT (Codex)| Primary + secondary rate-limit windows (labelled by their length, e.g. `5h`, `7d`). | Primary relative; secondary weekday + time. |
 
 The percentage is colour-coded: green below 70%, amber at 70–89%, red at 90%+. Reset times follow your browser's regional settings.
 
@@ -234,11 +238,11 @@ The same active-provider quota is mirrored in the **top bar** next to the health
 
 #### Refresh quota
 
-The ⋮ menu on an Anthropic OAuth provider header carries a **Refresh quota** item that forces an immediate, on-demand fetch (bypassing the background poll's backoff). While it runs, the Status column shows a spinner with *"Refreshing…"*; on success a *"Quota updated"* banner appears briefly.
+The ⋮ menu on a quota-capable OAuth provider header carries a **Refresh quota** item that forces an immediate, on-demand fetch (bypassing the background poll's backoff). While it runs, the Status column shows a spinner with *"Refreshing…"*; on success a *"Quota updated"* banner appears briefly.
 
 #### When quota is unavailable
 
-The Anthropic usage endpoint is aggressively rate-limited. Axiom applies a per-provider backoff on `429` responses and **keeps the last good snapshot** during transient failures instead of flapping to "unavailable". When there is no usable data, the Status column shows:
+These usage endpoints are aggressively rate-limited. Axiom applies a per-provider backoff on `429` responses and **keeps the last good snapshot** during transient failures instead of flapping to "unavailable". When there is no usable data, the Status column shows:
 
 - *"Rate-limited — try again shortly"* — a `429` was hit and no earlier snapshot exists yet. Wait a bit, or use **Refresh quota** later.
 - *"Quota unavailable"* — any other failure (auth error, network, …). Hover the text for the underlying error.

--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -229,7 +229,7 @@ Each usage window appears on its own line as `<window>: <utilization>% (<reset>)
 
 | Provider              | Windows                                                                 | Reset shown as                          |
 |-----------------------|------------------------------------------------------------------------|-----------------------------------------|
-| Anthropic Claude      | `5h` (rolling 5h), `7d` (rolling 7d), `Opus` (7d Opus, when your plan has one). | `5h` relative (e.g. `2h 14m`); `7d`/`Opus` weekday + time (e.g. `Mon 3:00PM`). |
+| Anthropic Claude      | `5h` (rolling 5h), `7d` (rolling 7d), `Opus` / `Sonnet` (7d model-specific windows; only shown when above 0%). | `5h` relative (e.g. `2h 14m`); `7d`/`Opus`/`Sonnet` weekday + time (e.g. `Mon 3:00PM`). |
 | OpenAI ChatGPT (Codex)| Primary + secondary rate-limit windows (labelled by their length, e.g. `5h`, `7d`). | Primary relative; secondary weekday + time. |
 
 The percentage is colour-coded: green below 70%, amber at 70–89%, red at 90%+. Reset times follow your browser's regional settings.

--- a/packages/core/src/anthropic-quota.test.ts
+++ b/packages/core/src/anthropic-quota.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fetchAnthropicQuota, isAnthropicOAuthProvider } from './anthropic-quota.js'
+import type { ProviderConfig } from './provider-config.js'
+
+function mockResponse(init: {
+  ok: boolean
+  status: number
+  json?: unknown
+  headers?: Record<string, string>
+}): Response {
+  return {
+    ok: init.ok,
+    status: init.status,
+    headers: { get: (name: string) => init.headers?.[name.toLowerCase()] ?? null },
+    json: async () => init.json,
+  } as unknown as Response
+}
+
+const anthropicProvider: ProviderConfig = {
+  id: 'anthropic-1',
+  name: 'Claude',
+  type: 'anthropic-messages',
+  providerType: 'anthropic-oauth',
+  provider: 'anthropic',
+  baseUrl: 'https://api.anthropic.com',
+  apiKey: '',
+  defaultModel: 'claude-sonnet-4',
+  authMethod: 'oauth',
+  oauthCredentials: { refresh: 'r', access: 'a', expires: Date.now() + 60_000 },
+}
+
+describe('isAnthropicOAuthProvider', () => {
+  it('matches only anthropic-oauth providers with credentials', () => {
+    expect(isAnthropicOAuthProvider(anthropicProvider)).toBe(true)
+    expect(isAnthropicOAuthProvider({ ...anthropicProvider, oauthCredentials: undefined })).toBe(false)
+    expect(isAnthropicOAuthProvider({ ...anthropicProvider, providerType: 'anthropic' })).toBe(false)
+  })
+})
+
+describe('fetchAnthropicQuota', () => {
+  it('normalizes all usage windows including the Sonnet bucket', async () => {
+    const resetsAt = '2026-01-01T00:00:00.000Z'
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        json: {
+          five_hour: { utilization: 12.4, resets_at: resetsAt },
+          seven_day: { utilization: 30, resets_at: resetsAt },
+          seven_day_opus: { utilization: 50, resets_at: resetsAt },
+          seven_day_sonnet: { utilization: 70, resets_at: resetsAt },
+        },
+      }),
+    )
+
+    const result = await fetchAnthropicQuota('token', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota?.kind).toBe('anthropic')
+    expect(result.quota?.windows).toEqual([
+      expect.objectContaining({ key: 'five_hour', label: '5h', utilization: 12, resetDisplay: 'relative' }),
+      expect.objectContaining({ key: 'seven_day', label: '7d', utilization: 30, resetDisplay: 'absolute' }),
+      expect.objectContaining({ key: 'seven_day_opus', label: 'Opus', utilization: 50, resetDisplay: 'absolute' }),
+      expect.objectContaining({
+        key: 'seven_day_sonnet',
+        label: 'Sonnet',
+        utilization: 70,
+        resetDisplay: 'absolute',
+        resetsAt,
+      }),
+    ])
+  })
+
+  it('hides Opus/Sonnet at 0% but always keeps 5h and 7d', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        json: {
+          five_hour: { utilization: 0, resets_at: null },
+          seven_day: { utilization: 0, resets_at: null },
+          seven_day_opus: { utilization: 0, resets_at: null },
+          // Rounds to 0% — should be hidden like an exact zero.
+          seven_day_sonnet: { utilization: 0.4, resets_at: null },
+        },
+      }),
+    )
+
+    const result = await fetchAnthropicQuota('token', fetchImpl as unknown as typeof fetch)
+    expect(result.quota?.windows.map((w) => w.key)).toEqual(['five_hour', 'seven_day'])
+  })
+
+  it('keeps Opus/Sonnet when they carry real usage', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        json: {
+          five_hour: { utilization: 0, resets_at: null },
+          seven_day: { utilization: 0, resets_at: null },
+          seven_day_opus: { utilization: 5, resets_at: null },
+          seven_day_sonnet: { utilization: 1, resets_at: null },
+        },
+      }),
+    )
+
+    const result = await fetchAnthropicQuota('token', fetchImpl as unknown as typeof fetch)
+    expect(result.quota?.windows.map((w) => w.key)).toEqual([
+      'five_hour',
+      'seven_day',
+      'seven_day_opus',
+      'seven_day_sonnet',
+    ])
+  })
+
+  it('omits windows the API does not return', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        json: {
+          five_hour: { utilization: 5, resets_at: null },
+          seven_day: { utilization: 10, resets_at: null },
+        },
+      }),
+    )
+
+    const result = await fetchAnthropicQuota('token', fetchImpl as unknown as typeof fetch)
+    expect(result.quota?.windows.map((w) => w.key)).toEqual(['five_hour', 'seven_day'])
+  })
+
+  it('surfaces status and retry-after on rate limit', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 429, headers: { 'retry-after': '90' } }),
+    )
+
+    const result = await fetchAnthropicQuota('token', fetchImpl as unknown as typeof fetch)
+    expect(result.quota).toBeNull()
+    expect(result.status).toBe(429)
+    expect(result.retryAfterMs).toBe(90_000)
+  })
+})

--- a/packages/core/src/anthropic-quota.ts
+++ b/packages/core/src/anthropic-quota.ts
@@ -1,5 +1,12 @@
 import type { ProviderConfig } from './provider-config.js'
 import { CLAUDE_CODE_VERSION, getApiKeyForProvider } from './provider-config.js'
+import type { ProviderQuotaWindowContract } from './contracts/providers.js'
+import {
+  normalizeUtilization,
+  parseRetryAfterMs,
+  type ProviderQuotaFetchResult,
+  type QuotaProviderAdapter,
+} from './provider-quota.js'
 
 const USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage'
 
@@ -20,26 +27,6 @@ interface RawUsageLimits {
   seven_day_sonnet?: RawUsageBucket | null
 }
 
-export interface AnthropicQuotaBucket {
-  utilization: number
-  resetsAt: string | null
-}
-
-export interface AnthropicQuota {
-  fiveHour: AnthropicQuotaBucket | null
-  sevenDay: AnthropicQuotaBucket | null
-  sevenDayOpus: AnthropicQuotaBucket | null
-  sevenDaySonnet: AnthropicQuotaBucket | null
-  fetchedAt: string
-}
-
-export interface AnthropicQuotaFetchResult {
-  quota: AnthropicQuota | null
-  status?: number
-  retryAfterMs?: number
-  error?: string
-}
-
 /** Only Anthropic subscriber (OAuth) credentials can query the usage endpoint. */
 export function isAnthropicOAuthProvider(provider: ProviderConfig): boolean {
   return (
@@ -49,26 +36,20 @@ export function isAnthropicOAuthProvider(provider: ProviderConfig): boolean {
   )
 }
 
-function parseRetryAfterMs(header: string | null): number | undefined {
-  if (!header) return undefined
-
-  const seconds = Number(header)
-  if (!Number.isNaN(seconds) && seconds > 0) {
-    return Math.round(seconds * 1000)
-  }
-
-  const retryAt = new Date(header).getTime()
-  if (!Number.isNaN(retryAt)) {
-    const diff = retryAt - Date.now()
-    if (diff > 0) return diff
-  }
-
-  return undefined
-}
-
-function toBucket(bucket: RawUsageBucket | null | undefined): AnthropicQuotaBucket | null {
+function toWindow(
+  key: string,
+  label: string,
+  resetDisplay: 'relative' | 'absolute',
+  bucket: RawUsageBucket | null | undefined,
+): ProviderQuotaWindowContract | null {
   if (!bucket || typeof bucket.utilization !== 'number') return null
-  return { utilization: bucket.utilization, resetsAt: bucket.resets_at ?? null }
+  return {
+    key,
+    label,
+    utilization: normalizeUtilization(bucket.utilization),
+    resetsAt: bucket.resets_at ?? null,
+    resetDisplay,
+  }
 }
 
 /**
@@ -81,7 +62,7 @@ function toBucket(bucket: RawUsageBucket | null | undefined): AnthropicQuotaBuck
 export async function fetchAnthropicQuota(
   accessToken: string,
   fetchImpl: typeof fetch = fetch,
-): Promise<AnthropicQuotaFetchResult> {
+): Promise<ProviderQuotaFetchResult> {
   try {
     const response = await fetchImpl(USAGE_ENDPOINT, {
       method: 'GET',
@@ -106,12 +87,17 @@ export async function fetchAnthropicQuota(
     }
 
     const data = (await response.json()) as RawUsageLimits
+    const windows = [
+      toWindow('five_hour', '5h', 'relative', data.five_hour),
+      toWindow('seven_day', '7d', 'absolute', data.seven_day),
+      toWindow('seven_day_opus', 'Opus', 'absolute', data.seven_day_opus),
+    ].filter((window): window is ProviderQuotaWindowContract => window !== null)
+
     return {
       quota: {
-        fiveHour: toBucket(data.five_hour),
-        sevenDay: toBucket(data.seven_day),
-        sevenDayOpus: toBucket(data.seven_day_opus),
-        sevenDaySonnet: toBucket(data.seven_day_sonnet),
+        kind: 'anthropic',
+        windows,
+        plan: null,
         fetchedAt: new Date().toISOString(),
       },
       status: response.status,
@@ -129,7 +115,7 @@ export async function fetchAnthropicQuota(
 export async function getAnthropicQuotaForProvider(
   provider: ProviderConfig,
   fetchImpl: typeof fetch = fetch,
-): Promise<AnthropicQuotaFetchResult> {
+): Promise<ProviderQuotaFetchResult> {
   if (!isAnthropicOAuthProvider(provider)) {
     return { quota: null, error: 'Provider is not an Anthropic OAuth subscriber' }
   }
@@ -146,4 +132,10 @@ export async function getAnthropicQuotaForProvider(
   }
 
   return fetchAnthropicQuota(accessToken, fetchImpl)
+}
+
+export const anthropicQuotaAdapter: QuotaProviderAdapter = {
+  kind: 'anthropic',
+  matches: isAnthropicOAuthProvider,
+  fetch: getAnthropicQuotaForProvider,
 }

--- a/packages/core/src/anthropic-quota.ts
+++ b/packages/core/src/anthropic-quota.ts
@@ -41,12 +41,17 @@ function toWindow(
   label: string,
   resetDisplay: 'relative' | 'absolute',
   bucket: RawUsageBucket | null | undefined,
+  options: { hideWhenZero?: boolean } = {},
 ): ProviderQuotaWindowContract | null {
   if (!bucket || typeof bucket.utilization !== 'number') return null
+  const utilization = normalizeUtilization(bucket.utilization)
+  // Model-specific 7d windows (Opus/Sonnet) only exist on some plans and are
+  // pure noise at 0% — drop them unless they carry real usage.
+  if (options.hideWhenZero && utilization === 0) return null
   return {
     key,
     label,
-    utilization: normalizeUtilization(bucket.utilization),
+    utilization,
     resetsAt: bucket.resets_at ?? null,
     resetDisplay,
   }
@@ -90,7 +95,8 @@ export async function fetchAnthropicQuota(
     const windows = [
       toWindow('five_hour', '5h', 'relative', data.five_hour),
       toWindow('seven_day', '7d', 'absolute', data.seven_day),
-      toWindow('seven_day_opus', 'Opus', 'absolute', data.seven_day_opus),
+      toWindow('seven_day_opus', 'Opus', 'absolute', data.seven_day_opus, { hideWhenZero: true }),
+      toWindow('seven_day_sonnet', 'Sonnet', 'absolute', data.seven_day_sonnet, { hideWhenZero: true }),
     ].filter((window): window is ProviderQuotaWindowContract => window !== null)
 
     return {

--- a/packages/core/src/contracts/index.ts
+++ b/packages/core/src/contracts/index.ts
@@ -57,8 +57,9 @@ export type {
 export type {
   ProviderStatusContract,
   ProviderAuthMethodContract,
-  AnthropicQuotaBucketContract,
-  AnthropicQuotaContract,
+  ProviderQuotaKindContract,
+  ProviderQuotaWindowContract,
+  ProviderQuotaContract,
   ProviderContract,
   ProviderTypePresetContract,
   AvailableModelContract,

--- a/packages/core/src/contracts/providers.ts
+++ b/packages/core/src/contracts/providers.ts
@@ -2,16 +2,33 @@ import type { ProviderType } from '../provider-config.js'
 
 export type ProviderStatusContract = 'connected' | 'error' | 'untested'
 
-export interface AnthropicQuotaBucketContract {
+/** Provider families that expose a subscriber usage quota endpoint. */
+export type ProviderQuotaKindContract = 'anthropic' | 'openai-codex'
+
+/**
+ * A single normalized usage window, provider-agnostic. Each window carries its
+ * own display hints so the UI can render any provider's quota without knowing
+ * the provider's bucket naming.
+ */
+export interface ProviderQuotaWindowContract {
+  /** Stable identifier within the provider (e.g. 'five_hour', 'primary'). */
+  key: string
+  /** Short display label (e.g. '5h', '7d', 'Opus'). */
+  label: string
+  /** Integer 0–100 percentage of the window consumed. */
   utilization: number
+  /** ISO-8601 timestamp when the window resets, or null if unknown. */
   resetsAt: string | null
+  /** Preferred reset rendering: relative countdown or absolute weekday/time. */
+  resetDisplay: 'relative' | 'absolute'
 }
 
-export interface AnthropicQuotaContract {
-  fiveHour: AnthropicQuotaBucketContract | null
-  sevenDay: AnthropicQuotaBucketContract | null
-  sevenDayOpus: AnthropicQuotaBucketContract | null
-  sevenDaySonnet: AnthropicQuotaBucketContract | null
+export interface ProviderQuotaContract {
+  kind: ProviderQuotaKindContract
+  /** Normalized usage windows in display order. */
+  windows: ProviderQuotaWindowContract[]
+  /** Optional human-readable plan label (e.g. 'Plus', 'Pro', 'Max'). */
+  plan?: string | null
   fetchedAt: string
   error?: string
 }
@@ -39,8 +56,10 @@ export interface ProviderContract {
   oauthCredentials?: { expires: number }
   cost?: { input: number; output: number } | null
   modelCosts?: Record<string, { input: number; output: number }>
-  /** Anthropic subscriber usage snapshot (only for anthropic-oauth providers). */
-  quota?: AnthropicQuotaContract | null
+  /** True when this provider exposes a subscriber usage quota endpoint. */
+  supportsQuota?: boolean
+  /** Subscriber usage snapshot (only for quota-capable OAuth providers). */
+  quota?: ProviderQuotaContract | null
 }
 
 export interface ProviderTypePresetContract {
@@ -101,7 +120,7 @@ export interface ProviderMutationResponseContract {
 }
 
 export interface ProviderQuotaRefreshResponseContract {
-  quota: AnthropicQuotaContract | null
+  quota: ProviderQuotaContract | null
 }
 
 export interface ProviderTestResultContract {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,8 +97,25 @@ export {
   fetchAnthropicQuota,
   getAnthropicQuotaForProvider,
   isAnthropicOAuthProvider,
+  anthropicQuotaAdapter,
 } from './anthropic-quota.js'
-export type { AnthropicQuota, AnthropicQuotaBucket, AnthropicQuotaFetchResult } from './anthropic-quota.js'
+export {
+  fetchOpenAiCodexQuota,
+  getOpenAiCodexQuotaForProvider,
+  isOpenAiCodexOAuthProvider,
+  extractCodexAccountId,
+  openaiCodexQuotaAdapter,
+} from './openai-codex-quota.js'
+export {
+  getQuotaAdapter,
+  isQuotaProvider,
+} from './quota-registry.js'
+export {
+  parseRetryAfterMs,
+  normalizeUtilization,
+  limitWindowLabel,
+} from './provider-quota.js'
+export type { ProviderQuotaFetchResult, QuotaProviderAdapter } from './provider-quota.js'
 export { encrypt, decrypt, isEncrypted, maskApiKey } from './encryption.js'
 export {
   logTokenUsage,

--- a/packages/core/src/openai-codex-quota.test.ts
+++ b/packages/core/src/openai-codex-quota.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  extractCodexAccountId,
+  fetchOpenAiCodexQuota,
+  isOpenAiCodexOAuthProvider,
+} from './openai-codex-quota.js'
+import type { ProviderConfig } from './provider-config.js'
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url')
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${header}.${body}.signature`
+}
+
+function mockResponse(init: {
+  ok: boolean
+  status: number
+  json?: unknown
+  headers?: Record<string, string>
+}): Response {
+  return {
+    ok: init.ok,
+    status: init.status,
+    headers: { get: (name: string) => init.headers?.[name.toLowerCase()] ?? null },
+    json: async () => init.json,
+  } as unknown as Response
+}
+
+const codexProvider: ProviderConfig = {
+  id: 'codex-1',
+  name: 'ChatGPT',
+  type: 'openai-codex-responses',
+  providerType: 'openai-codex',
+  provider: 'openai-codex',
+  baseUrl: '',
+  apiKey: '',
+  defaultModel: 'gpt-5-codex',
+  authMethod: 'oauth',
+  oauthCredentials: { refresh: 'r', access: 'a', expires: Date.now() + 60_000 },
+}
+
+describe('extractCodexAccountId', () => {
+  it('reads the chatgpt account id from the JWT auth claim', () => {
+    const token = makeJwt({
+      'https://api.openai.com/auth': { chatgpt_account_id: 'acc-abc-123' },
+    })
+    expect(extractCodexAccountId(token)).toBe('acc-abc-123')
+  })
+
+  it('returns null for a malformed token', () => {
+    expect(extractCodexAccountId('not-a-jwt')).toBeNull()
+    expect(extractCodexAccountId(makeJwt({ foo: 'bar' }))).toBeNull()
+  })
+})
+
+describe('isOpenAiCodexOAuthProvider', () => {
+  it('matches only openai-codex OAuth providers with credentials', () => {
+    expect(isOpenAiCodexOAuthProvider(codexProvider)).toBe(true)
+    expect(isOpenAiCodexOAuthProvider({ ...codexProvider, oauthCredentials: undefined })).toBe(false)
+    expect(isOpenAiCodexOAuthProvider({ ...codexProvider, providerType: 'openai' })).toBe(false)
+  })
+})
+
+describe('fetchOpenAiCodexQuota', () => {
+  it('normalizes primary/secondary windows and plan', async () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 3600
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        json: {
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: {
+              used_percent: 42.6,
+              limit_window_seconds: 18_000,
+              reset_after_seconds: 3600,
+            },
+            secondary_window: {
+              used_percent: 10,
+              limit_window_seconds: 604_800,
+              reset_at: resetAt,
+            },
+          },
+        },
+      }),
+    )
+
+    const result = await fetchOpenAiCodexQuota('token', 'acc-1', fetchImpl as unknown as typeof fetch)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://chatgpt.com/backend-api/wham/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token',
+          'ChatGPT-Account-Id': 'acc-1',
+        }),
+      }),
+    )
+    expect(result.quota?.kind).toBe('openai-codex')
+    expect(result.quota?.plan).toBe('Plus')
+    expect(result.quota?.windows).toEqual([
+      expect.objectContaining({ key: 'primary', label: '5h', utilization: 43, resetDisplay: 'relative' }),
+      expect.objectContaining({
+        key: 'secondary',
+        label: '7d',
+        utilization: 10,
+        resetDisplay: 'absolute',
+        resetsAt: new Date(resetAt * 1000).toISOString(),
+      }),
+    ])
+  })
+
+  it('surfaces status and retry-after on rate limit', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 429, headers: { 'retry-after': '120' } }),
+    )
+
+    const result = await fetchOpenAiCodexQuota('token', 'acc-1', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota).toBeNull()
+    expect(result.status).toBe(429)
+    expect(result.retryAfterMs).toBe(120_000)
+  })
+
+  it('returns an error result when the network call throws', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('boom'))
+    const result = await fetchOpenAiCodexQuota('token', 'acc-1', fetchImpl as unknown as typeof fetch)
+    expect(result.quota).toBeNull()
+    expect(result.error).toBe('boom')
+  })
+})

--- a/packages/core/src/openai-codex-quota.ts
+++ b/packages/core/src/openai-codex-quota.ts
@@ -1,0 +1,192 @@
+import type { ProviderConfig } from './provider-config.js'
+import { getApiKeyForProvider } from './provider-config.js'
+import type { ProviderQuotaWindowContract } from './contracts/providers.js'
+import {
+  limitWindowLabel,
+  normalizeUtilization,
+  parseRetryAfterMs,
+  type ProviderQuotaFetchResult,
+  type QuotaProviderAdapter,
+} from './provider-quota.js'
+
+const CODEX_USAGE_ENDPOINT = 'https://chatgpt.com/backend-api/wham/usage'
+
+// The OAuth access token is a JWT whose ChatGPT account id lives under this
+// namespaced claim. The usage endpoint requires the account id alongside the
+// bearer token.
+const JWT_CLAIM_PATH = 'https://api.openai.com/auth'
+
+interface RawUsageWindow {
+  used_percent?: number
+  limit_window_seconds?: number
+  reset_after_seconds?: number
+  /** Unix seconds when the window resets. */
+  reset_at?: number
+}
+
+interface RawRateLimitInfo {
+  primary_window?: RawUsageWindow | null
+  secondary_window?: RawUsageWindow | null
+}
+
+/** Shape returned by /backend-api/wham/usage (only the fields we consume). */
+interface RawCodexUsage {
+  plan_type?: string
+  rate_limit?: RawRateLimitInfo | null
+}
+
+/** Only ChatGPT (Codex) subscriber OAuth credentials can query the endpoint. */
+export function isOpenAiCodexOAuthProvider(provider: ProviderConfig): boolean {
+  return (
+    provider.providerType === 'openai-codex' &&
+    provider.authMethod === 'oauth' &&
+    !!provider.oauthCredentials
+  )
+}
+
+/**
+ * Extract the ChatGPT account id from a Codex OAuth access token (JWT). The id
+ * is stable across token refreshes, so deriving it from the current access
+ * token avoids depending on a separately-stored copy.
+ */
+export function extractCodexAccountId(accessToken: string): string | null {
+  try {
+    const parts = accessToken.split('.')
+    if (parts.length !== 3) return null
+
+    const payloadBase64 = parts[1]
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(parts[1].length / 4) * 4, '=')
+
+    const payloadText = Buffer.from(payloadBase64, 'base64').toString('utf-8')
+    const payload = JSON.parse(payloadText) as {
+      [JWT_CLAIM_PATH]?: { chatgpt_account_id?: string }
+    }
+
+    const accountId = payload?.[JWT_CLAIM_PATH]?.chatgpt_account_id
+    return typeof accountId === 'string' && accountId.length > 0 ? accountId : null
+  } catch {
+    return null
+  }
+}
+
+function capitalizeFirst(value: string): string {
+  return value.length ? value.charAt(0).toUpperCase() + value.slice(1) : value
+}
+
+function windowResetIso(window: RawUsageWindow, now: number): string | null {
+  if (typeof window.reset_at === 'number' && window.reset_at > 0) {
+    return new Date(window.reset_at * 1000).toISOString()
+  }
+  if (typeof window.reset_after_seconds === 'number' && window.reset_after_seconds > 0) {
+    return new Date(now + window.reset_after_seconds * 1000).toISOString()
+  }
+  return null
+}
+
+function toWindow(
+  key: string,
+  resetDisplay: 'relative' | 'absolute',
+  window: RawUsageWindow | null | undefined,
+  now: number,
+): ProviderQuotaWindowContract | null {
+  if (!window || typeof window.used_percent !== 'number') return null
+  const label =
+    typeof window.limit_window_seconds === 'number'
+      ? limitWindowLabel(window.limit_window_seconds)
+      : key
+  return {
+    key,
+    label,
+    utilization: normalizeUtilization(window.used_percent),
+    resetsAt: windowResetIso(window, now),
+    resetDisplay,
+  }
+}
+
+/**
+ * Fetch ChatGPT (Codex) usage using a raw OAuth access token and account id.
+ */
+export async function fetchOpenAiCodexQuota(
+  accessToken: string,
+  accountId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProviderQuotaFetchResult> {
+  try {
+    const response = await fetchImpl(CODEX_USAGE_ENDPOINT, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        'ChatGPT-Account-Id': accountId,
+      },
+    })
+
+    if (!response.ok) {
+      return {
+        quota: null,
+        status: response.status,
+        retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
+        error: `HTTP ${response.status}`,
+      }
+    }
+
+    const data = (await response.json()) as RawCodexUsage
+    const now = Date.now()
+    const windows = [
+      toWindow('primary', 'relative', data.rate_limit?.primary_window, now),
+      toWindow('secondary', 'absolute', data.rate_limit?.secondary_window, now),
+    ].filter((window): window is ProviderQuotaWindowContract => window !== null)
+
+    return {
+      quota: {
+        kind: 'openai-codex',
+        windows,
+        plan: data.plan_type ? capitalizeFirst(data.plan_type) : null,
+        fetchedAt: new Date().toISOString(),
+      },
+      status: response.status,
+    }
+  } catch (err) {
+    return { quota: null, error: (err as Error).message || 'Network error' }
+  }
+}
+
+/**
+ * Resolve an OAuth access token (auto-refreshing) for a Codex subscriber
+ * provider, derive its account id, and fetch usage. Works regardless of
+ * whether the provider is the active one — the endpoint is read-only.
+ */
+export async function getOpenAiCodexQuotaForProvider(
+  provider: ProviderConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProviderQuotaFetchResult> {
+  if (!isOpenAiCodexOAuthProvider(provider)) {
+    return { quota: null, error: 'Provider is not an OpenAI Codex OAuth subscriber' }
+  }
+
+  let accessToken: string
+  try {
+    accessToken = await getApiKeyForProvider(provider)
+  } catch (err) {
+    return { quota: null, error: (err as Error).message || 'Failed to resolve OAuth token' }
+  }
+
+  if (!accessToken) {
+    return { quota: null, error: 'No OAuth access token available' }
+  }
+
+  const accountId = extractCodexAccountId(accessToken)
+  if (!accountId) {
+    return { quota: null, error: 'Failed to resolve ChatGPT account id from token' }
+  }
+
+  return fetchOpenAiCodexQuota(accessToken, accountId, fetchImpl)
+}
+
+export const openaiCodexQuotaAdapter: QuotaProviderAdapter = {
+  kind: 'openai-codex',
+  matches: isOpenAiCodexOAuthProvider,
+  fetch: getOpenAiCodexQuotaForProvider,
+}

--- a/packages/core/src/provider-quota.test.ts
+++ b/packages/core/src/provider-quota.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { limitWindowLabel, normalizeUtilization, parseRetryAfterMs } from './provider-quota.js'
+
+describe('normalizeUtilization', () => {
+  it('rounds and clamps into [0, 100]', () => {
+    expect(normalizeUtilization(42.6)).toBe(43)
+    expect(normalizeUtilization(-5)).toBe(0)
+    expect(normalizeUtilization(150)).toBe(100)
+    expect(normalizeUtilization(Number.NaN)).toBe(0)
+  })
+})
+
+describe('limitWindowLabel', () => {
+  it('special-cases the common ChatGPT windows', () => {
+    expect(limitWindowLabel(18_000)).toBe('5h')
+    expect(limitWindowLabel(604_800)).toBe('7d')
+  })
+
+  it('derives day/hour/minute labels otherwise', () => {
+    expect(limitWindowLabel(172_800)).toBe('2d')
+    expect(limitWindowLabel(10_800)).toBe('3h')
+    expect(limitWindowLabel(900)).toBe('15m')
+  })
+})
+
+describe('parseRetryAfterMs', () => {
+  it('parses numeric seconds', () => {
+    expect(parseRetryAfterMs('120')).toBe(120_000)
+  })
+
+  it('returns undefined for missing or invalid headers', () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined()
+    expect(parseRetryAfterMs('0')).toBeUndefined()
+  })
+})

--- a/packages/core/src/provider-quota.ts
+++ b/packages/core/src/provider-quota.ts
@@ -1,0 +1,70 @@
+import type { ProviderQuotaContract } from './contracts/providers.js'
+import type { ProviderConfig } from './provider-config.js'
+
+/**
+ * Result of fetching a single provider's subscriber usage quota.
+ *
+ * `status` / `retryAfterMs` are surfaced so the background monitor can apply
+ * per-provider rate-limit backoff; `error` is a short human-readable summary
+ * shown in the UI when no usable snapshot exists yet.
+ */
+export interface ProviderQuotaFetchResult {
+  quota: ProviderQuotaContract | null
+  status?: number
+  retryAfterMs?: number
+  error?: string
+}
+
+/**
+ * Pluggable per-provider-family quota adapter. Adding a new subscriber quota
+ * source means implementing one of these and registering it in
+ * `quota-registry.ts` — the monitor, HTTP layer, and UI stay untouched.
+ */
+export interface QuotaProviderAdapter {
+  kind: ProviderQuotaContract['kind']
+  /** Whether this adapter handles the given provider. */
+  matches: (provider: ProviderConfig) => boolean
+  /** Resolve credentials, fetch, and normalize the provider's usage quota. */
+  fetch: (provider: ProviderConfig, fetchImpl?: typeof fetch) => Promise<ProviderQuotaFetchResult>
+}
+
+/**
+ * Parse an HTTP `Retry-After` header (seconds or HTTP-date) into milliseconds.
+ * Returns undefined when the header is absent or unparseable.
+ */
+export function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) return undefined
+
+  const seconds = Number(header)
+  if (!Number.isNaN(seconds) && seconds > 0) {
+    return Math.round(seconds * 1000)
+  }
+
+  const retryAt = new Date(header).getTime()
+  if (!Number.isNaN(retryAt)) {
+    const diff = retryAt - Date.now()
+    if (diff > 0) return diff
+  }
+
+  return undefined
+}
+
+/** Clamp a raw utilization value to an integer percentage in [0, 100]. */
+export function normalizeUtilization(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+/**
+ * Turn a rate-limit window length (in seconds) into a short label such as
+ * `5h`, `7d`, `30m`. The two common ChatGPT windows (`18000` = 5h, `604800`
+ * = 7d) are special-cased so rounding never drifts them off the canonical
+ * label.
+ */
+export function limitWindowLabel(seconds: number): string {
+  if (seconds === 18_000) return '5h'
+  if (seconds === 604_800) return '7d'
+  if (seconds % 86_400 === 0) return `${Math.round(seconds / 86_400)}d`
+  if (seconds % 3_600 === 0) return `${Math.round(seconds / 3_600)}h`
+  return `${Math.round(seconds / 60)}m`
+}

--- a/packages/core/src/quota-registry.test.ts
+++ b/packages/core/src/quota-registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { getQuotaAdapter, isQuotaProvider } from './quota-registry.js'
+import type { ProviderConfig } from './provider-config.js'
+
+function provider(overrides: Partial<ProviderConfig>): ProviderConfig {
+  return {
+    id: 'p',
+    name: 'p',
+    type: 'x',
+    providerType: 'openai',
+    provider: 'openai',
+    baseUrl: '',
+    apiKey: '',
+    defaultModel: 'm',
+    ...overrides,
+  }
+}
+
+const anthropicOAuth = provider({
+  providerType: 'anthropic-oauth',
+  authMethod: 'oauth',
+  oauthCredentials: { refresh: 'r', access: 'a', expires: Date.now() + 60_000 },
+})
+
+const codexOAuth = provider({
+  providerType: 'openai-codex',
+  authMethod: 'oauth',
+  oauthCredentials: { refresh: 'r', access: 'a', expires: Date.now() + 60_000 },
+})
+
+const apiKeyProvider = provider({ providerType: 'openai', authMethod: 'api-key', apiKey: 'sk' })
+
+describe('quota registry', () => {
+  it('resolves the correct adapter by provider family', () => {
+    expect(getQuotaAdapter(anthropicOAuth)?.kind).toBe('anthropic')
+    expect(getQuotaAdapter(codexOAuth)?.kind).toBe('openai-codex')
+    expect(getQuotaAdapter(apiKeyProvider)).toBeNull()
+  })
+
+  it('reports quota support', () => {
+    expect(isQuotaProvider(anthropicOAuth)).toBe(true)
+    expect(isQuotaProvider(codexOAuth)).toBe(true)
+    expect(isQuotaProvider(apiKeyProvider)).toBe(false)
+  })
+})

--- a/packages/core/src/quota-registry.ts
+++ b/packages/core/src/quota-registry.ts
@@ -1,0 +1,21 @@
+import type { ProviderConfig } from './provider-config.js'
+import type { QuotaProviderAdapter } from './provider-quota.js'
+import { anthropicQuotaAdapter } from './anthropic-quota.js'
+import { openaiCodexQuotaAdapter } from './openai-codex-quota.js'
+
+/**
+ * Registered subscriber-quota adapters. To add a new provider family, implement
+ * a `QuotaProviderAdapter` and append it here — the background monitor, HTTP
+ * layer, and frontend consume this registry generically.
+ */
+const QUOTA_ADAPTERS: QuotaProviderAdapter[] = [anthropicQuotaAdapter, openaiCodexQuotaAdapter]
+
+/** Resolve the quota adapter that handles a provider, or null if none does. */
+export function getQuotaAdapter(provider: ProviderConfig): QuotaProviderAdapter | null {
+  return QUOTA_ADAPTERS.find((adapter) => adapter.matches(provider)) ?? null
+}
+
+/** Whether a provider exposes a subscriber usage quota endpoint. */
+export function isQuotaProvider(provider: ProviderConfig): boolean {
+  return getQuotaAdapter(provider) !== null
+}

--- a/packages/web-backend/src/api/modules/providers/mapper.ts
+++ b/packages/web-backend/src/api/modules/providers/mapper.ts
@@ -1,11 +1,11 @@
-import { buildModel, PROVIDER_TYPE_MODEL_OVERRIDES, PROVIDER_TYPE_PRESETS } from '@axiom/core'
+import { buildModel, isQuotaProvider, PROVIDER_TYPE_MODEL_OVERRIDES, PROVIDER_TYPE_PRESETS } from '@axiom/core'
 import type {
   ProviderConfig,
   ProviderType,
   ProvidersFile,
 } from '@axiom/core'
 import type {
-  AnthropicQuotaContract,
+  ProviderQuotaContract,
   OllamaModelContract,
   ProviderActivationResponseContract,
   ProviderContract,
@@ -52,7 +52,7 @@ function resolveModelCost(provider: ProviderConfig, modelId: string): { input: n
 export function mapProvidersListResponse(
   masked: ProvidersFile,
   decrypted: ProvidersFile,
-  quotaSnapshot?: Record<string, AnthropicQuotaContract>,
+  quotaSnapshot?: Record<string, ProviderQuotaContract>,
 ): ProvidersListResponseContract {
   const providers = masked.providers.map((provider) => {
     const fullProvider = decrypted.providers.find((candidate) => candidate.id === provider.id)
@@ -76,6 +76,7 @@ export function mapProvidersListResponse(
       apiKeyMasked: (provider as unknown as { apiKeyMasked?: string }).apiKeyMasked ?? provider.apiKey,
       cost,
       modelCosts,
+      supportsQuota: fullProvider ? isQuotaProvider(fullProvider) : false,
       quota: quotaSnapshot?.[provider.id] ?? null,
     } as ProviderContract
   })

--- a/packages/web-backend/src/api/modules/providers/types.ts
+++ b/packages/web-backend/src/api/modules/providers/types.ts
@@ -1,11 +1,11 @@
 import type { OAuthCredentials } from '@earendil-works/pi-ai/oauth'
-import type { AnthropicQuotaContract } from '@axiom/core/contracts'
+import type { ProviderQuotaContract } from '@axiom/core/contracts'
 
 export interface ProvidersRouterOptions {
   onActiveProviderChanged?: () => void
   onFallbackProviderChanged?: () => void
-  getQuotaSnapshot?: () => Record<string, AnthropicQuotaContract>
-  refreshQuota?: (providerId: string) => Promise<AnthropicQuotaContract | null>
+  getQuotaSnapshot?: () => Record<string, ProviderQuotaContract>
+  refreshQuota?: (providerId: string) => Promise<ProviderQuotaContract | null>
 }
 
 export interface PendingOAuthLogin {

--- a/packages/web-backend/src/app.ts
+++ b/packages/web-backend/src/app.ts
@@ -23,7 +23,7 @@ import { createTtsRouter } from './routes/tts.js'
 import { createSttRouter } from './routes/stt.js'
 import { createDeepgramRouter } from './routes/deepgram.js'
 import type { ProviderConfig, TaskRuntimeBoundary, TaskEventBus, AgentHeartbeatService } from '@axiom/core'
-import type { AnthropicQuotaContract } from '@axiom/core/contracts'
+import type { ProviderQuotaContract } from '@axiom/core/contracts'
 import { ensureAdminUser } from './auth.js'
 import type { HealthMonitorService } from './health-monitor.js'
 import type { RuntimeMetrics } from './runtime-metrics.js'
@@ -64,12 +64,12 @@ export interface AppOptions {
   getBackgroundTaskToolNames?: () => string[]
   taskEventBus?: TaskEventBus | null
   /**
-   * Returns the latest cached Anthropic subscriber usage snapshots keyed by
-   * provider id. Used by the providers list endpoint to surface quota in the
-   * UI without blocking the request on a live usage fetch.
+   * Returns the latest cached subscriber usage snapshots keyed by provider id.
+   * Used by the providers list endpoint to surface quota in the UI without
+   * blocking the request on a live usage fetch.
    */
-  getQuotaSnapshot?: () => Record<string, AnthropicQuotaContract>
-  refreshQuota?: (providerId: string) => Promise<AnthropicQuotaContract | null>
+  getQuotaSnapshot?: () => Record<string, ProviderQuotaContract>
+  refreshQuota?: (providerId: string) => Promise<ProviderQuotaContract | null>
 }
 
 export function createApp(options?: AppOptions): express.Express {

--- a/packages/web-backend/src/quota-monitor.ts
+++ b/packages/web-backend/src/quota-monitor.ts
@@ -1,9 +1,9 @@
 import {
-  getAnthropicQuotaForProvider,
-  isAnthropicOAuthProvider,
+  getQuotaAdapter,
+  isQuotaProvider,
   loadProvidersDecrypted,
 } from '@axiom/core'
-import type { AnthropicQuotaContract } from '@axiom/core/contracts'
+import type { ProviderQuotaContract } from '@axiom/core/contracts'
 import type { ProviderConfig } from '@axiom/core'
 
 const DEFAULT_POLL_INTERVAL_MS = 10 * 60 * 1000
@@ -23,12 +23,13 @@ export interface QuotaMonitorServiceOptions {
 }
 
 /**
- * Background poller for Anthropic subscriber (OAuth) usage quotas.
+ * Background poller for subscriber (OAuth) usage quotas.
  *
- * Polls every `anthropic-oauth` provider on an interval and caches the latest
- * usage snapshot in memory keyed by provider id. This is independent of which
- * provider is "active" — the usage endpoint is read-only and works for any
- * provider that holds OAuth credentials.
+ * Polls every quota-capable provider (Anthropic Claude Pro/Max, ChatGPT Codex,
+ * …) on an interval and caches the latest normalized usage snapshot in memory
+ * keyed by provider id. This is independent of which provider is "active" — the
+ * usage endpoints are read-only and work for any provider that holds OAuth
+ * credentials.
  */
 export class QuotaMonitorService {
   private pollIntervalMs: number
@@ -37,7 +38,7 @@ export class QuotaMonitorService {
   private logger: Pick<typeof console, 'error'>
   private timer: ReturnType<typeof setTimeout> | null = null
   private running = false
-  private cache = new Map<string, AnthropicQuotaContract>()
+  private cache = new Map<string, ProviderQuotaContract>()
   private backoff = new Map<string, ProviderBackoff>()
 
   constructor(options: QuotaMonitorServiceOptions = {}) {
@@ -63,20 +64,20 @@ export class QuotaMonitorService {
 
   // Consumed via the http-boundary `getQuotaSnapshot` arrow wrapper, which Fallow cannot trace statically.
   // fallow-ignore-next-line unused-class-member
-  getSnapshot(): Record<string, AnthropicQuotaContract> {
+  getSnapshot(): Record<string, ProviderQuotaContract> {
     return Object.fromEntries(this.cache)
   }
 
   /**
    * Force an immediate, on-demand usage fetch for a single provider, bypassing
    * the rate-limit backoff. Returns the resulting cached snapshot (or null if
-   * the provider no longer exists / is not an Anthropic OAuth subscriber).
+   * the provider no longer exists / is not quota-capable).
    *
    * Consumed via the http-boundary `refreshQuota` arrow wrapper, which Fallow cannot trace statically.
    */
   // fallow-ignore-next-line unused-class-member
-  async refreshProvider(providerId: string): Promise<AnthropicQuotaContract | null> {
-    const provider = this.loadOAuthProviders().find((p) => p.id === providerId)
+  async refreshProvider(providerId: string): Promise<ProviderQuotaContract | null> {
+    const provider = this.loadQuotaProviders().find((p) => p.id === providerId)
     if (!provider) return null
     await this.pollProvider(provider, { force: true })
     return this.cache.get(providerId) ?? null
@@ -104,9 +105,9 @@ export class QuotaMonitorService {
     }
   }
 
-  private loadOAuthProviders() {
+  private loadQuotaProviders() {
     try {
-      return loadProvidersDecrypted().providers.filter(isAnthropicOAuthProvider)
+      return loadProvidersDecrypted().providers.filter(isQuotaProvider)
     } catch (err) {
       this.logger.error('[axiom] Quota monitor failed to load providers:', err)
       return []
@@ -114,7 +115,7 @@ export class QuotaMonitorService {
   }
 
   private async runPoll(): Promise<void> {
-    const providers = this.loadOAuthProviders()
+    const providers = this.loadQuotaProviders()
     const liveIds = new Set(providers.map((p) => p.id))
 
     // Drop cache/backoff for providers that no longer exist or lost OAuth.
@@ -129,6 +130,9 @@ export class QuotaMonitorService {
   }
 
   private async pollProvider(provider: ProviderConfig, opts: { force?: boolean } = {}): Promise<void> {
+    const adapter = getQuotaAdapter(provider)
+    if (!adapter) return
+
     const now = this.now()
     const state = this.backoff.get(provider.id)
 
@@ -136,17 +140,11 @@ export class QuotaMonitorService {
     // refresh); keep the stale cached value in the meantime.
     if (!opts.force && state && now < state.rateLimitedUntil) return
 
-    const result = await getAnthropicQuotaForProvider(provider, this.fetchImpl)
+    const result = await adapter.fetch(provider, this.fetchImpl)
 
     if (result.quota) {
       this.backoff.delete(provider.id)
-      this.cache.set(provider.id, {
-        fiveHour: result.quota.fiveHour,
-        sevenDay: result.quota.sevenDay,
-        sevenDayOpus: result.quota.sevenDayOpus,
-        sevenDaySonnet: result.quota.sevenDaySonnet,
-        fetchedAt: result.quota.fetchedAt,
-      })
+      this.cache.set(provider.id, result.quota)
       return
     }
 
@@ -161,8 +159,8 @@ export class QuotaMonitorService {
 
     // Preserve a previously successful snapshot on transient failures (429
     // rate-limit, network errors, 5xx) so the UI keeps showing the last known
-    // usage instead of flapping to "unavailable" — the Anthropic usage endpoint
-    // is aggressively rate-limited. Only surface an error entry when there is no
+    // usage instead of flapping to "unavailable" — these usage endpoints are
+    // aggressively rate-limited. Only surface an error entry when there is no
     // good data yet, or for hard failures (e.g. 401/403) the user must act on.
     const existing = this.cache.get(provider.id)
     const hasGoodData = !!existing && !existing.error
@@ -172,10 +170,9 @@ export class QuotaMonitorService {
       (typeof result.status === 'number' && result.status >= 500)
     if (!hasGoodData || !isTransient) {
       this.cache.set(provider.id, {
-        fiveHour: null,
-        sevenDay: null,
-        sevenDayOpus: null,
-        sevenDaySonnet: null,
+        kind: adapter.kind,
+        windows: [],
+        plan: null,
         fetchedAt: new Date(now).toISOString(),
         error: result.error ?? 'Failed to fetch usage',
       })

--- a/packages/web-backend/src/routes/health.ts
+++ b/packages/web-backend/src/routes/health.ts
@@ -5,26 +5,26 @@ import { jwtMiddleware } from '../auth.js'
 import type { AuthenticatedRequest } from '../auth.js'
 import type { HealthMonitorService } from '../health-monitor.js'
 import type { RuntimeMetrics } from '../runtime-metrics.js'
-import type { AnthropicQuotaContract } from '@axiom/core/contracts'
+import type { ProviderQuotaContract } from '@axiom/core/contracts'
 
 export interface HealthRouterOptions {
   db: Database
   healthMonitorService: HealthMonitorService
   runtimeMetrics: RuntimeMetrics
-  getQuotaSnapshot?: () => Record<string, AnthropicQuotaContract>
+  getQuotaSnapshot?: () => Record<string, ProviderQuotaContract>
 }
 
 /**
- * Resolve the Anthropic subscriber quota for the global top-bar indicator.
+ * Resolve the subscriber quota for the global top-bar indicator.
  *
  * Only the active provider's own snapshot is returned: the indicator sits next
  * to the active provider's health, so falling back to another provider would
  * show a different subscription's usage and mislead the user.
  */
 function selectTopBarQuota(
-  snapshot: Record<string, AnthropicQuotaContract>,
+  snapshot: Record<string, ProviderQuotaContract>,
   activeProviderId: string | null | undefined,
-): AnthropicQuotaContract | null {
+): ProviderQuotaContract | null {
   if (!activeProviderId) return null
   return snapshot[activeProviderId] ?? null
 }

--- a/packages/web-frontend/app/composables/useConnectionStatus.ts
+++ b/packages/web-frontend/app/composables/useConnectionStatus.ts
@@ -8,7 +8,7 @@
  *   - 'healthy'   → backend OK and provider healthy (green dot)
  */
 
-import type { AnthropicQuotaContract } from '@axiom/core/contracts'
+import type { ProviderQuotaContract } from '@axiom/core/contracts'
 
 export type GlobalStatus = 'offline' | 'degraded' | 'healthy'
 type OperatingMode = 'normal' | 'fallback'
@@ -24,7 +24,7 @@ interface HealthSnapshot {
     name: string
     model: string
   } | null
-  quota?: AnthropicQuotaContract | null
+  quota?: ProviderQuotaContract | null
 }
 
 const POLL_INTERVAL_MS = 30_000
@@ -38,7 +38,7 @@ export function useConnectionStatus() {
   const operatingMode = useState<OperatingMode>('global_operating_mode', () => 'normal')
   const fallbackProviderName = useState<string | null>('global_fallback_provider_name', () => null)
   const healthMonitorEnabled = useState<boolean>('global_health_monitor_enabled', () => true)
-  const quota = useState<AnthropicQuotaContract | null>('global_quota', () => null)
+  const quota = useState<ProviderQuotaContract | null>('global_quota', () => null)
 
   let timer: ReturnType<typeof setInterval> | null = null
   let polling = false

--- a/packages/web-frontend/app/composables/useQuotaFormat.ts
+++ b/packages/web-frontend/app/composables/useQuotaFormat.ts
@@ -1,10 +1,21 @@
+import type { ProviderQuotaWindowContract } from '@axiom/core/contracts'
+
+export interface QuotaDisplayPart {
+  key: string
+  label: string
+  utilization: number
+  colorClass: string
+  reset: string
+}
+
 /**
- * Shared formatting helpers for Anthropic subscriber quota display.
+ * Shared formatting helpers for subscriber usage quota display.
  *
  * Centralises the colour thresholds and reset-time formatting used by both the
- * providers table and the global top bar so the two views stay consistent.
- * Date/time output follows the user's browser/OS regional settings (the
- * `undefined` locale), matching `useFormat`.
+ * providers table and the global top bar so the two views stay consistent
+ * across every quota provider (Anthropic, OpenAI Codex, …). Date/time output
+ * follows the user's browser/OS regional settings (the `undefined` locale),
+ * matching `useFormat`.
  */
 export function useQuotaFormat() {
   function quotaColorClass(utilization: number): string {
@@ -38,9 +49,28 @@ export function useQuotaFormat() {
     return `${weekday} ${time}`
   }
 
+  /**
+   * Map a normalized quota snapshot into ready-to-render display parts. Each
+   * window renders its own reset time according to its `resetDisplay` hint
+   * (relative countdown vs. absolute weekday/time).
+   */
+  function quotaWindowParts(quota: { windows: readonly ProviderQuotaWindowContract[] }): QuotaDisplayPart[] {
+    return quota.windows.map((window) => ({
+      key: window.key,
+      label: window.label,
+      utilization: window.utilization,
+      colorClass: quotaColorClass(window.utilization),
+      reset:
+        window.resetDisplay === 'absolute'
+          ? formatQuotaResetNice(window.resetsAt)
+          : formatQuotaResetRelative(window.resetsAt),
+    }))
+  }
+
   return {
     quotaColorClass,
     formatQuotaResetRelative,
     formatQuotaResetNice,
+    quotaWindowParts,
   }
 }

--- a/packages/web-frontend/app/features/providers/components/ProvidersWorkspace.vue
+++ b/packages/web-frontend/app/features/providers/components/ProvidersWorkspace.vue
@@ -110,12 +110,12 @@
                       </span>
                       <template v-else>
                         <div
-                          v-for="part in quotaParts(getQuota(provider)!)"
-                          :key="part.label"
+                          v-for="part in quotaWindowParts(getQuota(provider)!)"
+                          :key="part.key"
                           class="flex items-center gap-1 whitespace-nowrap"
                         >
-                          <span class="font-medium" :class="quotaColorClass(part.utilization)">
-                            {{ part.label }} {{ part.utilization }}%
+                          <span class="font-medium" :class="part.colorClass">
+                            {{ part.label }}: {{ part.utilization }}%
                           </span>
                           <span v-if="part.reset" class="text-muted-foreground">({{ part.reset }})</span>
                         </div>
@@ -135,7 +135,7 @@
                           {{ $t('users.edit') }}
                         </DropdownMenuItem>
                         <DropdownMenuItem
-                            v-if="isAnthropicOAuth(provider)"
+                            v-if="providerSupportsQuota(provider)"
                             :disabled="isRefreshingQuota(provider.id)"
                             @click="handleRefreshQuota(provider.id)"
                         >
@@ -300,7 +300,7 @@ import type { ProviderFormPayload } from '~/components/ProviderFormDialog.vue'
 import { useProviders } from '~/features/providers/composables/useProviders'
 
 const { t } = useI18n()
-const { quotaColorClass, formatQuotaResetRelative, formatQuotaResetNice } = useQuotaFormat()
+const { quotaWindowParts } = useQuotaFormat()
 
 const {
   providers,
@@ -359,15 +359,14 @@ function getTypeLabel(providerType: string): string {
   return preset?.label ?? providerType
 }
 
-type QuotaBucket = { utilization: number; resetsAt: string | null }
 type ProviderQuota = NonNullable<Provider['quota']>
 
-function isAnthropicOAuth(provider: Provider): boolean {
-  return provider.authMethod === 'oauth' && provider.providerType === 'anthropic-oauth'
+function providerSupportsQuota(provider: Provider): boolean {
+  return provider.supportsQuota === true
 }
 
 function getQuota(provider: Provider): ProviderQuota | null {
-  if (!isAnthropicOAuth(provider)) {
+  if (!providerSupportsQuota(provider)) {
     return null
   }
   return provider.quota ?? null
@@ -404,23 +403,6 @@ async function handleRefreshQuota(providerId: string) {
     next.delete(providerId)
     refreshingQuotaIds.value = next
   }
-}
-
-type QuotaBucketSpec = { label: string; bucket: QuotaBucket | null; format: (resetsAt: string | null) => string }
-
-function quotaParts(quota: ProviderQuota): Array<{ label: string; utilization: number; reset: string }> {
-  const buckets: QuotaBucketSpec[] = [
-    { label: '5h:', bucket: quota.fiveHour, format: formatQuotaResetRelative },
-    { label: '7d:', bucket: quota.sevenDay, format: formatQuotaResetNice },
-    { label: 'Opus:', bucket: quota.sevenDayOpus, format: () => '' },
-  ]
-  return buckets
-    .filter((entry): entry is QuotaBucketSpec & { bucket: QuotaBucket } => entry.bucket != null)
-    .map((entry) => ({
-      label: entry.label,
-      utilization: entry.bucket.utilization,
-      reset: entry.format(entry.bucket.resetsAt),
-    }))
 }
 
 function getStatusVariant(status?: string): 'success' | 'destructive' | 'muted' {

--- a/packages/web-frontend/app/layouts/default.vue
+++ b/packages/web-frontend/app/layouts/default.vue
@@ -272,9 +272,9 @@
           </TooltipContent>
         </Tooltip>
 
-        <!-- Anthropic quota (desktop, wide viewports only) -->
+        <!-- Subscriber quota (desktop, wide viewports only) -->
         <div v-if="quotaTopBarParts.length > 0" class="hidden items-center gap-2 lg:flex">
-          <template v-for="(part, idx) in quotaTopBarParts" :key="part.label">
+          <template v-for="(part, idx) in quotaTopBarParts" :key="part.key">
             <span v-if="idx > 0" class="text-muted-foreground/40">·</span>
             <span class="text-xs">
               <span class="font-medium" :class="part.colorClass">{{ part.label }}: {{ part.utilization }}%</span>
@@ -376,24 +376,12 @@ const statusText = computed(() => {
   }
 })
 
-const { quotaColorClass, formatQuotaResetRelative, formatQuotaResetNice } = useQuotaFormat()
+const { quotaWindowParts } = useQuotaFormat()
 
 const quotaTopBarParts = computed(() => {
   const q = globalQuota.value
   if (!q || q.error) return []
-  const specs = [
-    { label: '5h', bucket: q.fiveHour, format: formatQuotaResetRelative },
-    { label: '7d', bucket: q.sevenDay, format: formatQuotaResetNice },
-    { label: 'Opus', bucket: q.sevenDayOpus, format: formatQuotaResetNice },
-  ]
-  return specs
-    .filter((s) => s.bucket != null)
-    .map((s) => ({
-      label: s.label,
-      utilization: s.bucket!.utilization,
-      reset: s.format(s.bucket!.resetsAt),
-      colorClass: quotaColorClass(s.bucket!.utilization),
-    }))
+  return quotaWindowParts(q)
 })
 
 onMounted(() => {


### PR DESCRIPTION
Surfaces ChatGPT Plus/Pro (Codex) subscription usage in the UI, alongside the existing Anthropic Claude Pro/Max quota — and refactors the quota system into a provider-agnostic abstraction so future providers can be added with minimal effort.