### PR TITLE
feat(quota): add OpenCode Go subscriber-quota adapter

### DIFF
--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -105,7 +105,7 @@ The dialog keeps connection details first, then model selection, then advanced h
 | Field                  | Notes                                                                                                |
 |------------------------|------------------------------------------------------------------------------------------------------|
 | **Name**               | Free text, your label for this provider — appears in the table, in `<task_injection>` blocks, on the Dashboard. |
-| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, xAI (Grok), Google Gemini, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, GitHub Copilot, …). |
+| **Type**               | Dropdown grouped into two sections: **API Key** (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, xAI (Grok), Google Gemini, OpenCode Zen, OpenCode Go, Ollama, generic OpenAI-compatible, …) and **Subscription / OAuth** (Anthropic Claude Pro/Max, OpenAI ChatGPT Plus/Pro, GitHub Copilot, …). |
 | **Base URL**           | Shown directly after Type when the preset has an editable URL (Ollama, generic OpenAI-compatible, …). |
 | **API Key**            | Shown after Base URL for API-key providers. Required for most hosted presets, optional for local/custom providers that do not need auth. |
 | **Enabled Models**     | Model selector or model-id entry for this provider. The exact control depends on the provider type. |
@@ -131,7 +131,7 @@ Stored encrypted at rest in `/data/config/providers.json` using `ENCRYPTION_KEY`
 
 The model selector adapts to the preset:
 
-- **Curated providers (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, xAI (Grok), …)** — a checkbox list of known models. Tick the ones you want to enable; the first enabled becomes the provider's internal default/fallback model.
+- **Curated providers (OpenAI, Anthropic, Mistral, OpenRouter, DeepSeek, Kimi / Moonshot, MiniMax, xAI (Grok), OpenCode Zen, OpenCode Go, …)** — a checkbox list of known models. Tick the ones you want to enable; the first enabled becomes the provider's internal default/fallback model. OpenCode Zen and Go source their catalog (models, per-token costs, per-model API type) directly from the bundled `@earendil-works/pi-ai` registry, so they stay in sync with [OpenCode Zen](https://opencode.ai/docs/zen) whenever that dependency is updated — no manual price table to maintain.
 - **Generic OpenAI-compatible** — free-text model-id entry plus an optional **Load models** button for providers that implement OpenAI's `/models` endpoint.
 - **Ollama** — a separate panel with its own controls (see below).
 
@@ -216,9 +216,9 @@ The full flow:
 
 **Remote server fallback.** If your Axiom instance runs on a remote box where the OAuth callback URL can't reach you, a manual-code field appears below the spinner: *"Or paste the redirect URL here (for remote servers)"*. Complete the login locally, copy the full redirect URL from the browser, paste it in, and click **Submit**.
 
-### Subscriber usage quota (OAuth plans)
+### Subscriber usage quota
 
-For **subscription (OAuth)** providers that expose a usage endpoint, the provider header row's **Status** column shows how much of your subscription allowance is left, polled in the background (no manual action needed). Quota is currently supported for:
+For subscription-style providers that expose a usage endpoint, the provider header row's **Status** column shows how much of your subscription allowance is left, polled in the background (no manual action needed). Quota is currently supported for:
 
 - **Anthropic Claude Pro/Max** (`anthropic-oauth`)
 - **OpenAI ChatGPT Plus/Pro (Codex)** (`openai-codex`)
@@ -227,12 +227,12 @@ For **subscription (OAuth)** providers that expose a usage endpoint, the provide
 Other provider types never show quota — they have no usage endpoint.
 
 ::: warning OpenCode Go is a special case
-OpenCode Go has no official usage API. Its quota is read by scraping the authenticated web dashboard, which requires two environment variables on the Axiom backend:
+OpenCode Go has no official usage API. Its quota is read by scraping the authenticated web dashboard. Configure the provider's extra fields in the provider dialog:
 
-- `OPENCODE_GO_WORKSPACE_ID` — your OpenCode workspace id
-- `OPENCODE_GO_AUTH_COOKIE` — a valid dashboard auth cookie (the `auth=` prefix is optional)
+- **Workspace ID** — the id from `opencode.ai/workspace/<id>/go`
+- **Dashboard Auth Cookie** — a valid dashboard auth cookie (the `auth=` prefix is optional)
 
-Quota is only shown once **both** are set. Because it parses dashboard markup rather than a stable API, this integration can break if the dashboard layout changes; in that case the Status column falls back to *"Quota unavailable"* and inference is unaffected.
+Quota is only shown once **both** fields are set. Because it parses dashboard markup rather than a stable API, this integration can break if the dashboard layout changes; in that case the Status column falls back to *"Quota unavailable"* and inference is unaffected.
 :::
 
 Each usage window appears on its own line as `<window>: <utilization>% (<reset>)`. The exact windows depend on the provider:

--- a/docs/web-ui/providers.md
+++ b/docs/web-ui/providers.md
@@ -222,8 +222,18 @@ For **subscription (OAuth)** providers that expose a usage endpoint, the provide
 
 - **Anthropic Claude Pro/Max** (`anthropic-oauth`)
 - **OpenAI ChatGPT Plus/Pro (Codex)** (`openai-codex`)
+- **OpenCode Go** (`opencode-go`) — see the credential note below
 
 Other provider types never show quota — they have no usage endpoint.
+
+::: warning OpenCode Go is a special case
+OpenCode Go has no official usage API. Its quota is read by scraping the authenticated web dashboard, which requires two environment variables on the Axiom backend:
+
+- `OPENCODE_GO_WORKSPACE_ID` — your OpenCode workspace id
+- `OPENCODE_GO_AUTH_COOKIE` — a valid dashboard auth cookie (the `auth=` prefix is optional)
+
+Quota is only shown once **both** are set. Because it parses dashboard markup rather than a stable API, this integration can break if the dashboard layout changes; in that case the Status column falls back to *"Quota unavailable"* and inference is unaffected.
+:::
 
 Each usage window appears on its own line as `<window>: <utilization>% (<reset>)`. The exact windows depend on the provider:
 
@@ -231,6 +241,7 @@ Each usage window appears on its own line as `<window>: <utilization>% (<reset>)
 |-----------------------|------------------------------------------------------------------------|-----------------------------------------|
 | Anthropic Claude      | `5h` (rolling 5h), `7d` (rolling 7d), `Opus` / `Sonnet` (7d model-specific windows; only shown when above 0%). | `5h` relative (e.g. `2h 14m`); `7d`/`Opus`/`Sonnet` weekday + time (e.g. `Mon 3:00PM`). |
 | OpenAI ChatGPT (Codex)| Primary + secondary rate-limit windows (labelled by their length, e.g. `5h`, `7d`). | Primary relative; secondary weekday + time. |
+| OpenCode Go           | `5h` (rolling), `7d` (weekly), `30d` (monthly). | `5h` relative; `7d`/`30d` weekday + time. |
 
 The percentage is colour-coded: green below 70%, amber at 70–89%, red at 90%+. Reset times follow your browser's regional settings.
 

--- a/packages/core/src/contracts/providers.ts
+++ b/packages/core/src/contracts/providers.ts
@@ -60,6 +60,20 @@ export interface ProviderContract {
   supportsQuota?: boolean
   /** Subscriber usage snapshot (only for quota-capable OAuth providers). */
   quota?: ProviderQuotaContract | null
+  /** Non-secret provider-specific extra field values (secret values are omitted). */
+  extraFields?: Record<string, string>
+  /** Presence flags for secret extra fields (the values themselves are never returned). */
+  extraFieldsSet?: Record<string, boolean>
+}
+
+/** Declarative definition of one provider-specific extra configuration field. */
+export interface ProviderExtraFieldDefContract {
+  key: string
+  label: string
+  secret?: boolean
+  required?: boolean
+  placeholder?: string
+  hint?: string
 }
 
 export interface ProviderTypePresetContract {
@@ -83,6 +97,13 @@ export interface ProviderTypePresetContract {
   hasKnownModels: boolean
   authMethod: ProviderAuthMethodContract
   oauthProviderId?: string
+  /**
+   * Display-only hint: the UI groups this preset under "Subscription / OAuth"
+   * even though it authenticates with an API key (e.g. OpenCode Go).
+   */
+  subscription?: boolean
+  /** Provider-specific extra fields the UI should render generically. */
+  extraFields?: ProviderExtraFieldDefContract[]
 }
 
 export interface AvailableModelContract {
@@ -162,6 +183,7 @@ export interface ProviderCreatePayloadContract {
   degradedThresholdMs?: number
   textVerbosity?: ProviderTextVerbosityContract | null
   transport?: ProviderTransportContract | null
+  extraFields?: Record<string, string>
 }
 
 export interface ProviderUpdatePayloadContract {
@@ -174,6 +196,7 @@ export interface ProviderUpdatePayloadContract {
   degradedThresholdMs?: number
   textVerbosity?: ProviderTextVerbosityContract | null
   transport?: ProviderTransportContract | null
+  extraFields?: Record<string, string>
 }
 
 export interface ProviderFallbackUpdatePayloadContract {

--- a/packages/core/src/contracts/providers.ts
+++ b/packages/core/src/contracts/providers.ts
@@ -3,7 +3,7 @@ import type { ProviderType } from '../provider-config.js'
 export type ProviderStatusContract = 'connected' | 'error' | 'untested'
 
 /** Provider families that expose a subscriber usage quota endpoint. */
-export type ProviderQuotaKindContract = 'anthropic' | 'openai-codex'
+export type ProviderQuotaKindContract = 'anthropic' | 'openai-codex' | 'opencode-go'
 
 /**
  * A single normalized usage window, provider-agnostic. Each window carries its

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,6 +107,14 @@ export {
   openaiCodexQuotaAdapter,
 } from './openai-codex-quota.js'
 export {
+  fetchOpenCodeGoQuota,
+  getOpenCodeGoQuotaForProvider,
+  isOpenCodeGoQuotaProvider,
+  parseOpenCodeGoQuotaHtml,
+  resolveOpenCodeGoQuotaCredentials,
+  opencodeGoQuotaAdapter,
+} from './opencode-go-quota.js'
+export {
   getQuotaAdapter,
   isQuotaProvider,
 } from './quota-registry.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,8 +91,10 @@ export {
   PROVIDER_TYPE_PRESETS,
   PROVIDER_TYPE_MODEL_OVERRIDES,
   CLAUDE_CODE_VERSION,
+  getProviderExtraFieldDefs,
+  maskProviderExtraFields,
 } from './provider-config.js'
-export type { ProviderConfig, ProviderModelConfig, ProvidersFile, ProviderType, ProviderTypePreset, AuthMethod, TextVerbosity, AvailableModel, OAuthCredentialsStored, TokenPriceTable } from './provider-config.js'
+export type { ProviderConfig, MaskedProviderConfig, MaskedProvidersFile, ProviderModelConfig, ProvidersFile, ProviderType, ProviderTypePreset, ProviderExtraFieldDef, AuthMethod, TextVerbosity, AvailableModel, OAuthCredentialsStored, TokenPriceTable } from './provider-config.js'
 export {
   fetchAnthropicQuota,
   getAnthropicQuotaForProvider,

--- a/packages/core/src/opencode-go-quota.test.ts
+++ b/packages/core/src/opencode-go-quota.test.ts
@@ -33,41 +33,35 @@ const provider: ProviderConfig = {
   authMethod: 'api-key',
 }
 
+const providerWithQuota: ProviderConfig = {
+  ...provider,
+  extraFields: { workspaceId: 'workspace-1', authCookie: 'cookie-1' },
+}
+
 describe('OpenCode Go quota credentials', () => {
-  it('resolves the dashboard workspace id and auth cookie from env', () => {
+  it('resolves the workspace id and auth cookie from the provider extra fields', () => {
     expect(
       resolveOpenCodeGoQuotaCredentials({
-        OPENCODE_GO_WORKSPACE_ID: ' workspace-1 ',
-        OPENCODE_GO_AUTH_COOKIE: ' cookie-1 ',
+        ...provider,
+        extraFields: { workspaceId: ' workspace-1 ', authCookie: ' cookie-1 ' },
       }),
     ).toEqual({ workspaceId: 'workspace-1', authCookie: 'cookie-1' })
   })
 
-  it('returns null when either dashboard credential is missing', () => {
-    expect(resolveOpenCodeGoQuotaCredentials({ OPENCODE_GO_WORKSPACE_ID: 'workspace-1' })).toBeNull()
-    expect(resolveOpenCodeGoQuotaCredentials({ OPENCODE_GO_AUTH_COOKIE: 'cookie-1' })).toBeNull()
+  it('returns null when either credential is missing', () => {
+    expect(resolveOpenCodeGoQuotaCredentials({ ...provider, extraFields: { workspaceId: 'workspace-1' } })).toBeNull()
+    expect(resolveOpenCodeGoQuotaCredentials({ ...provider, extraFields: { authCookie: 'cookie-1' } })).toBeNull()
+    expect(resolveOpenCodeGoQuotaCredentials(provider)).toBeNull()
   })
 })
 
 describe('isOpenCodeGoQuotaProvider', () => {
-  const previousEnv = { ...process.env }
-
-  afterEach(() => {
-    process.env = { ...previousEnv }
-  })
-
   it('matches OpenCode Go providers when dashboard credentials are configured', () => {
-    process.env.OPENCODE_GO_WORKSPACE_ID = 'workspace-1'
-    process.env.OPENCODE_GO_AUTH_COOKIE = 'cookie-1'
-
-    expect(isOpenCodeGoQuotaProvider(provider)).toBe(true)
-    expect(isOpenCodeGoQuotaProvider({ ...provider, providerType: 'openai' })).toBe(false)
+    expect(isOpenCodeGoQuotaProvider(providerWithQuota)).toBe(true)
+    expect(isOpenCodeGoQuotaProvider({ ...providerWithQuota, providerType: 'openai' })).toBe(false)
   })
 
-  it('does not enable quota UI for OpenCode Go when no dashboard credentials are configured', () => {
-    delete process.env.OPENCODE_GO_WORKSPACE_ID
-    delete process.env.OPENCODE_GO_AUTH_COOKIE
-
+  it('does not enable quota for OpenCode Go without credentials', () => {
     expect(isOpenCodeGoQuotaProvider(provider)).toBe(false)
   })
 })

--- a/packages/core/src/opencode-go-quota.test.ts
+++ b/packages/core/src/opencode-go-quota.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchOpenCodeGoQuota,
+  isOpenCodeGoQuotaProvider,
+  parseOpenCodeGoQuotaHtml,
+  resolveOpenCodeGoQuotaCredentials,
+} from './opencode-go-quota.js'
+import type { ProviderConfig } from './provider-config.js'
+
+function mockResponse(init: {
+  ok: boolean
+  status: number
+  text?: string
+  headers?: Record<string, string>
+}): Response {
+  return {
+    ok: init.ok,
+    status: init.status,
+    headers: { get: (name: string) => init.headers?.[name.toLowerCase()] ?? null },
+    text: async () => init.text ?? '',
+  } as unknown as Response
+}
+
+const provider: ProviderConfig = {
+  id: 'opencode-go-1',
+  name: 'OpenCode Go',
+  type: 'openai-completions',
+  providerType: 'opencode-go',
+  provider: 'opencode-go',
+  baseUrl: 'https://opencode.ai/zen/go/v1',
+  apiKey: 'oc-go-key',
+  defaultModel: 'kimi-k2.7-code',
+  authMethod: 'api-key',
+}
+
+describe('OpenCode Go quota credentials', () => {
+  it('resolves the dashboard workspace id and auth cookie from env', () => {
+    expect(
+      resolveOpenCodeGoQuotaCredentials({
+        OPENCODE_GO_WORKSPACE_ID: ' workspace-1 ',
+        OPENCODE_GO_AUTH_COOKIE: ' cookie-1 ',
+      }),
+    ).toEqual({ workspaceId: 'workspace-1', authCookie: 'cookie-1' })
+  })
+
+  it('returns null when either dashboard credential is missing', () => {
+    expect(resolveOpenCodeGoQuotaCredentials({ OPENCODE_GO_WORKSPACE_ID: 'workspace-1' })).toBeNull()
+    expect(resolveOpenCodeGoQuotaCredentials({ OPENCODE_GO_AUTH_COOKIE: 'cookie-1' })).toBeNull()
+  })
+})
+
+describe('isOpenCodeGoQuotaProvider', () => {
+  const previousEnv = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...previousEnv }
+  })
+
+  it('matches OpenCode Go providers when dashboard credentials are configured', () => {
+    process.env.OPENCODE_GO_WORKSPACE_ID = 'workspace-1'
+    process.env.OPENCODE_GO_AUTH_COOKIE = 'cookie-1'
+
+    expect(isOpenCodeGoQuotaProvider(provider)).toBe(true)
+    expect(isOpenCodeGoQuotaProvider({ ...provider, providerType: 'openai' })).toBe(false)
+  })
+
+  it('does not enable quota UI for OpenCode Go when no dashboard credentials are configured', () => {
+    delete process.env.OPENCODE_GO_WORKSPACE_ID
+    delete process.env.OPENCODE_GO_AUTH_COOKIE
+
+    expect(isOpenCodeGoQuotaProvider(provider)).toBe(false)
+  })
+})
+
+describe('parseOpenCodeGoQuotaHtml', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('normalizes SolidJS hydration usage windows', () => {
+    const windows = parseOpenCodeGoQuotaHtml(`
+      rollingUsage:$R[1]={usagePercent:42.6,resetInSec:3600}
+      weeklyUsage:$R[2]={resetInSec:172800,usagePercent:88}
+      monthlyUsage:$R[3]={usagePercent:101,resetInSec:2592000}
+    `)
+
+    expect(windows).toEqual([
+      {
+        key: 'rolling',
+        label: '5h',
+        utilization: 43,
+        resetsAt: '2026-06-16T13:00:00.000Z',
+        resetDisplay: 'relative',
+      },
+      {
+        key: 'weekly',
+        label: '7d',
+        utilization: 88,
+        resetsAt: '2026-06-18T12:00:00.000Z',
+        resetDisplay: 'absolute',
+      },
+      {
+        key: 'monthly',
+        label: '30d',
+        utilization: 100,
+        resetsAt: '2026-07-16T12:00:00.000Z',
+        resetDisplay: 'absolute',
+      },
+    ])
+  })
+
+  it('falls back to data-slot dashboard markup', () => {
+    const windows = parseOpenCodeGoQuotaHtml(`
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Rolling Usage</span>
+        <span data-slot="usage-value">7%</span>
+        <span data-slot="reset-time">Resets in 1 hour 30 minutes</span>
+      </div>
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Weekly Usage</span>
+        <span data-slot="usage-value">12%</span>
+        <span data-slot="reset-now">Reset now</span>
+      </div>
+    `)
+
+    expect(windows).toEqual([
+      expect.objectContaining({ key: 'rolling', utilization: 7, resetsAt: '2026-06-16T13:30:00.000Z' }),
+      expect.objectContaining({ key: 'weekly', utilization: 12, resetsAt: '2026-06-16T12:00:00.000Z' }),
+    ])
+  })
+})
+
+
+describe('fetchOpenCodeGoQuota', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scrapes the authenticated workspace dashboard and normalizes windows', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({
+        ok: true,
+        status: 200,
+        text: 'rollingUsage:$R[1]={usagePercent:25,resetInSec:3600}',
+      }),
+    )
+
+    const result = await fetchOpenCodeGoQuota('workspace-1', 'cookie-1', fetchImpl as unknown as typeof fetch)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://opencode.ai/workspace/workspace-1/go',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Cookie: 'auth=cookie-1' }),
+      }),
+    )
+    expect(result.status).toBe(200)
+    expect(result.error).toBeUndefined()
+    expect(result.quota).toEqual({
+      kind: 'opencode-go',
+      plan: 'Go',
+      fetchedAt: '2026-06-16T12:00:00.000Z',
+      windows: [
+        {
+          key: 'rolling',
+          label: '5h',
+          utilization: 25,
+          resetsAt: '2026-06-16T13:00:00.000Z',
+          resetDisplay: 'relative',
+        },
+      ],
+    })
+  })
+
+  it('passes through a pre-formatted auth cookie unchanged', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({ ok: true, status: 200, text: 'rollingUsage:$R[1]={usagePercent:1,resetInSec:60}' }),
+    )
+
+    await fetchOpenCodeGoQuota('ws', 'auth=already-set; other=1', fetchImpl as unknown as typeof fetch)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: expect.objectContaining({ Cookie: 'auth=already-set; other=1' }) }),
+    )
+  })
+
+  it('surfaces an HTTP error with retry-after metadata', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({ ok: false, status: 429, headers: { 'retry-after': '30' } }),
+    )
+
+    const result = await fetchOpenCodeGoQuota('ws', 'cookie', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota).toBeNull()
+    expect(result.status).toBe(429)
+    expect(result.retryAfterMs).toBe(30_000)
+    expect(result.error).toBe('HTTP 429')
+  })
+
+  it('reports a parse failure when the dashboard markup yields no windows', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ ok: true, status: 200, text: '<html>no usage here</html>' }))
+
+    const result = await fetchOpenCodeGoQuota('ws', 'cookie', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota).toBeNull()
+    expect(result.status).toBe(200)
+    expect(result.error).toMatch(/could not parse/i)
+  })
+
+  it('returns a network error message when the request throws', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('socket hang up')
+    })
+
+    const result = await fetchOpenCodeGoQuota('ws', 'cookie', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota).toBeNull()
+    expect(result.error).toBe('socket hang up')
+  })
+})

--- a/packages/core/src/opencode-go-quota.test.ts
+++ b/packages/core/src/opencode-go-quota.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchOpenCodeGoQuota,
+  isOpenCodeGoQuotaProvider,
+  parseOpenCodeGoQuotaHtml,
+  resolveOpenCodeGoQuotaCredentials,
+} from './opencode-go-quota.js'
+import type { ProviderConfig } from './provider-config.js'
+
+function mockResponse(init: {
+  ok: boolean
+  status: number
+  text?: string
+  headers?: Record<string, string>
+}): Response {
+  return {
+    ok: init.ok,
+    status: init.status,
+    headers: { get: (name: string) => init.headers?.[name.toLowerCase()] ?? null },
+    text: async () => init.text ?? '',
+  } as unknown as Response
+}
+
+const provider: ProviderConfig = {
+  id: 'opencode-go-1',
+  name: 'OpenCode Go',
+  type: 'openai-completions',
+  providerType: 'opencode-go',
+  provider: 'opencode-go',
+  baseUrl: 'https://opencode.ai/zen/go/v1',
+  apiKey: 'oc-go-key',
+  defaultModel: 'kimi-k2.7-code',
+  authMethod: 'api-key',
+}
+
+describe('OpenCode Go quota credentials', () => {
+  it('resolves the dashboard workspace id and auth cookie from env', () => {
+    expect(
+      resolveOpenCodeGoQuotaCredentials({
+        OPENCODE_GO_WORKSPACE_ID: ' workspace-1 ',
+        OPENCODE_GO_AUTH_COOKIE: ' cookie-1 ',
+      }),
+    ).toEqual({ workspaceId: 'workspace-1', authCookie: 'cookie-1' })
+  })
+
+  it('returns null when either dashboard credential is missing', () => {
+    expect(resolveOpenCodeGoQuotaCredentials({ OPENCODE_GO_WORKSPACE_ID: 'workspace-1' })).toBeNull()
+    expect(resolveOpenCodeGoQuotaCredentials({ OPENCODE_GO_AUTH_COOKIE: 'cookie-1' })).toBeNull()
+  })
+})
+
+describe('isOpenCodeGoQuotaProvider', () => {
+  const previousEnv = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...previousEnv }
+  })
+
+  it('matches OpenCode Go providers when dashboard credentials are configured', () => {
+    process.env.OPENCODE_GO_WORKSPACE_ID = 'workspace-1'
+    process.env.OPENCODE_GO_AUTH_COOKIE = 'cookie-1'
+
+    expect(isOpenCodeGoQuotaProvider(provider)).toBe(true)
+    expect(isOpenCodeGoQuotaProvider({ ...provider, providerType: 'openai' })).toBe(false)
+  })
+
+  it('does not enable quota UI for OpenCode Go until both dashboard credentials are configured', () => {
+    delete process.env.OPENCODE_GO_WORKSPACE_ID
+    delete process.env.OPENCODE_GO_AUTH_COOKIE
+    expect(isOpenCodeGoQuotaProvider(provider)).toBe(false)
+
+    process.env.OPENCODE_GO_WORKSPACE_ID = 'workspace-1'
+    expect(isOpenCodeGoQuotaProvider(provider)).toBe(false)
+
+    delete process.env.OPENCODE_GO_WORKSPACE_ID
+    process.env.OPENCODE_GO_AUTH_COOKIE = 'cookie-1'
+    expect(isOpenCodeGoQuotaProvider(provider)).toBe(false)
+  })
+})
+
+describe('parseOpenCodeGoQuotaHtml', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('normalizes SolidJS hydration usage windows', () => {
+    const windows = parseOpenCodeGoQuotaHtml(`
+      rollingUsage:$R[1]={usagePercent:42.6,resetInSec:3600}
+      weeklyUsage:$R[2]={resetInSec:172800,usagePercent:88}
+      monthlyUsage:$R[3]={usagePercent:101,resetInSec:2592000}
+    `)
+
+    expect(windows).toEqual([
+      {
+        key: 'rolling',
+        label: '5h',
+        utilization: 43,
+        resetsAt: '2026-06-16T13:00:00.000Z',
+        resetDisplay: 'relative',
+      },
+      {
+        key: 'weekly',
+        label: '7d',
+        utilization: 88,
+        resetsAt: '2026-06-18T12:00:00.000Z',
+        resetDisplay: 'absolute',
+      },
+      {
+        key: 'monthly',
+        label: '30d',
+        utilization: 100,
+        resetsAt: '2026-07-16T12:00:00.000Z',
+        resetDisplay: 'absolute',
+      },
+    ])
+  })
+
+  it('falls back to data-slot dashboard markup', () => {
+    const windows = parseOpenCodeGoQuotaHtml(`
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Rolling Usage</span>
+        <span data-slot="usage-value">7%</span>
+        <span data-slot="reset-time">Resets in 1 hour 30 minutes</span>
+      </div>
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Weekly Usage</span>
+        <span data-slot="usage-value">12%</span>
+        <span data-slot="reset-now">Reset now</span>
+      </div>
+    `)
+
+    expect(windows).toEqual([
+      expect.objectContaining({ key: 'rolling', utilization: 7, resetsAt: '2026-06-16T13:30:00.000Z' }),
+      expect.objectContaining({ key: 'weekly', utilization: 12, resetsAt: '2026-06-16T12:00:00.000Z' }),
+    ])
+  })
+})
+
+
+describe('fetchOpenCodeGoQuota', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-16T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scrapes the authenticated workspace dashboard and normalizes windows', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({
+        ok: true,
+        status: 200,
+        text: 'rollingUsage:$R[1]={usagePercent:25,resetInSec:3600}',
+      }),
+    )
+
+    const result = await fetchOpenCodeGoQuota('workspace-1', 'cookie-1', fetchImpl as unknown as typeof fetch)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://opencode.ai/workspace/workspace-1/go',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Cookie: 'auth=cookie-1' }),
+      }),
+    )
+    expect(result.status).toBe(200)
+    expect(result.error).toBeUndefined()
+    expect(result.quota).toEqual({
+      kind: 'opencode-go',
+      plan: 'Go',
+      fetchedAt: '2026-06-16T12:00:00.000Z',
+      windows: [
+        {
+          key: 'rolling',
+          label: '5h',
+          utilization: 25,
+          resetsAt: '2026-06-16T13:00:00.000Z',
+          resetDisplay: 'relative',
+        },
+      ],
+    })
+  })
+
+  it('passes through a pre-formatted auth cookie unchanged', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({ ok: true, status: 200, text: 'rollingUsage:$R[1]={usagePercent:1,resetInSec:60}' }),
+    )
+
+    await fetchOpenCodeGoQuota('ws', 'auth=already-set; other=1', fetchImpl as unknown as typeof fetch)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: expect.objectContaining({ Cookie: 'auth=already-set; other=1' }) }),
+    )
+  })
+
+  it('surfaces an HTTP error with retry-after metadata', async () => {
+    const fetchImpl = vi.fn(async () =>
+      mockResponse({ ok: false, status: 429, headers: { 'retry-after': '30' } }),
+    )
+
+    const result = await fetchOpenCodeGoQuota('ws', 'cookie', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota).toBeNull()
+    expect(result.status).toBe(429)
+    expect(result.retryAfterMs).toBe(30_000)
+    expect(result.error).toBe('HTTP 429')
+  })
+
+  it('reports a parse failure when the dashboard markup yields no windows', async () => {
+    const fetchImpl = vi.fn(async () => mockResponse({ ok: true, status: 200, text: '<html>no usage here</html>' }))
+
+    const result = await fetchOpenCodeGoQuota('ws', 'cookie', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota).toBeNull()
+    expect(result.status).toBe(200)
+    expect(result.error).toMatch(/could not parse/i)
+  })
+
+  it('returns a network error message when the request throws', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('socket hang up')
+    })
+
+    const result = await fetchOpenCodeGoQuota('ws', 'cookie', fetchImpl as unknown as typeof fetch)
+
+    expect(result.quota).toBeNull()
+    expect(result.error).toBe('socket hang up')
+  })
+})

--- a/packages/core/src/opencode-go-quota.ts
+++ b/packages/core/src/opencode-go-quota.ts
@@ -1,0 +1,233 @@
+import type { ProviderConfig } from './provider-config.js'
+import type { ProviderQuotaWindowContract } from './contracts/providers.js'
+import {
+  normalizeUtilization,
+  parseRetryAfterMs,
+  type ProviderQuotaFetchResult,
+  type QuotaProviderAdapter,
+} from './provider-quota.js'
+
+const DASHBOARD_ENDPOINT_PREFIX = 'https://opencode.ai/workspace/'
+const DASHBOARD_ENDPOINT_SUFFIX = '/go'
+const DEFAULT_USER_AGENT = 'axiom-quota/1.0'
+
+const WINDOW_DEFINITIONS = [
+  { key: 'rolling', field: 'rollingUsage', label: '5h', resetDisplay: 'relative' },
+  { key: 'weekly', field: 'weeklyUsage', label: '7d', resetDisplay: 'absolute' },
+  { key: 'monthly', field: 'monthlyUsage', label: '30d', resetDisplay: 'absolute' },
+] as const satisfies ReadonlyArray<{
+  key: string
+  field: string
+  label: string
+  resetDisplay: ProviderQuotaWindowContract['resetDisplay']
+}>
+
+interface OpenCodeGoQuotaCredentials {
+  workspaceId: string
+  authCookie: string
+}
+
+interface RawOpenCodeGoUsageWindow {
+  usagePercent: number
+  resetInSec: number
+}
+
+function envValue(name: string, env: NodeJS.ProcessEnv): string {
+  return env[name]?.trim() ?? ''
+}
+
+export function resolveOpenCodeGoQuotaCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): OpenCodeGoQuotaCredentials | null {
+  const workspaceId = envValue('OPENCODE_GO_WORKSPACE_ID', env)
+  const authCookie = envValue('OPENCODE_GO_AUTH_COOKIE', env)
+  if (!workspaceId || !authCookie) return null
+  return { workspaceId, authCookie }
+}
+
+function hasOpenCodeGoQuotaCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(envValue('OPENCODE_GO_WORKSPACE_ID', env) && envValue('OPENCODE_GO_AUTH_COOKIE', env))
+}
+
+/** OpenCode Go quota is read from the web dashboard, not from the inference API key. */
+export function isOpenCodeGoQuotaProvider(provider: ProviderConfig): boolean {
+  return provider.providerType === 'opencode-go' && hasOpenCodeGoQuotaCredentials()
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseNumberField(text: string, field: string): number | null {
+  const match = new RegExp(`${escapeRegExp(field)}\\s*:\\s*(-?\\d+(?:\\.\\d+)?)`).exec(text)
+  if (!match) return null
+  const value = Number(match[1])
+  return Number.isFinite(value) ? value : null
+}
+
+function parseHydrationWindow(html: string, field: string): RawOpenCodeGoUsageWindow | null {
+  const match = new RegExp(`${escapeRegExp(field)}\\s*:\\s*\\$R\\[\\d+\\]\\s*=\\s*\\{([^}]*)\\}`).exec(html)
+  if (!match) return null
+
+  const usagePercent = parseNumberField(match[1], 'usagePercent')
+  const resetInSec = parseNumberField(match[1], 'resetInSec')
+  if (usagePercent === null || resetInSec === null) return null
+  return { usagePercent, resetInSec }
+}
+
+function parseHumanDurationSeconds(value: string): number | null {
+  const normalized = value.toLowerCase().replace(/\s+/g, ' ').trim()
+  if (['now', 'reset now', 'resets now'].includes(normalized)) return 0
+
+  const units: Array<[RegExp, number]> = [
+    [/(\d+(?:\.\d+)?)\s*days?/, 86_400],
+    [/(\d+(?:\.\d+)?)\s*hours?/, 3_600],
+    [/(\d+(?:\.\d+)?)\s*minutes?/, 60],
+    [/(\d+(?:\.\d+)?)\s*seconds?/, 1],
+  ]
+
+  let seconds = 0
+  let matched = false
+  for (const [regex, multiplier] of units) {
+    const match = regex.exec(normalized)
+    if (!match) continue
+    matched = true
+    seconds += Number(match[1]) * multiplier
+  }
+
+  return matched && Number.isFinite(seconds) ? seconds : null
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<!--\$-->|<!--\/-->/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function parseDataSlotWindows(html: string): Partial<Record<string, RawOpenCodeGoUsageWindow>> {
+  const windows: Partial<Record<string, RawOpenCodeGoUsageWindow>> = {}
+  const items = html.split(/data-slot=["']usage-item["']/)
+
+  for (const item of items.slice(1)) {
+    const labelMatch = /data-slot=["']usage-label["'][^>]*>([\s\S]*?)<\//.exec(item)
+    const valueMatch = /data-slot=["']usage-value["'][^>]*>[\s\S]*?(\d+(?:\.\d+)?)/.exec(item)
+    const resetMatch = /data-slot=["'](reset-time|reset-now)["'][^>]*>([\s\S]*?)<\/span>/.exec(item)
+    if (!labelMatch || !valueMatch || !resetMatch) continue
+
+    const label = stripHtml(labelMatch[1]).toLowerCase()
+    const usagePercent = Number(valueMatch[1])
+    const resetText = stripHtml(resetMatch[2]).replace(/^resets?\s+in\s+/i, '')
+    const resetInSec = resetMatch[1] === 'reset-now' ? 0 : parseHumanDurationSeconds(resetText)
+    if (!Number.isFinite(usagePercent) || resetInSec === null) continue
+
+    const definition = WINDOW_DEFINITIONS.find((candidate) => label.includes(candidate.key))
+    if (definition) windows[definition.key] = { usagePercent, resetInSec }
+  }
+
+  return windows
+}
+
+export function parseOpenCodeGoQuotaHtml(html: string): ProviderQuotaWindowContract[] {
+  const dataSlotWindows = parseDataSlotWindows(html)
+  const now = Date.now()
+
+  return WINDOW_DEFINITIONS.flatMap((definition) => {
+    const raw = parseHydrationWindow(html, definition.field) ?? dataSlotWindows[definition.key]
+    if (!raw) return []
+
+    const resetInSec = Math.max(0, raw.resetInSec)
+    return [{
+      key: definition.key,
+      label: definition.label,
+      utilization: normalizeUtilization(raw.usagePercent),
+      resetsAt: new Date(now + resetInSec * 1000).toISOString(),
+      resetDisplay: definition.resetDisplay,
+    }]
+  })
+}
+
+function openCodeGoDashboardUrl(workspaceId: string): string {
+  return `${DASHBOARD_ENDPOINT_PREFIX}${encodeURIComponent(workspaceId)}${DASHBOARD_ENDPOINT_SUFFIX}`
+}
+
+function cookieHeader(authCookie: string): string {
+  if (/\bauth=/.test(authCookie)) return authCookie
+  return `auth=${authCookie}`
+}
+
+/** Fetch OpenCode Go usage by scraping the authenticated workspace dashboard. */
+export async function fetchOpenCodeGoQuota(
+  workspaceId: string,
+  authCookie: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProviderQuotaFetchResult> {
+  try {
+    const response = await fetchImpl(openCodeGoDashboardUrl(workspaceId), {
+      method: 'GET',
+      headers: {
+        Accept: 'text/html',
+        Cookie: cookieHeader(authCookie),
+        'User-Agent': DEFAULT_USER_AGENT,
+      },
+    })
+
+    if (!response.ok) {
+      return {
+        quota: null,
+        status: response.status,
+        retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
+        error: `HTTP ${response.status}`,
+      }
+    }
+
+    const html = await response.text()
+    const windows = parseOpenCodeGoQuotaHtml(html)
+    if (windows.length === 0) {
+      return {
+        quota: null,
+        status: response.status,
+        error: 'Could not parse OpenCode Go dashboard quota windows',
+      }
+    }
+
+    return {
+      quota: {
+        kind: 'opencode-go',
+        windows,
+        plan: 'Go',
+        fetchedAt: new Date().toISOString(),
+      },
+      status: response.status,
+    }
+  } catch (err) {
+    return { quota: null, error: (err as Error).message || 'Network error' }
+  }
+}
+
+export async function getOpenCodeGoQuotaForProvider(
+  provider: ProviderConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProviderQuotaFetchResult> {
+  if (provider.providerType !== 'opencode-go') {
+    return { quota: null, error: 'Provider is not an OpenCode Go provider' }
+  }
+
+  const workspaceId = envValue('OPENCODE_GO_WORKSPACE_ID', process.env)
+  const authCookie = envValue('OPENCODE_GO_AUTH_COOKIE', process.env)
+  if (!workspaceId || !authCookie) {
+    const missing = !workspaceId ? 'OPENCODE_GO_WORKSPACE_ID' : 'OPENCODE_GO_AUTH_COOKIE'
+    return { quota: null, error: `Missing ${missing}` }
+  }
+
+  return fetchOpenCodeGoQuota(workspaceId, authCookie, fetchImpl)
+}
+
+export const opencodeGoQuotaAdapter: QuotaProviderAdapter = {
+  kind: 'opencode-go',
+  matches: isOpenCodeGoQuotaProvider,
+  fetch: getOpenCodeGoQuotaForProvider,
+}

--- a/packages/core/src/opencode-go-quota.ts
+++ b/packages/core/src/opencode-go-quota.ts
@@ -1,0 +1,233 @@
+import type { ProviderConfig } from './provider-config.js'
+import type { ProviderQuotaWindowContract } from './contracts/providers.js'
+import {
+  normalizeUtilization,
+  parseRetryAfterMs,
+  type ProviderQuotaFetchResult,
+  type QuotaProviderAdapter,
+} from './provider-quota.js'
+
+const DASHBOARD_ENDPOINT_PREFIX = 'https://opencode.ai/workspace/'
+const DASHBOARD_ENDPOINT_SUFFIX = '/go'
+const DEFAULT_USER_AGENT = 'axiom-quota/1.0'
+
+const WINDOW_DEFINITIONS = [
+  { key: 'rolling', field: 'rollingUsage', label: '5h', resetDisplay: 'relative' },
+  { key: 'weekly', field: 'weeklyUsage', label: '7d', resetDisplay: 'absolute' },
+  { key: 'monthly', field: 'monthlyUsage', label: '30d', resetDisplay: 'absolute' },
+] as const satisfies ReadonlyArray<{
+  key: string
+  field: string
+  label: string
+  resetDisplay: ProviderQuotaWindowContract['resetDisplay']
+}>
+
+interface OpenCodeGoQuotaCredentials {
+  workspaceId: string
+  authCookie: string
+}
+
+interface RawOpenCodeGoUsageWindow {
+  usagePercent: number
+  resetInSec: number
+}
+
+function envValue(name: string, env: NodeJS.ProcessEnv): string {
+  return env[name]?.trim() ?? ''
+}
+
+export function resolveOpenCodeGoQuotaCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): OpenCodeGoQuotaCredentials | null {
+  const workspaceId = envValue('OPENCODE_GO_WORKSPACE_ID', env)
+  const authCookie = envValue('OPENCODE_GO_AUTH_COOKIE', env)
+  if (!workspaceId || !authCookie) return null
+  return { workspaceId, authCookie }
+}
+
+function hasOpenCodeGoQuotaCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(envValue('OPENCODE_GO_WORKSPACE_ID', env) || envValue('OPENCODE_GO_AUTH_COOKIE', env))
+}
+
+/** OpenCode Go quota is read from the web dashboard, not from the inference API key. */
+export function isOpenCodeGoQuotaProvider(provider: ProviderConfig): boolean {
+  return provider.providerType === 'opencode-go' && hasOpenCodeGoQuotaCredentials()
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseNumberField(text: string, field: string): number | null {
+  const match = new RegExp(`${escapeRegExp(field)}\\s*:\\s*(-?\\d+(?:\\.\\d+)?)`).exec(text)
+  if (!match) return null
+  const value = Number(match[1])
+  return Number.isFinite(value) ? value : null
+}
+
+function parseHydrationWindow(html: string, field: string): RawOpenCodeGoUsageWindow | null {
+  const match = new RegExp(`${escapeRegExp(field)}\\s*:\\s*\\$R\\[\\d+\\]\\s*=\\s*\\{([^}]*)\\}`).exec(html)
+  if (!match) return null
+
+  const usagePercent = parseNumberField(match[1], 'usagePercent')
+  const resetInSec = parseNumberField(match[1], 'resetInSec')
+  if (usagePercent === null || resetInSec === null) return null
+  return { usagePercent, resetInSec }
+}
+
+function parseHumanDurationSeconds(value: string): number | null {
+  const normalized = value.toLowerCase().replace(/\s+/g, ' ').trim()
+  if (['now', 'reset now', 'resets now'].includes(normalized)) return 0
+
+  const units: Array<[RegExp, number]> = [
+    [/(\d+(?:\.\d+)?)\s*days?/, 86_400],
+    [/(\d+(?:\.\d+)?)\s*hours?/, 3_600],
+    [/(\d+(?:\.\d+)?)\s*minutes?/, 60],
+    [/(\d+(?:\.\d+)?)\s*seconds?/, 1],
+  ]
+
+  let seconds = 0
+  let matched = false
+  for (const [regex, multiplier] of units) {
+    const match = regex.exec(normalized)
+    if (!match) continue
+    matched = true
+    seconds += Number(match[1]) * multiplier
+  }
+
+  return matched && Number.isFinite(seconds) ? seconds : null
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<!--\$-->|<!--\/-->/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function parseDataSlotWindows(html: string): Partial<Record<string, RawOpenCodeGoUsageWindow>> {
+  const windows: Partial<Record<string, RawOpenCodeGoUsageWindow>> = {}
+  const items = html.split(/data-slot=["']usage-item["']/)
+
+  for (const item of items.slice(1)) {
+    const labelMatch = /data-slot=["']usage-label["'][^>]*>([\s\S]*?)<\//.exec(item)
+    const valueMatch = /data-slot=["']usage-value["'][^>]*>[\s\S]*?(\d+(?:\.\d+)?)/.exec(item)
+    const resetMatch = /data-slot=["'](reset-time|reset-now)["'][^>]*>([\s\S]*?)<\/span>/.exec(item)
+    if (!labelMatch || !valueMatch || !resetMatch) continue
+
+    const label = stripHtml(labelMatch[1]).toLowerCase()
+    const usagePercent = Number(valueMatch[1])
+    const resetText = stripHtml(resetMatch[2]).replace(/^resets?\s+in\s+/i, '')
+    const resetInSec = resetMatch[1] === 'reset-now' ? 0 : parseHumanDurationSeconds(resetText)
+    if (!Number.isFinite(usagePercent) || resetInSec === null) continue
+
+    const definition = WINDOW_DEFINITIONS.find((candidate) => label.includes(candidate.key))
+    if (definition) windows[definition.key] = { usagePercent, resetInSec }
+  }
+
+  return windows
+}
+
+export function parseOpenCodeGoQuotaHtml(html: string): ProviderQuotaWindowContract[] {
+  const dataSlotWindows = parseDataSlotWindows(html)
+  const now = Date.now()
+
+  return WINDOW_DEFINITIONS.flatMap((definition) => {
+    const raw = parseHydrationWindow(html, definition.field) ?? dataSlotWindows[definition.key]
+    if (!raw) return []
+
+    const resetInSec = Math.max(0, raw.resetInSec)
+    return [{
+      key: definition.key,
+      label: definition.label,
+      utilization: normalizeUtilization(raw.usagePercent),
+      resetsAt: new Date(now + resetInSec * 1000).toISOString(),
+      resetDisplay: definition.resetDisplay,
+    }]
+  })
+}
+
+function openCodeGoDashboardUrl(workspaceId: string): string {
+  return `${DASHBOARD_ENDPOINT_PREFIX}${encodeURIComponent(workspaceId)}${DASHBOARD_ENDPOINT_SUFFIX}`
+}
+
+function cookieHeader(authCookie: string): string {
+  if (/\bauth=/.test(authCookie)) return authCookie
+  return `auth=${authCookie}`
+}
+
+/** Fetch OpenCode Go usage by scraping the authenticated workspace dashboard. */
+export async function fetchOpenCodeGoQuota(
+  workspaceId: string,
+  authCookie: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProviderQuotaFetchResult> {
+  try {
+    const response = await fetchImpl(openCodeGoDashboardUrl(workspaceId), {
+      method: 'GET',
+      headers: {
+        Accept: 'text/html',
+        Cookie: cookieHeader(authCookie),
+        'User-Agent': DEFAULT_USER_AGENT,
+      },
+    })
+
+    if (!response.ok) {
+      return {
+        quota: null,
+        status: response.status,
+        retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after')),
+        error: `HTTP ${response.status}`,
+      }
+    }
+
+    const html = await response.text()
+    const windows = parseOpenCodeGoQuotaHtml(html)
+    if (windows.length === 0) {
+      return {
+        quota: null,
+        status: response.status,
+        error: 'Could not parse OpenCode Go dashboard quota windows',
+      }
+    }
+
+    return {
+      quota: {
+        kind: 'opencode-go',
+        windows,
+        plan: 'Go',
+        fetchedAt: new Date().toISOString(),
+      },
+      status: response.status,
+    }
+  } catch (err) {
+    return { quota: null, error: (err as Error).message || 'Network error' }
+  }
+}
+
+export async function getOpenCodeGoQuotaForProvider(
+  provider: ProviderConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProviderQuotaFetchResult> {
+  if (provider.providerType !== 'opencode-go') {
+    return { quota: null, error: 'Provider is not an OpenCode Go provider' }
+  }
+
+  const workspaceId = envValue('OPENCODE_GO_WORKSPACE_ID', process.env)
+  const authCookie = envValue('OPENCODE_GO_AUTH_COOKIE', process.env)
+  if (!workspaceId || !authCookie) {
+    const missing = !workspaceId ? 'OPENCODE_GO_WORKSPACE_ID' : 'OPENCODE_GO_AUTH_COOKIE'
+    return { quota: null, error: `Missing ${missing}` }
+  }
+
+  return fetchOpenCodeGoQuota(workspaceId, authCookie, fetchImpl)
+}
+
+export const opencodeGoQuotaAdapter: QuotaProviderAdapter = {
+  kind: 'opencode-go',
+  matches: isOpenCodeGoQuotaProvider,
+  fetch: getOpenCodeGoQuotaForProvider,
+}

--- a/packages/core/src/opencode-go-quota.ts
+++ b/packages/core/src/opencode-go-quota.ts
@@ -27,31 +27,32 @@ interface OpenCodeGoQuotaCredentials {
   authCookie: string
 }
 
+/** Keys of the OpenCode Go preset's `extraFields` that hold quota credentials. */
+const WORKSPACE_ID_FIELD = 'workspaceId'
+const AUTH_COOKIE_FIELD = 'authCookie'
+
 interface RawOpenCodeGoUsageWindow {
   usagePercent: number
   resetInSec: number
 }
 
-function envValue(name: string, env: NodeJS.ProcessEnv): string {
-  return env[name]?.trim() ?? ''
-}
-
+/**
+ * Resolve dashboard credentials from the provider's `extraFields`. Expects the
+ * decrypted record (the auth cookie is encrypted at rest). Returns `null` when
+ * either credential is missing.
+ */
 export function resolveOpenCodeGoQuotaCredentials(
-  env: NodeJS.ProcessEnv = process.env,
+  provider: ProviderConfig,
 ): OpenCodeGoQuotaCredentials | null {
-  const workspaceId = envValue('OPENCODE_GO_WORKSPACE_ID', env)
-  const authCookie = envValue('OPENCODE_GO_AUTH_COOKIE', env)
+  const workspaceId = provider.extraFields?.[WORKSPACE_ID_FIELD]?.trim() ?? ''
+  const authCookie = provider.extraFields?.[AUTH_COOKIE_FIELD]?.trim() ?? ''
   if (!workspaceId || !authCookie) return null
   return { workspaceId, authCookie }
 }
 
-function hasOpenCodeGoQuotaCredentials(env: NodeJS.ProcessEnv = process.env): boolean {
-  return Boolean(envValue('OPENCODE_GO_WORKSPACE_ID', env) || envValue('OPENCODE_GO_AUTH_COOKIE', env))
-}
-
 /** OpenCode Go quota is read from the web dashboard, not from the inference API key. */
 export function isOpenCodeGoQuotaProvider(provider: ProviderConfig): boolean {
-  return provider.providerType === 'opencode-go' && hasOpenCodeGoQuotaCredentials()
+  return provider.providerType === 'opencode-go' && resolveOpenCodeGoQuotaCredentials(provider) !== null
 }
 
 function escapeRegExp(value: string): string {
@@ -216,14 +217,15 @@ export async function getOpenCodeGoQuotaForProvider(
     return { quota: null, error: 'Provider is not an OpenCode Go provider' }
   }
 
-  const workspaceId = envValue('OPENCODE_GO_WORKSPACE_ID', process.env)
-  const authCookie = envValue('OPENCODE_GO_AUTH_COOKIE', process.env)
-  if (!workspaceId || !authCookie) {
-    const missing = !workspaceId ? 'OPENCODE_GO_WORKSPACE_ID' : 'OPENCODE_GO_AUTH_COOKIE'
-    return { quota: null, error: `Missing ${missing}` }
+  const credentials = resolveOpenCodeGoQuotaCredentials(provider)
+  if (!credentials) {
+    return {
+      quota: null,
+      error: 'Missing OpenCode Go Workspace ID / Dashboard Auth Cookie. Configure them on the provider.',
+    }
   }
 
-  return fetchOpenCodeGoQuota(workspaceId, authCookie, fetchImpl)
+  return fetchOpenCodeGoQuota(credentials.workspaceId, credentials.authCookie, fetchImpl)
 }
 
 export const opencodeGoQuotaAdapter: QuotaProviderAdapter = {

--- a/packages/core/src/provider-config.test.ts
+++ b/packages/core/src/provider-config.test.ts
@@ -735,6 +735,53 @@ describe('provider CRUD', () => {
     expect(masked.providers[0].apiKeyMasked).not.toContain('sk-test1234567890')
   })
 
+  it('stores provider extra fields generically and masks secret entries', () => {
+    setupEmpty()
+    const created = addProvider({
+      name: 'OpenCode Go',
+      providerType: 'opencode-go',
+      apiKey: 'oc-key',
+      defaultModel: 'glm-5.1',
+      extraFields: {
+        workspaceId: ' workspace-1 ',
+        authCookie: ' auth-cookie-1 ',
+        unknown: 'ignored',
+      },
+    })
+
+    const stored = loadProviders().providers.find(p => p.id === created.id)!
+    expect(stored.extraFields).toEqual({
+      workspaceId: 'workspace-1',
+      authCookie: expect.any(String),
+    })
+    expect(stored.extraFields!.authCookie).not.toBe('auth-cookie-1')
+    expect(decrypt(stored.extraFields!.authCookie)).toBe('auth-cookie-1')
+
+    const decrypted = loadProvidersDecrypted().providers.find(p => p.id === created.id)!
+    expect(decrypted.extraFields).toEqual({ workspaceId: 'workspace-1', authCookie: 'auth-cookie-1' })
+
+    const masked = loadProvidersMasked().providers.find(p => p.id === created.id)!
+    expect(masked.extraFields).toEqual({ workspaceId: 'workspace-1' })
+    expect(masked.extraFieldsSet).toEqual({ authCookie: true })
+  })
+
+  it('keeps secret extra fields on blank update and clears blank non-secret fields', () => {
+    setupEmpty()
+    const created = addProvider({
+      name: 'OpenCode Go',
+      providerType: 'opencode-go',
+      apiKey: 'oc-key',
+      defaultModel: 'glm-5.1',
+      extraFields: { workspaceId: 'workspace-1', authCookie: 'auth-cookie-1' },
+    })
+
+    updateProvider(created.id, { extraFields: { workspaceId: '', authCookie: '' } })
+    expect(loadProvidersDecrypted().providers[0]!.extraFields).toEqual({ authCookie: 'auth-cookie-1' })
+
+    updateProvider(created.id, { extraFields: { authCookie: 'auth-cookie-2' } })
+    expect(loadProvidersDecrypted().providers[0]!.extraFields).toEqual({ authCookie: 'auth-cookie-2' })
+  })
+
   it('setFallbackProvider sets the fallback provider', () => {
     setupEmpty()
     addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })
@@ -1044,5 +1091,80 @@ describe('getAvailableModels', () => {
     expect(model.cost.cacheRead).toBe(0.15)
     expect(model.api).toBe('openai-completions')
     expect(model.baseUrl).toBe('https://api.moonshot.ai/v1')
+  })
+})
+
+describe('OpenCode Zen/Go catalog presets (sourced from pi-ai)', () => {
+  const makeProvider = (providerType: 'opencode-go' | 'opencode-zen', defaultModel: string) => ({
+    id: 'test-id',
+    name: providerType,
+    type: 'openai-completions',
+    providerType,
+    provider: providerType === 'opencode-zen' ? 'opencode' : 'opencode-go',
+    baseUrl: PROVIDER_TYPE_PRESETS[providerType].baseUrl,
+    apiKey: 'sk-test',
+    defaultModel,
+  })
+
+  it('groups OpenCode Go under Subscription (api-key auth, subscription flag) but not Zen', () => {
+    expect(PROVIDER_TYPE_PRESETS['opencode-go'].subscription).toBe(true)
+    expect(PROVIDER_TYPE_PRESETS['opencode-go'].authMethod).toBe('api-key')
+    expect(PROVIDER_TYPE_PRESETS['opencode-zen'].subscription).toBeUndefined()
+  })
+
+  it('getAvailableModels resolves the OpenCode Go catalog from pi-ai', () => {
+    const ids = getAvailableModels('opencode-go').map(m => m.id)
+    expect(ids.length).toBeGreaterThan(0)
+    expect(ids).toContain('glm-5.1')
+    expect(ids).toContain('kimi-k2.6')
+  })
+
+  it('getAvailableModels resolves the OpenCode Zen catalog from pi-ai', () => {
+    const ids = getAvailableModels('opencode-zen').map(m => m.id)
+    expect(ids.length).toBeGreaterThan(0)
+    expect(ids).toContain('claude-opus-4-5')
+    expect(ids).toContain('gemini-3.5-flash')
+    expect(ids).toContain('gpt-5.5')
+  })
+
+  it('buildModel uses real per-token costs for OpenCode Go (not the old zeroed override)', () => {
+    const model = buildModel(makeProvider('opencode-go', 'glm-5.1'))
+    expect(model.id).toBe('glm-5.1')
+    expect(model.api).toBe('openai-completions')
+    expect(model.baseUrl).toBe('https://opencode.ai/zen/go/v1')
+    expect(model.cost.input).toBeGreaterThan(0)
+    expect(model.cost.output).toBeGreaterThan(0)
+  })
+
+  it('buildModel resolves per-model api + baseUrl for OpenCode Zen models across wire APIs', () => {
+    const claude = buildModel(makeProvider('opencode-zen', 'claude-opus-4-5'))
+    expect(claude.api).toBe('anthropic-messages')
+    expect(claude.baseUrl).toContain('opencode.ai/zen')
+    expect(claude.cost.input).toBeGreaterThan(0)
+
+    const gemini = buildModel(makeProvider('opencode-zen', 'gemini-3.5-flash'))
+    expect(gemini.api).toBe('google-generative-ai')
+
+    const gpt = buildModel(makeProvider('opencode-zen', 'gpt-5.5'))
+    expect(gpt.api).toBe('openai-responses')
+
+    const glm = buildModel(makeProvider('opencode-zen', 'glm-5.1'))
+    expect(glm.api).toBe('openai-completions')
+  })
+
+  it('does not change api-key providers without resolveModelsFromCatalog (openai stays single-api)', () => {
+    const provider = {
+      id: 'test-id',
+      name: 'openai',
+      type: 'openai-completions',
+      providerType: 'openai' as const,
+      provider: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+      defaultModel: 'gpt-4o',
+    }
+    const model = buildModel(provider)
+    expect(model.api).toBe('openai-completions')
+    expect(model.baseUrl).toBe('https://api.openai.com/v1')
   })
 })

--- a/packages/core/src/provider-config.test.ts
+++ b/packages/core/src/provider-config.test.ts
@@ -782,6 +782,53 @@ describe('provider CRUD', () => {
     expect(loadProvidersDecrypted().providers[0]!.extraFields).toEqual({ authCookie: 'auth-cookie-2' })
   })
 
+  it('clears provider extra fields when provider type changes', () => {
+    setupEmpty()
+    const created = addProvider({
+      name: 'OpenCode Go',
+      providerType: 'opencode-go',
+      apiKey: 'oc-key',
+      defaultModel: 'glm-5.1',
+      extraFields: { workspaceId: 'workspace-1', authCookie: 'auth-cookie-1' },
+    })
+
+    updateProvider(created.id, { providerType: 'openai', defaultModel: 'gpt-4o', enabledModels: ['gpt-4o'] })
+
+    const stored = loadProviders().providers.find(p => p.id === created.id)!
+    expect(stored.extraFields).toBeUndefined()
+
+    const masked = loadProvidersMasked().providers.find(p => p.id === created.id)!
+    expect(masked.extraFields).toEqual({})
+    expect(masked.extraFieldsSet).toEqual({})
+  })
+
+  it('omits stale unknown extra fields from masked providers', () => {
+    setupEmpty()
+    fs.writeFileSync(
+      path.join(tmpDir, 'config', 'providers.json'),
+      JSON.stringify({
+        providers: [{
+          id: 'stale-openai',
+          name: 'Stale OpenAI',
+          type: 'openai-completions',
+          providerType: 'openai',
+          provider: 'openai',
+          baseUrl: 'https://api.openai.com/v1',
+          apiKey: encrypt('sk-test'),
+          defaultModel: 'gpt-4o',
+          extraFields: { workspaceId: 'workspace-1', authCookie: encrypt('auth-cookie-1') },
+          status: 'untested',
+          authMethod: 'api-key',
+        }],
+      }, null, 2),
+      'utf-8',
+    )
+
+    const masked = loadProvidersMasked().providers[0]!
+    expect(masked.extraFields).toEqual({})
+    expect(masked.extraFieldsSet).toEqual({})
+  })
+
   it('setFallbackProvider sets the fallback provider', () => {
     setupEmpty()
     addProvider({ name: 'primary', providerType: 'openai', apiKey: 'sk-1', defaultModel: 'gpt-4o' })

--- a/packages/core/src/provider-config.test.ts
+++ b/packages/core/src/provider-config.test.ts
@@ -1054,6 +1054,13 @@ describe('getAvailableModels', () => {
     expect(resolveModelTemperature(provider, 'some-other-model', 0.7)).toBe(0.7)
   })
 
+  it('resolveModelTemperature applies pi-ai catalog Kimi K2 constraints for OpenCode presets', () => {
+    expect(resolveModelTemperature({ providerType: 'opencode-go' as const }, 'kimi-k2.7-code', 0)).toBe(1)
+    expect(resolveModelTemperature({ providerType: 'opencode-go' as const }, 'kimi-k2.6', 0)).toBe(1)
+    expect(resolveModelTemperature({ providerType: 'opencode-zen' as const }, 'kimi-k2.5', 0)).toBe(1)
+    expect(resolveModelTemperature({ providerType: 'opencode-go' as const }, 'glm-5.1', 0)).toBe(0)
+  })
+
   it('presetSupportsTextVerbosity is true only for openai-codex-responses presets', () => {
     expect(presetSupportsTextVerbosity('openai-codex')).toBe(true)
     expect(presetSupportsTextVerbosity('openai')).toBe(false)

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -18,7 +18,7 @@ export const CLAUDE_CODE_VERSION = '2.1.96'
  * Supported provider types with presets
  */
 export type ProviderType =
-  | 'openai' | 'anthropic' | 'mistral' | 'ollama' | 'openrouter' | 'deepseek' | 'kimi' | 'minimax' | 'zai' | 'xai' | 'opencode-go' | 'openai-compatible' | 'google'
+  | 'openai' | 'anthropic' | 'mistral' | 'ollama' | 'openrouter' | 'deepseek' | 'kimi' | 'minimax' | 'zai' | 'xai' | 'opencode-go' | 'opencode-zen' | 'openai-compatible' | 'google'
   // Legacy aliases kept for migration
   | 'ollama-local' | 'ollama-cloud'
   | 'openai-codex' | 'github-copilot' | 'anthropic-oauth'
@@ -39,11 +39,52 @@ export interface ProviderTypePreset {
   piAiProvider: string | null // maps to pi-ai KnownProvider for model lookup
   authMethod: AuthMethod
   oauthProviderId?: string // pi-ai OAuth provider ID
+  /**
+   * Provider-specific extra configuration fields beyond the common ones
+   * (name/apiKey/baseUrl/models). Declared per preset so new providers can
+   * add bespoke inputs (e.g. OpenCode Go's quota-dashboard credentials)
+   * without growing `ProviderConfig` with provider-specific properties. The
+   * values are stored in `ProviderConfig.extraFields`; fields marked `secret`
+   * are encrypted at rest and never returned to the client.
+   */
+  extraFields?: ProviderExtraFieldDef[]
+  /**
+   * When true, `buildModel()` returns the pi-ai catalog model verbatim
+   * (per-model `api`, `baseUrl`, cost, limits) instead of the generic build
+   * that pins every model to the preset's single `apiType`. Required for
+   * gateways like OpenCode Zen/Go whose models span multiple wire APIs
+   * (openai-completions, anthropic-messages, google, responses) under one
+   * provider entry.
+   */
+  resolveModelsFromCatalog?: boolean
+  /**
+   * Display-only hint: group this preset under "Subscription / OAuth" in the
+   * UI even though it authenticates with an API key (e.g. OpenCode Go is a
+   * flat-fee subscription that issues an API key rather than using OAuth).
+   * Does not affect the auth flow — `authMethod` still drives that.
+   */
+  subscription?: boolean
 }
 
 export interface AvailableModel {
   id: string
   name: string
+}
+
+/**
+ * Declarative definition of one provider-specific extra configuration field.
+ * Rendered generically by the UI and persisted into `ProviderConfig.extraFields`.
+ */
+export interface ProviderExtraFieldDef {
+  /** Stable key within the provider type (also the storage key). */
+  key: string
+  /** Default English label (UIs may localize via an i18n override). */
+  label: string
+  /** Encrypt at rest and never return the value to the client. */
+  secret?: boolean
+  required?: boolean
+  placeholder?: string
+  hint?: string
 }
 
 export const PROVIDER_TYPE_PRESETS: Record<ProviderType, ProviderTypePreset> = {
@@ -189,8 +230,37 @@ export const PROVIDER_TYPE_PRESETS: Record<ProviderType, ProviderTypePreset> = {
     baseUrl: 'https://opencode.ai/zen/go/v1',
     requiresApiKey: true,
     urlEditable: false,
-    piAiProvider: null,
+    piAiProvider: 'opencode-go',
     authMethod: 'api-key',
+    resolveModelsFromCatalog: true,
+    subscription: true,
+    extraFields: [
+      {
+        key: 'workspaceId',
+        label: 'Workspace ID',
+        placeholder: 'e.g. 0a1b2c3d',
+        hint: 'From your dashboard URL: opencode.ai/workspace/[id]/go',
+      },
+      {
+        key: 'authCookie',
+        label: 'Dashboard Auth Cookie',
+        secret: true,
+        hint: 'The authenticated dashboard cookie (the `auth=` prefix is optional). Used only to read your usage quota.',
+      },
+    ],
+  },
+  'opencode-zen': {
+    type: 'opencode-zen',
+    label: 'OpenCode Zen',
+    description: 'Pay-as-you-go AI gateway by the OpenCode team',
+    apiType: 'openai-completions',
+    providerName: 'opencode',
+    baseUrl: 'https://opencode.ai/zen/v1',
+    requiresApiKey: true,
+    urlEditable: false,
+    piAiProvider: 'opencode',
+    authMethod: 'api-key',
+    resolveModelsFromCatalog: true,
   },
   'openai-compatible': {
     type: 'openai-compatible',
@@ -266,30 +336,6 @@ export const PROVIDER_TYPE_PRESETS: Record<ProviderType, ProviderTypePreset> = {
  * Keep this list in sync with the upstream provider's published catalog.
  */
 export const PROVIDER_TYPE_MODEL_OVERRIDES: Partial<Record<ProviderType, ProviderModelConfig[]>> = {
-  // OpenCode Go — subscription plan by the OpenCode team ($5 first month, $10/month)
-  // OpenAI-compatible endpoint: https://opencode.ai/zen/go/v1/chat/completions
-  // MiniMax M2.x use the Anthropic-compatible endpoint and are intentionally excluded here;
-  // they require a separate provider entry with apiType 'anthropic-messages'.
-  // Pricing is subscription-based (flat fee), so per-token costs are set to 0.
-  // Model IDs confirmed from https://opencode.ai/docs/go/ (April 2026).
-  'opencode-go': [
-    { id: 'glm-5.1', name: 'GLM-5.1', contextWindow: 131_072, maxTokens: 16_384, reasoning: true,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-    { id: 'glm-5', name: 'GLM-5', contextWindow: 131_072, maxTokens: 16_384, reasoning: false,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-    { id: 'kimi-k2.6', name: 'Kimi K2.6', contextWindow: 262_144, maxTokens: 32_768, reasoning: true,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-    { id: 'kimi-k2.5', name: 'Kimi K2.5', contextWindow: 262_144, maxTokens: 32_768, reasoning: true,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-    { id: 'mimo-v2-pro', name: 'MiMo-V2-Pro', contextWindow: 131_072, maxTokens: 16_384, reasoning: true,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-    { id: 'mimo-v2-omni', name: 'MiMo-V2-Omni', contextWindow: 131_072, maxTokens: 16_384, reasoning: false,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-    { id: 'qwen3.6-plus', name: 'Qwen3.6 Plus', contextWindow: 131_072, maxTokens: 16_384, reasoning: true,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-    { id: 'qwen3.5-plus', name: 'Qwen3.5 Plus', contextWindow: 131_072, maxTokens: 16_384, reasoning: false,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
-  ],
   // Moonshot Platform API (https://platform.moonshot.ai)
   // Confirmed via GET https://api.moonshot.ai/v1/models and official pricing docs.
   kimi: [
@@ -500,6 +546,11 @@ export interface ProviderConfig {
   modelStatuses?: Record<string, 'connected' | 'error' | 'untested'>
   authMethod?: AuthMethod
   oauthCredentials?: OAuthCredentialsStored // encrypted at rest
+  /**
+   * Provider-specific extra field values (see `ProviderTypePreset.extraFields`).
+   * Values for fields declared `secret` are encrypted at rest.
+   */
+  extraFields?: Record<string, string>
 }
 
 /**
@@ -560,6 +611,110 @@ export const DEFAULT_PRICE_TABLE: TokenPriceTable = {
 }
 
 /**
+ * Extra-field definitions declared by a provider type's preset (empty when none).
+ */
+export function getProviderExtraFieldDefs(providerType: ProviderType | string): ProviderExtraFieldDef[] {
+  return PROVIDER_TYPE_PRESETS[providerType as ProviderType]?.extraFields ?? []
+}
+
+function secretExtraFieldKeys(providerType: ProviderType | string): Set<string> {
+  return new Set(getProviderExtraFieldDefs(providerType).filter(f => f.secret).map(f => f.key))
+}
+
+/**
+ * Decrypt the secret entries of a stored `extraFields` record, leaving
+ * non-secret values untouched. Returns `undefined`/the input as-is when empty.
+ */
+function decryptExtraFields(
+  providerType: ProviderType | string,
+  extraFields: Record<string, string> | undefined,
+  providerName: string,
+): Record<string, string> | undefined {
+  if (!extraFields) return extraFields
+  const secrets = secretExtraFieldKeys(providerType)
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(extraFields)) {
+    out[key] = secrets.has(key)
+      ? (tryDecryptField(value, `extra field "${key}" for provider "${providerName}"`) ?? value)
+      : value
+  }
+  return out
+}
+
+/**
+ * Encrypt + sanitize an incoming `extraFields` record for storage: drops empty
+ * values and unknown keys, encrypts fields declared `secret`. Returns
+ * `undefined` when nothing remains.
+ */
+function sanitizeExtraFieldsForStorage(
+  providerType: ProviderType | string,
+  extraFields: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!extraFields) return undefined
+  const defs = getProviderExtraFieldDefs(providerType)
+  const knownKeys = new Set(defs.map(f => f.key))
+  const secrets = new Set(defs.filter(f => f.secret).map(f => f.key))
+  const out: Record<string, string> = {}
+  for (const [key, raw] of Object.entries(extraFields)) {
+    if (!knownKeys.has(key)) continue
+    const trimmed = (raw ?? '').trim()
+    if (!trimmed) continue
+    out[key] = secrets.has(key) ? encrypt(trimmed) : trimmed
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+/**
+ * Merge incoming extra-field edits into the currently-stored record. Secret
+ * fields left blank keep their existing (encrypted) value; non-secret fields
+ * set to blank are cleared. Unknown keys are pruned.
+ */
+function mergeExtraFieldsForUpdate(
+  providerType: ProviderType | string,
+  current: Record<string, string> | undefined,
+  incoming: Record<string, string>,
+): Record<string, string> | undefined {
+  const defs = getProviderExtraFieldDefs(providerType)
+  const knownKeys = new Set(defs.map(f => f.key))
+  const secrets = new Set(defs.filter(f => f.secret).map(f => f.key))
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(current ?? {})) {
+    if (knownKeys.has(key)) out[key] = value
+  }
+  for (const [key, raw] of Object.entries(incoming)) {
+    if (!knownKeys.has(key)) continue
+    const trimmed = (raw ?? '').trim()
+    if (secrets.has(key)) {
+      if (trimmed) out[key] = encrypt(trimmed)
+    } else if (trimmed) {
+      out[key] = trimmed
+    } else {
+      delete out[key]
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+/**
+ * Produce a client-safe view of a provider's extra fields: non-secret values
+ * pass through, secret values are omitted and reported as a presence boolean
+ * in `extraFieldsSet`. Expects the decrypted record.
+ */
+export function maskProviderExtraFields(
+  providerType: ProviderType | string,
+  extraFields: Record<string, string> | undefined,
+): { extraFields: Record<string, string>; extraFieldsSet: Record<string, boolean> } {
+  const secrets = secretExtraFieldKeys(providerType)
+  const masked: Record<string, string> = {}
+  const set: Record<string, boolean> = {}
+  for (const [key, value] of Object.entries(extraFields ?? {})) {
+    if (secrets.has(key)) set[key] = Boolean(value)
+    else masked[key] = value
+  }
+  return { extraFields: masked, extraFieldsSet: set }
+}
+
+/**
  * Load providers.json from config directory
  */
 export function loadProviders(): ProvidersFile {
@@ -617,6 +772,7 @@ export function loadProvidersDecrypted(): ProvidersFile {
       const baseUrl = (preset && !preset.urlEditable) ? preset.baseUrl : p.baseUrl
 
       const decryptedApiKey = tryDecryptField(p.apiKey, `API key for provider "${p.name}"`) ?? p.apiKey
+      const decryptedExtraFields = decryptExtraFields(p.providerType, p.extraFields, p.name)
 
       let decryptedOAuth: OAuthCredentialsStored | undefined
       if (p.oauthCredentials) {
@@ -632,6 +788,7 @@ export function loadProvidersDecrypted(): ProvidersFile {
         ...p,
         baseUrl,
         apiKey: decryptedApiKey,
+        extraFields: decryptedExtraFields,
         oauthCredentials: decryptedOAuth,
       }
     }),
@@ -641,16 +798,30 @@ export function loadProvidersDecrypted(): ProvidersFile {
 /**
  * Get providers with API keys masked for display
  */
-export function loadProvidersMasked(): ProvidersFile & { providers: (ProviderConfig & { apiKeyMasked: string })[] } {
+export type MaskedProviderConfig = ProviderConfig & {
+  apiKeyMasked: string
+  extraFieldsSet: Record<string, boolean>
+}
+
+export type MaskedProvidersFile = Omit<ProvidersFile, 'providers'> & {
+  providers: MaskedProviderConfig[]
+}
+
+export function loadProvidersMasked(): MaskedProvidersFile {
   const file = loadProvidersDecrypted() // Already syncs URLs from presets
   return {
     ...file,
-    providers: file.providers.map(p => ({
-      ...p,
-      apiKey: '', // Never send real key to frontend
-      apiKeyMasked: p.apiKey ? maskApiKey(p.apiKey) : '',
-      oauthCredentials: p.oauthCredentials ? { refresh: '', access: '', expires: p.oauthCredentials.expires } : undefined,
-    })),
+    providers: file.providers.map(p => {
+      const { extraFields, extraFieldsSet } = maskProviderExtraFields(p.providerType, p.extraFields)
+      return {
+        ...p,
+        apiKey: '', // Never send real key to frontend
+        apiKeyMasked: p.apiKey ? maskApiKey(p.apiKey) : '',
+        extraFields,
+        extraFieldsSet,
+        oauthCredentials: p.oauthCredentials ? { refresh: '', access: '', expires: p.oauthCredentials.expires } : undefined,
+      }
+    }),
   }
 }
 
@@ -738,6 +909,7 @@ export function addProvider(input: {
   degradedThresholdMs?: number
   textVerbosity?: TextVerbosity
   transport?: ProviderTransport
+  extraFields?: Record<string, string>
 }): ProviderConfig {
   const preset = PROVIDER_TYPE_PRESETS[input.providerType]
   if (!preset) {
@@ -773,6 +945,10 @@ export function addProvider(input: {
       && { textVerbosity: input.textVerbosity }),
     ...(input.transport && input.transport !== 'sse' && presetSupportsTransport(input.providerType)
       && { transport: input.transport }),
+    ...((() => {
+      const extra = sanitizeExtraFieldsForStorage(input.providerType, input.extraFields)
+      return extra ? { extraFields: extra } : {}
+    })()),
     status: 'untested',
     authMethod: preset.authMethod,
   }
@@ -868,6 +1044,7 @@ export function updateProvider(id: string, input: {
   degradedThresholdMs?: number
   textVerbosity?: TextVerbosity | null
   transport?: ProviderTransport | null
+  extraFields?: Record<string, string>
 }): ProviderConfig {
   const file = loadProviders()
   const index = file.providers.findIndex(p => p.id === id)
@@ -909,6 +1086,9 @@ export function updateProvider(id: string, input: {
       : [dm, ...input.enabledModels]
   }
   if (input.degradedThresholdMs !== undefined) existing.degradedThresholdMs = input.degradedThresholdMs
+  if (input.extraFields !== undefined) {
+    existing.extraFields = mergeExtraFieldsForUpdate(existing.providerType, existing.extraFields, input.extraFields)
+  }
   if (input.textVerbosity !== undefined) {
     if (input.textVerbosity === null || !presetSupportsTextVerbosity(existing.providerType)) {
       // Either the caller explicitly cleared the value or the (possibly
@@ -1201,8 +1381,10 @@ export function buildModel(provider: ProviderConfig, modelId?: string): Model<Ap
   const id = modelId ?? provider.defaultModel
   const preset = PROVIDER_TYPE_PRESETS[provider.providerType]
 
-  // For OAuth providers, look up the model from pi-ai to get correct api type and metadata
-  if (preset?.authMethod === 'oauth' && preset.piAiProvider) {
+  // Look up the model from pi-ai to get the correct per-model api type and
+  // metadata. This path covers OAuth providers as well as api-key gateways
+  // (OpenCode Zen/Go) whose catalog spans multiple wire APIs under one entry.
+  if (preset?.piAiProvider && (preset.authMethod === 'oauth' || preset.resolveModelsFromCatalog)) {
     try {
       const piAiModels = getPiAiModels(preset.piAiProvider as KnownProvider)
 

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -724,10 +724,13 @@ export function maskProviderExtraFields(
   providerType: ProviderType | string,
   extraFields: Record<string, string> | undefined,
 ): { extraFields: Record<string, string>; extraFieldsSet: Record<string, boolean> } {
-  const secrets = secretExtraFieldKeys(providerType)
+  const defs = getProviderExtraFieldDefs(providerType)
+  const knownKeys = new Set(defs.map(f => f.key))
+  const secrets = new Set(defs.filter(f => f.secret).map(f => f.key))
   const masked: Record<string, string> = {}
   const set: Record<string, boolean> = {}
   for (const [key, value] of Object.entries(extraFields ?? {})) {
+    if (!knownKeys.has(key)) continue
     if (secrets.has(key)) set[key] = Boolean(value)
     else masked[key] = value
   }
@@ -1079,8 +1082,10 @@ export function updateProvider(id: string, input: {
     throw new Error(`Provider with name "${input.name}" already exists`)
   }
 
+  const providerTypeChanged = Boolean(input.providerType && input.providerType !== existing.providerType)
+
   // If providerType is being changed, update derived fields
-  if (input.providerType && input.providerType !== existing.providerType) {
+  if (providerTypeChanged && input.providerType) {
     const preset = PROVIDER_TYPE_PRESETS[input.providerType]
     if (!preset) {
       throw new Error(`Unknown provider type: ${input.providerType}`)
@@ -1089,6 +1094,7 @@ export function updateProvider(id: string, input: {
     existing.type = preset.apiType
     existing.provider = preset.providerName
     existing.authMethod = preset.authMethod
+    delete existing.extraFields
     if (!input.baseUrl) {
       existing.baseUrl = preset.baseUrl
     }

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -494,6 +494,22 @@ function findOverrideModel(providerType: ProviderType | undefined, modelId: stri
   return overrides?.find(m => m.id === modelId)
 }
 
+function findPiAiCatalogModel(providerType: ProviderType | undefined, modelId: string): Model<Api> | undefined {
+  if (!providerType) return undefined
+  const preset = PROVIDER_TYPE_PRESETS[providerType]
+  if (!preset?.piAiProvider) return undefined
+  try {
+    return (getPiAiModels(preset.piAiProvider as KnownProvider) as Model<Api>[]).find(m => m.id === modelId)
+  } catch {
+    return undefined
+  }
+}
+
+function catalogModelRequiresTemperatureOne(providerType: ProviderType | undefined, modelId: string): boolean {
+  const catalogModel = findPiAiCatalogModel(providerType, modelId)
+  return Boolean(catalogModel?.reasoning && /^kimi-k2(?:[.-]|$)/.test(catalogModel.id))
+}
+
 /**
  * Resolve the effective sampling temperature for a given provider+model.
  *
@@ -506,6 +522,7 @@ function findOverrideModel(providerType: ProviderType | undefined, modelId: stri
  * Resolution order for the constraint:
  *   1. `provider.models[].fixedTemperature` (per-provider user override)
  *   2. `PROVIDER_TYPE_MODEL_OVERRIDES[...].fixedTemperature` (local catalog)
+ *   3. pi-ai catalog metadata for known Kimi K2 reasoning models
  *
  * If no constraint applies, the `requested` value is returned unchanged.
  */
@@ -521,6 +538,9 @@ export function resolveModelTemperature(
   const override = findOverrideModel(provider.providerType, modelId)
   if (override?.fixedTemperature !== undefined) {
     return override.fixedTemperature
+  }
+  if (catalogModelRequiresTemperatureOne(provider.providerType, modelId)) {
+    return 1
   }
   return requested
 }

--- a/packages/core/src/provider-health.ts
+++ b/packages/core/src/provider-health.ts
@@ -234,7 +234,7 @@ export async function performProviderHealthCheck(
     // use pi-ai's completeSimple for proper API-type-aware health check
     const preset = PROVIDER_TYPE_PRESETS[provider.providerType as keyof typeof PROVIDER_TYPE_PRESETS]
     const hasCustomRequestBuilder = provider.type === 'anthropic-messages' || provider.type === 'openai-completions'
-    if (preset?.authMethod === 'oauth' || !hasCustomRequestBuilder) {
+    if (preset?.authMethod === 'oauth' || preset?.resolveModelsFromCatalog || !hasCustomRequestBuilder) {
       return await performPiAiHealthCheck(provider, startedAt, checkedAt, timeoutMs, degradedThresholdMs)
     }
 

--- a/packages/core/src/quota-registry.ts
+++ b/packages/core/src/quota-registry.ts
@@ -2,13 +2,18 @@ import type { ProviderConfig } from './provider-config.js'
 import type { QuotaProviderAdapter } from './provider-quota.js'
 import { anthropicQuotaAdapter } from './anthropic-quota.js'
 import { openaiCodexQuotaAdapter } from './openai-codex-quota.js'
+import { opencodeGoQuotaAdapter } from './opencode-go-quota.js'
 
 /**
  * Registered subscriber-quota adapters. To add a new provider family, implement
  * a `QuotaProviderAdapter` and append it here — the background monitor, HTTP
  * layer, and frontend consume this registry generically.
  */
-const QUOTA_ADAPTERS: QuotaProviderAdapter[] = [anthropicQuotaAdapter, openaiCodexQuotaAdapter]
+const QUOTA_ADAPTERS: QuotaProviderAdapter[] = [
+  anthropicQuotaAdapter,
+  openaiCodexQuotaAdapter,
+  opencodeGoQuotaAdapter,
+]
 
 /** Resolve the quota adapter that handles a provider, or null if none does. */
 export function getQuotaAdapter(provider: ProviderConfig): QuotaProviderAdapter | null {

--- a/packages/web-backend/src/api/modules/providers/mapper.ts
+++ b/packages/web-backend/src/api/modules/providers/mapper.ts
@@ -1,4 +1,4 @@
-import { buildModel, isQuotaProvider, PROVIDER_TYPE_MODEL_OVERRIDES, PROVIDER_TYPE_PRESETS } from '@axiom/core'
+import { buildModel, isQuotaProvider, maskProviderExtraFields, PROVIDER_TYPE_MODEL_OVERRIDES, PROVIDER_TYPE_PRESETS } from '@axiom/core'
 import type {
   ProviderConfig,
   ProviderType,
@@ -102,21 +102,27 @@ export function mapProvidersListResponse(
 }
 
 export function mapCreatedProviderResponse(provider: ProviderConfig, rawApiKey?: string): ProviderMutationResponseContract {
+  const { extraFields, extraFieldsSet } = maskProviderExtraFields(provider.providerType, provider.extraFields)
   return {
     provider: {
       ...provider,
       apiKey: '',
       apiKeyMasked: rawApiKey ? maskApiKey(rawApiKey) : '',
+      extraFields,
+      extraFieldsSet,
     } as ProviderContract,
   }
 }
 
 export function mapUpdatedProviderResponse(provider: ProviderConfig, rawApiKey?: string): ProviderMutationResponseContract {
+  const { extraFields, extraFieldsSet } = maskProviderExtraFields(provider.providerType, provider.extraFields)
   return {
     provider: {
       ...provider,
       apiKey: '',
       apiKeyMasked: rawApiKey ? maskApiKey(rawApiKey) : '(unchanged)',
+      extraFields,
+      extraFieldsSet,
     } as ProviderContract,
   }
 }

--- a/packages/web-backend/src/api/modules/providers/schema.test.ts
+++ b/packages/web-backend/src/api/modules/providers/schema.test.ts
@@ -98,6 +98,22 @@ describe('providers schema', () => {
     if (cleared.ok) expect(cleared.value.transport).toBeNull()
   })
 
+  it('parses provider extra fields on create and update payloads', () => {
+    const create = parseProviderCreatePayload({
+      name: 'OpenCode Go',
+      providerType: 'opencode-go',
+      apiKey: 'oc-key',
+      defaultModel: 'glm-5.1',
+      extraFields: { workspaceId: ' workspace-1 ', authCookie: ' cookie-1 ', ignoredNumber: 123 },
+    }, PROVIDER_TYPE_PRESETS as unknown as typeof PROVIDER_TYPE_PRESETS)
+    expect(create.ok).toBe(true)
+    if (create.ok) expect(create.value.extraFields).toEqual({ workspaceId: 'workspace-1', authCookie: 'cookie-1' })
+
+    const update = parseProviderUpdatePayload({ extraFields: { workspaceId: '', authCookie: ' cookie-2 ' } })
+    expect(update.ok).toBe(true)
+    if (update.ok) expect(update.value.extraFields).toEqual({ workspaceId: '', authCookie: 'cookie-2' })
+  })
+
   it('validates ollama probe payload and url format', () => {
     expect(parseOllamaProbePayload({ providerType: 'ollama' })).toEqual({
       ok: true,

--- a/packages/web-backend/src/api/modules/providers/schema.ts
+++ b/packages/web-backend/src/api/modules/providers/schema.ts
@@ -52,6 +52,15 @@ function normalizeDegradedThresholdMs(value: unknown): number | undefined {
   return Math.max(1, Math.round(value as number))
 }
 
+function normalizeExtraFields(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const out: Record<string, string> = {}
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw === 'string') out[key] = raw.trim()
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
 function normalizeTextVerbosity(value: unknown): 'low' | 'medium' | 'high' | null | undefined {
   if (value === null || value === '') return null
   if (value === 'low' || value === 'medium' || value === 'high') return value
@@ -204,6 +213,7 @@ export function parseProviderCreatePayload(
       degradedThresholdMs: normalizeDegradedThresholdMs(body.degradedThresholdMs),
       textVerbosity: normalizeTextVerbosity(body.textVerbosity),
       transport: normalizeTransport(body.transport),
+      extraFields: normalizeExtraFields(body.extraFields),
     },
   }
 }
@@ -231,6 +241,7 @@ export function parseProviderUpdatePayload(payload: unknown): ParseResult<Provid
       degradedThresholdMs: normalizeDegradedThresholdMs(body.degradedThresholdMs),
       textVerbosity: normalizeTextVerbosity(body.textVerbosity),
       transport: normalizeTransport(body.transport),
+      extraFields: normalizeExtraFields(body.extraFields),
     },
   }
 }

--- a/packages/web-backend/src/api/modules/providers/service.ts
+++ b/packages/web-backend/src/api/modules/providers/service.ts
@@ -350,6 +350,7 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
         degradedThresholdMs: payload.degradedThresholdMs,
         textVerbosity: payload.textVerbosity ?? undefined,
         transport: payload.transport ?? undefined,
+        extraFields: payload.extraFields,
       })
 
       const afterActiveProvider = loadProviders().activeProvider ?? null
@@ -376,6 +377,7 @@ export function createProvidersService(options: ProvidersRouterOptions = {}): Pr
         degradedThresholdMs: payload.degradedThresholdMs,
         textVerbosity: payload.textVerbosity,
         transport: payload.transport,
+        extraFields: payload.extraFields,
       })
 
       if (activeProvider === id) {

--- a/packages/web-frontend/app/components/ProviderFormDialog.vue
+++ b/packages/web-frontend/app/components/ProviderFormDialog.vue
@@ -42,7 +42,7 @@
               <SelectSeparator />
               <SelectGroup>
                 <SelectLabel>{{ $t('providers.groupSubscription') }}</SelectLabel>
-                <SelectItem v-for="(preset, key) in oauthPresets" :key="key" :value="String(key)">
+                <SelectItem v-for="(preset, key) in subscriptionPresets" :key="key" :value="String(key)">
                   {{ presetLabel(String(key), preset) }}
                 </SelectItem>
               </SelectGroup>
@@ -83,6 +83,24 @@
           <p v-if="mode === 'edit'" class="text-xs text-muted-foreground">{{ $t('providers.apiKeyHint') }}</p>
           <p v-if="!selectedPreset?.requiresApiKey && mode !== 'edit'" class="text-xs text-muted-foreground">{{ $t('providers.apiKeyOptionalHint') }}</p>
         </div>
+
+        <!-- Provider-specific extra fields declared by the selected preset -->
+        <template v-if="extraFieldDefs.length > 0">
+          <div v-for="field in extraFieldDefs" :key="field.key" class="flex flex-col gap-1.5">
+            <Label :for="`provider-extra-${field.key}`">
+              {{ extraFieldLabel(field) }}
+              <span v-if="!field.required" class="text-xs font-normal text-muted-foreground">({{ $t('providers.optional') }})</span>
+            </Label>
+            <Input
+              :id="`provider-extra-${field.key}`"
+              v-model="form.extraFields[field.key]"
+              :type="field.secret ? 'password' : 'text'"
+              :placeholder="extraFieldPlaceholder(field)"
+              :disabled="oauthInProgress"
+            />
+            <p v-if="extraFieldHint(field)" class="text-xs text-muted-foreground">{{ extraFieldHint(field) }}</p>
+          </div>
+        </template>
 
         <!-- Models (checkbox list for providers with pi-ai models) -->
         <div v-if="form.providerType && hasKnownModels" class="flex flex-col gap-1.5">
@@ -493,6 +511,7 @@ export interface ProviderFormPayload {
   degradedThresholdMs: number
   textVerbosity: null | 'low' | 'medium' | 'high'
   transport: null | 'sse' | 'websocket' | 'websocket-cached' | 'auto'
+  extraFields: Record<string, string>
 }
 
 const props = defineProps<{
@@ -532,6 +551,7 @@ const form = reactive({
   degradedThresholdMs: 5000,
   textVerbosity: 'default' as 'default' | 'low' | 'medium' | 'high',
   transport: 'default' as 'default' | 'sse' | 'websocket' | 'websocket-cached' | 'auto',
+  extraFields: {} as Record<string, string>,
 })
 
 const availableModels = ref<AvailableModel[]>([])
@@ -615,6 +635,10 @@ const selectedPreset = computed(() => {
   return props.presets[form.providerType] ?? null
 })
 
+type ExtraFieldDef = NonNullable<ProviderTypePreset['extraFields']>[number]
+
+const extraFieldDefs = computed<ExtraFieldDef[]>(() => selectedPreset.value?.extraFields ?? [])
+
 const hasKnownModels = computed(() => {
   // Prefer the backend-computed flag (covers presets with local overrides
   // like kimi/moonshot that don't have a pi-ai provider). Fall back to the
@@ -673,9 +697,36 @@ const openAiCompatibleBaseUrlHint = computed(() => translatedOr(
   'Required. Endpoint root that exposes /v1/chat/completions (e.g. NVIDIA NIM, LM Studio, vLLM).',
 ))
 
-const apiKeyPresets = computed(() => {
+function extraFieldTranslation(field: ExtraFieldDef, part: 'label' | 'placeholder' | 'hint', fallback: string): string {
+  return translatedOr(`providers.providerExtraFields.${form.providerType}.${field.key}.${part}`, fallback)
+}
+
+function extraFieldLabel(field: ExtraFieldDef): string {
+  return extraFieldTranslation(field, 'label', field.label)
+}
+
+function extraFieldHint(field: ExtraFieldDef): string {
+  return extraFieldTranslation(field, 'hint', field.hint ?? '')
+}
+
+function extraFieldPlaceholder(field: ExtraFieldDef): string {
+  if (field.secret && props.mode === 'edit' && props.provider?.extraFieldsSet?.[field.key]) {
+    return translatedOr('providers.extraFieldSecretKeep', 'Leave blank to keep the stored value')
+  }
+  return extraFieldTranslation(field, 'placeholder', field.placeholder ?? '')
+}
+
+function sortPresetsByLabel(entries: [string, ProviderTypePreset][]): Record<string, ProviderTypePreset> {
   return Object.fromEntries(
-    Object.entries(props.presets).filter(([, p]) => p.authMethod !== 'oauth')
+    [...entries].sort(([aKey, a], [bKey, b]) =>
+      presetLabel(aKey, a).localeCompare(presetLabel(bKey, b))
+    )
+  )
+}
+
+const apiKeyPresets = computed(() => {
+  return sortPresetsByLabel(
+    Object.entries(props.presets).filter(([, p]) => p.authMethod !== 'oauth' && !p.subscription)
   )
 })
 
@@ -694,9 +745,13 @@ function presetLabel(key: string, preset: ProviderTypePreset): string {
   return translated && translated !== translationKey ? translated : preset.label
 }
 
-const oauthPresets = computed(() => {
-  return Object.fromEntries(
-    Object.entries(props.presets).filter(([, p]) => p.authMethod === 'oauth')
+// Grouped under "Subscription / OAuth" in the dropdown. Includes OAuth
+// providers plus API-key providers flagged as subscriptions (e.g. OpenCode
+// Go). The flag only affects this visual grouping; `isOAuthProvider` still
+// drives the actual auth flow.
+const subscriptionPresets = computed(() => {
+  return sortPresetsByLabel(
+    Object.entries(props.presets).filter(([, p]) => p.authMethod === 'oauth' || p.subscription)
   )
 })
 
@@ -712,6 +767,7 @@ watch(() => [props.open, props.provider] as const, ([isOpen, entry]) => {
     form.degradedThresholdMs = entry.degradedThresholdMs ?? 5000
     form.textVerbosity = entry.textVerbosity ?? 'default'
     form.transport = entry.transport ?? 'default'
+    form.extraFields = { ...(entry.extraFields ?? {}) }
     customModelInput.value = ''
     customDiscoveredModels.value = []
     customModelsError.value = null
@@ -732,6 +788,7 @@ watch(() => [props.open, props.provider] as const, ([isOpen, entry]) => {
     form.degradedThresholdMs = 5000
     form.textVerbosity = 'default'
     form.transport = 'default'
+    form.extraFields = {}
     customModelInput.value = ''
     availableModels.value = []
     customDiscoveredModels.value = []
@@ -1003,8 +1060,8 @@ function onTypeChange() {
     form.baseUrl = preset.baseUrl
     form.defaultModel = ''
     form.enabledModels = []
+    form.extraFields = {}
     customModelInput.value = ''
-    customDiscoveredModels.value = []
     customModelsError.value = null
   }
   oauthError.value = null
@@ -1014,6 +1071,12 @@ function onTypeChange() {
   } else {
     loadModelsForType(form.providerType)
   }
+}
+
+function normalizeExtraFieldsPayload(): Record<string, string> {
+  return Object.fromEntries(
+    extraFieldDefs.value.map(field => [field.key, form.extraFields[field.key]?.trim() ?? '']),
+  )
 }
 
 function handleSubmit() {
@@ -1031,6 +1094,7 @@ function handleSubmit() {
     textVerbosity: normalizeTextVerbosityPayload(),
     transport: normalizeTransportPayload(),
     enabledModels,
+    extraFields: normalizeExtraFieldsPayload(),
   })
 }
 

--- a/packages/web-frontend/app/composables/useQuotaFormat.ts
+++ b/packages/web-frontend/app/composables/useQuotaFormat.ts
@@ -42,10 +42,20 @@ export function useQuotaFormat() {
     if (Number.isNaN(reset.getTime())) return ''
 
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-    const weekday = reset.toLocaleDateString(undefined, { weekday: 'short', timeZone })
     const time = reset
       .toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit', timeZone })
       .replace(' ', '')
+
+    // The bare weekday is only unambiguous within the next week. For resets
+    // further out (e.g. the 30d window) add the date so "Fr" can't refer to an
+    // arbitrary Friday weeks away.
+    const aWeekMs = 7 * 24 * 60 * 60 * 1000
+    if (reset.getTime() - Date.now() >= aWeekMs) {
+      const date = reset.toLocaleDateString(undefined, { day: '2-digit', month: '2-digit', timeZone })
+      return `${date} ${time}`
+    }
+
+    const weekday = reset.toLocaleDateString(undefined, { weekday: 'short', timeZone })
     return `${weekday} ${time}`
   }
 

--- a/packages/web-frontend/app/features/providers/components/ProvidersWorkspace.vue
+++ b/packages/web-frontend/app/features/providers/components/ProvidersWorkspace.vue
@@ -295,6 +295,7 @@
 </template>
 
 <script setup lang="ts">
+import type { ProviderUpdatePayloadContract } from '@axiom/core/contracts'
 import type { Provider } from '~/features/providers/composables/useProviders'
 import type { ProviderFormPayload } from '~/components/ProviderFormDialog.vue'
 import { useProviders } from '~/features/providers/composables/useProviders'
@@ -503,7 +504,7 @@ function closeForm() {
 
 async function handleSubmit(payload: ProviderFormPayload) {
   if (formMode.value === 'edit' && editingProvider.value) {
-    const input: Record<string, string | number | string[] | null | undefined> = {
+    const input: ProviderUpdatePayloadContract = {
       name: payload.name,
       providerType: payload.providerType,
       baseUrl: payload.baseUrl,
@@ -512,6 +513,7 @@ async function handleSubmit(payload: ProviderFormPayload) {
       degradedThresholdMs: payload.degradedThresholdMs,
       textVerbosity: payload.textVerbosity,
       transport: payload.transport,
+      extraFields: payload.extraFields,
     }
     if (payload.apiKey) {
       input.apiKey = payload.apiKey
@@ -529,6 +531,7 @@ async function handleSubmit(payload: ProviderFormPayload) {
       degradedThresholdMs: payload.degradedThresholdMs,
       textVerbosity: payload.textVerbosity,
       transport: payload.transport,
+      extraFields: payload.extraFields,
     })
     if (result) closeForm()
   }

--- a/packages/web-frontend/app/i18n/locales/de.json
+++ b/packages/web-frontend/app/i18n/locales/de.json
@@ -252,7 +252,21 @@
     "ollamaPullError": "Download fehlgeschlagen",
     "ollamaDeleteConfirm": "Modell {model} löschen?",
     "ollamaDeleteSuccess": "Modell gelöscht",
-    "ollamaNoModelsHint": "Lade die Modellliste von deiner Ollama-Instanz, dann wähle die zu aktivierenden Modelle aus."
+    "ollamaNoModelsHint": "Lade die Modellliste von deiner Ollama-Instanz, dann wähle die zu aktivierenden Modelle aus.",
+    "extraFieldSecretKeep": "Leer lassen, um den gespeicherten Wert beizubehalten",
+    "providerExtraFields": {
+      "opencode-go": {
+        "workspaceId": {
+          "label": "Workspace-ID",
+          "placeholder": "z. B. 0a1b2c3d",
+          "hint": "Aus der Dashboard-URL: opencode.ai/workspace/[id]/go"
+        },
+        "authCookie": {
+          "label": "Dashboard-Auth-Cookie",
+          "hint": "Der authentifizierte Dashboard-Cookie (das Präfix `auth=` ist optional). Wird nur zum Lesen der Go-Nutzungsquota verwendet."
+        }
+      }
+    }
   },
   "logs": {
     "title": "Aktivitätsprotokolle",
@@ -624,7 +638,6 @@
     "ttsProviderDeepgram": "Deepgram Aura",
     "ttsDeepgramModel": "Deepgram-Stimme",
     "ttsDeepgramModelHint": "Deepgram-Aura-Stimmmodell für die Synthese.",
-
     "deepgramApiKey": "Deepgram-API-Schlüssel",
     "deepgramApiKeyPlaceholder": "Deepgram-API-Schlüssel eingeben",
     "deepgramApiKeyHint": "Maskierten Wert stehen lassen, um den bestehenden Schlüssel zu behalten.",

--- a/packages/web-frontend/app/i18n/locales/en.json
+++ b/packages/web-frontend/app/i18n/locales/en.json
@@ -252,7 +252,21 @@
     "ollamaPullError": "Pull failed",
     "ollamaDeleteConfirm": "Delete model {model}?",
     "ollamaDeleteSuccess": "Model deleted",
-    "ollamaNoModelsHint": "Load the model list from your Ollama instance, then select models to enable."
+    "ollamaNoModelsHint": "Load the model list from your Ollama instance, then select models to enable.",
+    "extraFieldSecretKeep": "Leave blank to keep the stored value",
+    "providerExtraFields": {
+      "opencode-go": {
+        "workspaceId": {
+          "label": "Workspace ID",
+          "placeholder": "e.g. 0a1b2c3d",
+          "hint": "From your dashboard URL: opencode.ai/workspace/[id]/go"
+        },
+        "authCookie": {
+          "label": "Dashboard Auth Cookie",
+          "hint": "The authenticated dashboard cookie (the `auth=` prefix is optional). Used only to read your Go usage quota."
+        }
+      }
+    }
   },
   "logs": {
     "title": "Activity Logs",
@@ -624,7 +638,6 @@
     "ttsProviderDeepgram": "Deepgram Aura",
     "ttsDeepgramModel": "Deepgram Voice",
     "ttsDeepgramModelHint": "Deepgram Aura voice model used for synthesis.",
-
     "deepgramApiKey": "Deepgram API Key",
     "deepgramApiKeyPlaceholder": "Enter Deepgram API key",
     "deepgramApiKeyHint": "Leave the masked value to keep the existing key.",


### PR DESCRIPTION
## Problem

Axiom can display subscriber usage quota for Anthropic and OpenAI Codex, but not for **OpenCode Go**, whose subscription plan exposes rolling/weekly/monthly usage limits.

## What changed

Adds an `opencode-go` quota adapter that plugs into the generalized quota system from #85:

- `packages/core/src/opencode-go-quota.ts` — new adapter implementing `QuotaProviderAdapter`.
- `packages/core/src/quota-registry.ts` — registers the adapter.
- `packages/core/src/contracts/providers.ts` — adds `opencode-go` to `ProviderQuotaKindContract`.
- `packages/core/src/index.ts` — re-exports the adapter API.
- `packages/core/src/opencode-go-quota.test.ts` — unit tests for credentials, matching, parsing, successful fetch, HTTP errors, parse failure, and network errors.
- `docs/web-ui/providers.md` — documents the provider, required credentials, windows, and the scraping caveat.

This update also fixes stale provider-specific `extraFields` when a provider is switched away from `opencode-go`, so previously stored dashboard credentials are not returned by masked provider APIs.

## How quota is read

OpenCode Go has **no official usage API** (upstream feature request anomalyco/opencode#16017 is still open). Quota is therefore read by scraping the authenticated workspace dashboard, the same approach used by the reference plugin `slkiser/opencode-quota`.

To enable quota, configure these fields in the OpenCode Go provider dialog:

- **Workspace ID** (`workspaceId`)
- **Dashboard auth cookie** (`authCookie`; the `auth=` prefix is optional)

`authCookie` is encrypted at rest and never returned to the frontend; the UI only receives a presence flag.

The parser handles both the SolidJS hydration payload and the `data-slot` dashboard markup, and normalizes the `rolling` (5h), `weekly` (7d), and `monthly` (30d) windows into the shared `windows` contract. Quota only appears when both provider extra fields are configured; on parse or network failure it degrades to "Quota unavailable" without affecting inference.

**Robustness caveat:** because this parses dashboard HTML rather than a stable API, it can break if the dashboard layout changes. This is isolated in one module and fails safe.

## Testing

Run locally after rebasing onto `main`, all green:

- `npm run test -- packages/core/src/provider-config.test.ts` — 86 tests
- `npm run lint`
- `npm run baseline:unit` — 1111 tests
- `npm run baseline:api` — 189 tests
- `npm run verify:critical-flows` — 29 smoke tests + 35 critical-flow tests
- `npm run build`
