### PR TITLE
fix(tasks): fall back to active provider when task default has no model

### DIFF
--- a/packages/web-backend/src/bootstrap/runtime-composition.test.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.test.ts
@@ -2,10 +2,24 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { createEmailAccount } from '@axiom/core'
-import { createRuntimeComposition, loadRuntimeSettings } from './runtime-composition.js'
+import { createEmailAccount, type ProviderConfig } from '@axiom/core'
+import { createRuntimeComposition, loadRuntimeSettings, resolveTaskDefaultProvider } from './runtime-composition.js'
 
 const silentLogger = { log: () => {}, warn: () => {}, error: () => {} }
+
+function makeProvider(overrides: Partial<ProviderConfig> = {}): ProviderConfig {
+  return {
+    id: 'p-active',
+    name: 'active',
+    type: 'openai-completions',
+    providerType: 'openai',
+    provider: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    apiKey: 'sk-test',
+    enabledModels: ['active-model'],
+    ...overrides,
+  }
+}
 
 let tempDataDir: string
 let previousDataDir: string | undefined
@@ -93,5 +107,63 @@ describe('background task tools rebuild on email account change', () => {
     expect(toolNames).toContain('email_list')
     expect(toolNames).toContain('email_send')
     expect(toolNames).toContain('create_task')
+  })
+})
+
+describe('resolveTaskDefaultProvider', () => {
+  const active = makeProvider({ id: 'p-active', name: 'active', enabledModels: ['active-model'] })
+  const configured = makeProvider({ id: 'p-conf', name: 'configured', enabledModels: ['conf-model'] })
+
+  function deps(over: Partial<Parameters<typeof resolveTaskDefaultProvider>[0]> = {}) {
+    return {
+      taskDefaultProvider: '',
+      resolveProvider: (id: string) => (id === configured.id ? configured : null),
+      getActiveProvider: () => active,
+      getActiveModelId: () => 'active-model',
+      ...over,
+    }
+  }
+
+  it('pins the requested model when the task default specifies provider and model', () => {
+    const result = resolveTaskDefaultProvider(deps({ taskDefaultProvider: 'p-conf:conf-model-2' }))
+    expect(result?.id).toBe('p-conf')
+    expect(result?.enabledModels).toEqual(['conf-model-2'])
+  })
+
+  it('returns the configured provider unchanged when it has enabled models and no model is pinned', () => {
+    const result = resolveTaskDefaultProvider(deps({ taskDefaultProvider: 'p-conf' }))
+    expect(result).toBe(configured)
+  })
+
+  it('falls back to the active provider when the configured provider has no enabled models', () => {
+    const emptyConfigured = makeProvider({ id: 'p-conf', name: 'configured', enabledModels: [] })
+    const result = resolveTaskDefaultProvider(deps({
+      taskDefaultProvider: 'p-conf',
+      resolveProvider: () => emptyConfigured,
+    }))
+    expect(result?.id).toBe('p-active')
+    expect(result?.enabledModels).toEqual(['active-model'])
+  })
+
+  it('falls back to the active provider when the configured provider cannot be resolved', () => {
+    const result = resolveTaskDefaultProvider(deps({ taskDefaultProvider: 'missing' }))
+    expect(result?.id).toBe('p-active')
+    expect(result?.enabledModels).toEqual(['active-model'])
+  })
+
+  it('pins the active model when no task default is configured', () => {
+    const result = resolveTaskDefaultProvider(deps())
+    expect(result?.id).toBe('p-active')
+    expect(result?.enabledModels).toEqual(['active-model'])
+  })
+
+  it('returns the active provider unchanged when no active model is selected', () => {
+    const result = resolveTaskDefaultProvider(deps({ getActiveModelId: () => null }))
+    expect(result).toBe(active)
+  })
+
+  it('returns null when there is no active provider to fall back to', () => {
+    const result = resolveTaskDefaultProvider(deps({ getActiveProvider: () => null }))
+    expect(result).toBeNull()
   })
 })

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -296,6 +296,42 @@ function parseNumericUserId(userId: string): number | null {
   return Number.isSafeInteger(numericUserId) ? numericUserId : null
 }
 
+/**
+ * Resolve the provider (and its model, pinned as the sole `enabledModels`
+ * entry) that background tasks run on when no explicit provider/model is given
+ * at task creation.
+ *
+ * An explicitly configured task provider is only honored when it can actually
+ * run a model. Providers may be created without selecting a model upfront, so a
+ * configured provider with no enabled models would start tasks with an empty
+ * model; in that case we fall back to the active provider/model selection.
+ */
+export function resolveTaskDefaultProvider(deps: {
+  taskDefaultProvider: string
+  resolveProvider: (providerId: string) => ProviderConfig | null
+  getActiveProvider: () => ProviderConfig | null
+  getActiveModelId: () => string | null
+}): ProviderConfig | null {
+  const { taskDefaultProvider, resolveProvider, getActiveProvider, getActiveModelId } = deps
+
+  if (taskDefaultProvider) {
+    const { providerId, modelId } = parseProviderModelId(taskDefaultProvider)
+    if (providerId) {
+      const resolved = resolveProvider(providerId)
+      if (resolved && modelId) return { ...resolved, enabledModels: [modelId] }
+      if (resolved && getProviderDefaultModel(resolved)) return resolved
+    }
+  }
+
+  // "Active provider (default)": follow the live chat selection for both
+  // provider and model so tasks pick the user's active model instead of the
+  // provider's first enabled model.
+  const active = getActiveProvider()
+  if (!active) return null
+  const activeModelId = getActiveModelId()
+  return activeModelId ? { ...active, enabledModels: [activeModelId] } : active
+}
+
 export async function createRuntimeComposition(options: RuntimeCompositionOptions = {}): Promise<RuntimeComposition> {
   const logger = options.logger ?? console
 
@@ -331,30 +367,12 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   }
 
   function getTaskDefaultProvider(): ProviderConfig {
-    const currentTaskSettings = getCurrentTaskSettings()
-    if (currentTaskSettings.defaultProvider) {
-      const { providerId, modelId } = parseProviderModelId(currentTaskSettings.defaultProvider)
-      if (providerId) {
-        let resolved = resolveProvider(providerId)
-        if (resolved && modelId) {
-          resolved = { ...resolved, enabledModels: [modelId] }
-        }
-        if (resolved) return resolved
-      }
-    }
-
-    // "Active provider (default)": follow the live chat selection for BOTH
-    // provider and model. Downstream task creation derives the model via
-    // getProviderDefaultModel() (= enabledModels[0]), so we narrow the cloned
-    // provider to the active model. Without this, tasks would pick the
-    // provider's first enabled model instead of the user's active model — and
-    // if enabledModels is empty they'd run with no model at all and fail.
-    const active = getActiveProvider()!
-    const activeModelId = getActiveModelId()
-    if (activeModelId) {
-      return { ...active, enabledModels: [activeModelId] }
-    }
-    return active
+    return resolveTaskDefaultProvider({
+      taskDefaultProvider: getCurrentTaskSettings().defaultProvider,
+      resolveProvider,
+      getActiveProvider,
+      getActiveModelId,
+    })!
   }
 
   const chatEventBus = new ChatEventBus()


### PR DESCRIPTION
## Problem

`getTaskDefaultProvider()` returned an explicitly configured task default provider even when that provider had **no enabled models**. Since providers can now be created without selecting a model upfront (#87, `8824e19`), such a provider starts background tasks (heartbeat, cronjobs, manual defaults) with an empty model.

The configured-provider branch short-circuited with `if (resolved) return resolved`, so the active-provider fallback below was never reached when the configured provider had no usable model.

## Change

- Only honor an explicitly configured task provider when it can actually run a model (explicit model pin, or a non-empty `enabledModels`). Otherwise fall back to the active provider/model selection — matching the documented behavior ("Defaults to the currently active chat provider").
- Extract the resolution into a pure, dependency-injected helper `resolveTaskDefaultProvider()` so the logic is unit-testable; `getTaskDefaultProvider()` is now a thin wrapper.

No behavior change for the common paths (explicit `provider:model`, configured provider with models, active-provider default).

## Testing

- New unit tests in `runtime-composition.test.ts` cover: explicit provider+model pin, configured provider with models (unchanged), configured provider with **no** enabled models (falls back to active), unresolvable provider, active default, no active model, and no active provider.
- `npm run lint`, `npm run baseline:unit` (1127), `npm run baseline:api` (198), `npm run build` — all green.