### PR TITLE
fix: prevent duplicate heartbeat/cronjob execution in multi-instance setups

### DIFF
--- a/packages/core/src/agent-heartbeat.test.ts
+++ b/packages/core/src/agent-heartbeat.test.ts
@@ -1,8 +1,19 @@
 import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { AgentHeartbeatService, DEFAULT_AGENT_HEARTBEAT_SETTINGS, isHeartbeatContentEffectivelyEmpty } from './agent-heartbeat.js'
 import type { AgentHeartbeatSettings, AgentHeartbeatServiceOptions } from './agent-heartbeat.js'
 import type { ProviderConfig } from './provider-config.js'
+import BetterSqlite3 from 'better-sqlite3'
+import { initDatabase } from './database.js'
+import { TaskStore } from './task-store.js'
+import type { Database } from './database.js'
+
+// Force-load the native better-sqlite3 addon before any test mocks
+// fs.readFileSync — the `bindings` loader reads files on first init and would
+// otherwise pick up the heartbeat-content mock and fail to open a database.
+new BetterSqlite3(':memory:').close()
 
 const mockProvider: ProviderConfig = {
   id: 'test-provider',
@@ -398,6 +409,62 @@ describe('AgentHeartbeatService', () => {
       await vi.advanceTimersByTimeAsync(120 * 60 * 1000)
 
       expect(mocks.mockTaskRuntime.create).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('multi-instance deduplication', () => {
+    let db: Database
+    let taskStore: TaskStore
+    const tmpFiles: string[] = []
+
+    function tmpDbPath(): string {
+      const p = path.join(os.tmpdir(), `axiom-heartbeat-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+      tmpFiles.push(p)
+      return p
+    }
+
+    beforeEach(() => {
+      db = initDatabase(tmpDbPath())
+      taskStore = new TaskStore(db)
+    })
+
+    afterEach(() => {
+      db.close()
+      for (const f of tmpFiles) {
+        try { fs.unlinkSync(f) } catch { /* ignore */ }
+      }
+      tmpFiles.length = 0
+    })
+
+    it('skips when another instance already started a recent heartbeat', async () => {
+      taskStore.create({
+        name: 'Agent Heartbeat',
+        prompt: 'p',
+        triggerType: 'heartbeat',
+        triggerSourceId: 'agent-heartbeat',
+      })
+
+      service = createService({ db })
+
+      const taskId = await service.executeHeartbeat()
+      expect(taskId).toBeNull()
+      expect(mocks.mockTaskRuntime.create).not.toHaveBeenCalled()
+    })
+
+    it('proceeds when the only recent heartbeat already completed', async () => {
+      const done = taskStore.create({
+        name: 'Agent Heartbeat',
+        prompt: 'p',
+        triggerType: 'heartbeat',
+        triggerSourceId: 'agent-heartbeat',
+      })
+      taskStore.update(done.id, { status: 'completed' })
+
+      service = createService({ db })
+
+      const taskId = await service.executeHeartbeat()
+      expect(taskId).toBe('task-123')
+      expect(mocks.mockTaskRuntime.create).toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/agent-heartbeat.ts
+++ b/packages/core/src/agent-heartbeat.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { ensureConfigTemplates, getDefaultTimezone, loadConfig } from './config.js'
+import type { Database } from './database.js'
 import type { Task } from './task-store.js'
+import { hasRecentActiveTask } from './task-store.js'
 import type { ProviderConfig } from './provider-config.js'
 import { getProviderDefaultModel } from './provider-config.js'
 import type { TaskRuntimeTaskBoundary } from './task-runtime.js'
@@ -37,6 +39,12 @@ type HeartbeatTaskRuntime = Pick<TaskRuntimeTaskBoundary, 'create' | 'start'>
 export interface AgentHeartbeatServiceOptions {
   taskRuntime: HeartbeatTaskRuntime
   getDefaultProvider: () => ProviderConfig
+  /**
+   * Database handle used to deduplicate heartbeat task creation across
+   * instances that share one DATA_DIR. Optional so existing callers/tests
+   * that don't exercise the dedup path keep working.
+   */
+  db?: Database
   /** Override for testing — returns the current time */
   now?: () => Date
   /** Override for testing — returns the configured timezone */
@@ -64,6 +72,7 @@ export function isHeartbeatContentEffectivelyEmpty(content: string): boolean {
 export class AgentHeartbeatService {
   private taskRuntime: HeartbeatTaskRuntime
   private getDefaultProvider: () => ProviderConfig
+  private db: Database | null
   private nowFn: () => Date
   private getTimezoneFn: () => string
   private timer: ReturnType<typeof setTimeout> | null = null
@@ -77,6 +86,7 @@ export class AgentHeartbeatService {
 
     this.taskRuntime = options.taskRuntime
     this.getDefaultProvider = options.getDefaultProvider
+    this.db = options.db ?? null
     this.nowFn = options.now ?? (() => new Date())
     this.getTimezoneFn = options.getTimezone ?? (() => this.loadTimezone())
   }
@@ -180,6 +190,14 @@ export class AgentHeartbeatService {
     const provider = this.getDefaultProvider()
     if (!provider) {
       console.warn('[axiom] Agent heartbeat skipped: no provider available')
+      return null
+    }
+
+    // Window is shorter than the interval so a legitimately-spaced next
+    // heartbeat is never suppressed, only a near-simultaneous one from a
+    // second instance sharing the same database.
+    if (this.db && hasRecentActiveTask(this.db, 'heartbeat', 'agent-heartbeat', this.settings.intervalMinutes * 0.8)) {
+      console.log('[axiom] Heartbeat skipped: another instance already started one recently')
       return null
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -240,7 +240,7 @@ export type { AgentRuntimeBoundary, AgentRuntimeOptions, AgentRuntimePiAgentAcce
 export type { AgentRuntimeStateSnapshot } from './agent-runtime-types.js'
 export { ProviderManager } from './provider-manager.js'
 export type { OperatingMode, ProviderManagerEvents } from './provider-manager.js'
-export { TaskStore, initTasksTable, buildTaskFilterClause } from './task-store.js'
+export { TaskStore, initTasksTable, buildTaskFilterClause, hasRecentActiveTask } from './task-store.js'
 export type {
   Task,
   TaskStatus,

--- a/packages/core/src/task-scheduler.test.ts
+++ b/packages/core/src/task-scheduler.test.ts
@@ -165,6 +165,51 @@ describe('TaskScheduler', () => {
     })
   })
 
+  describe('multi-instance deduplication', () => {
+    it('skips firing when another instance already started a task for the same cronjob', async () => {
+      scheduler.start()
+      const scheduledTask = scheduledTaskStore.create({
+        name: 'Shared Job',
+        prompt: 'work',
+        schedule: '0 9 * * *',
+      })
+
+      // Simulate a second instance having just created the cronjob task.
+      taskStore.create({
+        name: 'Shared Job',
+        prompt: 'work',
+        triggerType: 'cronjob',
+        triggerSourceId: scheduledTask.id,
+      })
+
+      const result = await scheduler.triggerNow(scheduledTask.id)
+
+      expect(result).toBeNull()
+      expect(mockTaskRunner.startTask).not.toHaveBeenCalled()
+    })
+
+    it('still fires when the recent task belongs to a different cronjob', async () => {
+      scheduler.start()
+      const scheduledTask = scheduledTaskStore.create({
+        name: 'Job A',
+        prompt: 'work',
+        schedule: '0 9 * * *',
+      })
+
+      taskStore.create({
+        name: 'Job B',
+        prompt: 'work',
+        triggerType: 'cronjob',
+        triggerSourceId: 'other-cronjob-id',
+      })
+
+      const result = await scheduler.triggerNow(scheduledTask.id)
+
+      expect(result).toBeTruthy()
+      expect(mockTaskRunner.startTask).toHaveBeenCalled()
+    })
+  })
+
   describe('injection mode', () => {
     let injectionCallback: ReturnType<typeof vi.fn>
     let injectionScheduler: TaskScheduler

--- a/packages/core/src/task-scheduler.ts
+++ b/packages/core/src/task-scheduler.ts
@@ -2,6 +2,7 @@ import type { Database } from './database.js'
 import { ScheduledTaskStore } from './scheduled-task-store.js'
 import type { ScheduledTask } from './scheduled-task-store.js'
 import type { TaskStore } from './task-store.js'
+import { hasRecentActiveTask } from './task-store.js'
 import type { TaskRunner } from './task-runner.js'
 import type { TaskOverrides } from './task-runner.js'
 import type { ProviderConfig } from './provider-config.js'
@@ -156,6 +157,14 @@ export class TaskScheduler {
 
   /** Minimum cooldown between firings of the same cronjob (in ms) */
   private static readonly FIRE_COOLDOWN_MS = 55_000 // 55 seconds — prevents double-firing within the same cron minute
+
+  /**
+   * Dedup window for cross-instance double-firing. Scoped to a single cron
+   * minute so a duplicate from a second instance sharing the database is
+   * caught, while the next legitimately-scheduled run (≥ 1 minute later) is
+   * never suppressed.
+   */
+  private static readonly CRON_DEDUP_WINDOW_MINUTES = 1
 
   /**
    * Check whether a cronjob was already fired recently (deduplication guard).
@@ -341,6 +350,11 @@ export class TaskScheduler {
    * Fire a scheduled task — create a task via TaskRunner
    */
   private async fireTask(scheduledTask: ScheduledTask): Promise<string | null> {
+    if (hasRecentActiveTask(this.options.db, 'cronjob', scheduledTask.id, TaskScheduler.CRON_DEDUP_WINDOW_MINUTES)) {
+      console.log(`[axiom] Cronjob "${scheduledTask.name}" skipped: another instance already started one recently`)
+      return null
+    }
+
     // Resolve provider — the stored value is either a `providerId:modelId`
     // composite (same format used everywhere else in settings) or, for legacy
     // rows, a plain provider name/id. `parseProviderModelId` handles both:

--- a/packages/core/src/task-store.test.ts
+++ b/packages/core/src/task-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { initDatabase } from './database.js'
-import { buildTaskFilterClause, TaskStore } from './task-store.js'
+import { buildTaskFilterClause, hasRecentActiveTask, TaskStore } from './task-store.js'
 import type { Database } from './database.js'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -346,6 +346,54 @@ describe('TaskStore', () => {
       const heartbeatTasks = store.list({ triggerType: 'heartbeat' })
       expect(heartbeatTasks).toHaveLength(1)
       expect(heartbeatTasks[0].name).toBe('Heartbeat')
+    })
+  })
+
+  describe('hasRecentActiveTask', () => {
+    it('returns false when no matching task exists', () => {
+      expect(hasRecentActiveTask(db, 'heartbeat', 'agent-heartbeat', 48)).toBe(false)
+    })
+
+    it('detects a recent running task for the trigger type', () => {
+      store.create({ name: 'HB', prompt: 'p', triggerType: 'heartbeat', triggerSourceId: 'agent-heartbeat' })
+      expect(hasRecentActiveTask(db, 'heartbeat', 'agent-heartbeat', 48)).toBe(true)
+    })
+
+    it('detects a paused task as active', () => {
+      const t = store.create({ name: 'HB', prompt: 'p', triggerType: 'heartbeat', triggerSourceId: 'agent-heartbeat' })
+      store.update(t.id, { status: 'paused' })
+      expect(hasRecentActiveTask(db, 'heartbeat', 'agent-heartbeat', 48)).toBe(true)
+    })
+
+    it('ignores completed and failed tasks', () => {
+      const done = store.create({ name: 'HB', prompt: 'p', triggerType: 'heartbeat', triggerSourceId: 'agent-heartbeat' })
+      store.update(done.id, { status: 'completed' })
+      const failed = store.create({ name: 'HB', prompt: 'p', triggerType: 'heartbeat', triggerSourceId: 'agent-heartbeat' })
+      store.update(failed.id, { status: 'failed' })
+      expect(hasRecentActiveTask(db, 'heartbeat', 'agent-heartbeat', 48)).toBe(false)
+    })
+
+    it('ignores tasks created outside the window', () => {
+      const t = store.create({ name: 'HB', prompt: 'p', triggerType: 'heartbeat', triggerSourceId: 'agent-heartbeat' })
+      db.prepare("UPDATE tasks SET created_at = datetime('now', '-120 minutes') WHERE id = ?").run(t.id)
+      expect(hasRecentActiveTask(db, 'heartbeat', 'agent-heartbeat', 48)).toBe(false)
+    })
+
+    it('scopes the check to the matching trigger type', () => {
+      store.create({ name: 'Cron', prompt: 'p', triggerType: 'cronjob', triggerSourceId: 'job-1' })
+      expect(hasRecentActiveTask(db, 'heartbeat', 'agent-heartbeat', 48)).toBe(false)
+      expect(hasRecentActiveTask(db, 'cronjob', 'job-1', 1)).toBe(true)
+    })
+
+    it('scopes the check to the matching trigger source id when provided', () => {
+      store.create({ name: 'Cron A', prompt: 'p', triggerType: 'cronjob', triggerSourceId: 'job-a' })
+      expect(hasRecentActiveTask(db, 'cronjob', 'job-a', 1)).toBe(true)
+      expect(hasRecentActiveTask(db, 'cronjob', 'job-b', 1)).toBe(false)
+    })
+
+    it('matches any source id when triggerSourceId is null', () => {
+      store.create({ name: 'Cron', prompt: 'p', triggerType: 'cronjob', triggerSourceId: 'job-x' })
+      expect(hasRecentActiveTask(db, 'cronjob', null, 1)).toBe(true)
     })
   })
 

--- a/packages/core/src/task-store.ts
+++ b/packages/core/src/task-store.ts
@@ -129,6 +129,43 @@ export function buildTaskFilterClause(
   return { sql, params }
 }
 
+/**
+ * Returns true when an active (running or paused) task created within the last
+ * `windowMinutes` already exists for the given trigger type (and optional
+ * source id).
+ *
+ * Defense-in-depth against duplicate scheduler-driven task creation when two
+ * Axiom instances share one SQLite database: each instance runs its own
+ * heartbeat/cron/consolidation timers, so without this guard the same
+ * scheduled work is created twice. The query is bounded by the indexed
+ * `trigger_type` column, so it stays sub-millisecond on production-sized
+ * task tables.
+ */
+export function hasRecentActiveTask(
+  db: Database,
+  triggerType: TaskTriggerType,
+  triggerSourceId: string | null,
+  windowMinutes: number,
+): boolean {
+  const clauses = [
+    'trigger_type = ?',
+    "status IN ('running', 'paused')",
+    "created_at > datetime('now', ?)",
+  ]
+  const params: unknown[] = [triggerType, `-${windowMinutes} minutes`]
+
+  if (triggerSourceId !== null) {
+    clauses.push('trigger_source_id = ?')
+    params.push(triggerSourceId)
+  }
+
+  const row = db.prepare(
+    `SELECT COUNT(*) AS count FROM tasks WHERE ${clauses.join(' AND ')}`,
+  ).get(...params) as { count: number }
+
+  return row.count > 0
+}
+
 // Raw row from SQLite
 interface TaskRow {
   id: string

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -910,6 +910,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
   consolidationScheduler.start()
 
   const agentHeartbeatService = new AgentHeartbeatService({
+    db,
     taskRuntime: taskRuntime.tasks,
     getDefaultProvider: getTaskDefaultProvider,
   })

--- a/packages/web-backend/src/memory-consolidation-scheduler.test.ts
+++ b/packages/web-backend/src/memory-consolidation-scheduler.test.ts
@@ -269,6 +269,33 @@ describe('MemoryConsolidationScheduler', () => {
       expect(result1).toBe(result2)
     })
 
+    it('skips when another instance already started a recent consolidation', async () => {
+      const taskStore = new TaskStore(db)
+      const taskRuntime = createMockTaskRuntime(taskStore)
+      const provider = makeProvider()
+
+      // Simulate a second instance having just started its consolidation task.
+      taskStore.create({
+        name: 'Nightly Memory Consolidation',
+        prompt: 'p',
+        triggerType: 'consolidation',
+        triggerSourceId: 'memory-consolidation',
+      })
+
+      const scheduler = new MemoryConsolidationScheduler({
+        db,
+        taskRuntime,
+        getDefaultProvider: () => provider,
+      })
+
+      const result = await scheduler.runNow()
+
+      expect(result.updated).toBe(false)
+      expect(result.reason).toContain('Another instance already started consolidation recently')
+      expect(taskRuntime.create).not.toHaveBeenCalled()
+      expect(taskRuntime.start).not.toHaveBeenCalled()
+    })
+
     it('records lastRun and lastResult after execution', async () => {
       const taskStore = new TaskStore(db)
       const taskRuntime = createMockTaskRuntime(taskStore)

--- a/packages/web-backend/src/memory-consolidation-scheduler.ts
+++ b/packages/web-backend/src/memory-consolidation-scheduler.ts
@@ -14,6 +14,7 @@ import {
   ensureConfigTemplates,
   loadConfig,
   logToolCall,
+  hasRecentActiveTask,
   readConsolidationFile,
   getMemoryDir,
 } from '@axiom/core'
@@ -27,6 +28,14 @@ export interface ConsolidationSettings {
   /** Provider ID to use. Empty string or 'default' = use active provider */
   providerId: string
 }
+
+/**
+ * Dedup window for cross-instance double-firing. Consolidation runs at most
+ * once per day, so a few minutes comfortably absorbs clock skew between two
+ * instances firing at the same scheduled hour without ever suppressing the
+ * next day's run.
+ */
+const CONSOLIDATION_DEDUP_WINDOW_MINUTES = 5
 
 export const DEFAULT_CONSOLIDATION_SETTINGS: ConsolidationSettings = {
   enabled: false,
@@ -278,6 +287,20 @@ export class MemoryConsolidationScheduler {
   }
 
   private async executeConsolidation(): Promise<ConsolidationResult> {
+    // Checked before allocating a session/task so a duplicate from a second
+    // instance sharing the database skips without leaving an orphan session row.
+    if (hasRecentActiveTask(this.db, 'consolidation', 'memory-consolidation', CONSOLIDATION_DEDUP_WINDOW_MINUTES)) {
+      const result: ConsolidationResult = {
+        updated: false,
+        dailyFilesReviewed: 0,
+        reason: 'Another instance already started consolidation recently',
+      }
+      this.lastRun = new Date().toISOString()
+      this.lastResult = result
+      console.log('[axiom] Memory consolidation skipped: another instance already started one recently')
+      return result
+    }
+
     console.log('[axiom] Starting memory consolidation...')
     const startTime = Date.now()
     // Create the consolidation session up-front so both the task and the


### PR DESCRIPTION
## Problem

When two Axiom instances share the same `DATA_DIR` (i.e. two containers on one volume → one SQLite DB), the Agent Heartbeat, Cronjob scheduler, and Memory Consolidation scheduler each run their own in-process timers. Because nothing coordinates across processes, the same scheduled work is created twice. Observed in production:

- Two "Agent Heartbeat" tasks per hour (~5–6 min apart — two independent `setTimeout` chains).
- Cronjobs firing twice at the same scheduled second (e.g. Reddit Digest 2× at 06:00:00).
- Nightly Memory Consolidation firing twice at 00:00:00.

This is fundamentally a deployment misconfiguration, but Axiom should be resilient to it as defense-in-depth.

## Change

Add a DB-only deduplication guard — no OS file locks, no external coordination.

- New helper `hasRecentActiveTask(db, triggerType, triggerSourceId?, windowMinutes)` in `packages/core/src/task-store.ts`. It runs
  `SELECT COUNT(*) FROM tasks WHERE trigger_type = ? AND status IN ('running','paused') AND created_at > datetime('now', ?)` (plus an optional `trigger_source_id` filter). The query is bounded by the existing `idx_tasks_trigger_type` index, so it stays sub-millisecond. No schema change.
- **Heartbeat** (`agent-heartbeat.ts`): skips creation when an active heartbeat task exists within `intervalMinutes * 0.8` minutes. The sub-interval window guarantees a legitimately-spaced next heartbeat is never suppressed.
- **Cronjobs** (`task-scheduler.ts`): `fireTask` skips when an active task for the same cronjob id exists within a 1-minute window (scoped to one cron minute so the next scheduled run is never suppressed). Complements the existing `lastRunAt` cooldown.
- **Consolidation** (`memory-consolidation-scheduler.ts`): skips at the top of `executeConsolidation` (before allocating a session) when an active consolidation task exists within 5 minutes.

Each skip logs a clear line, e.g. `[axiom] Heartbeat skipped: another instance already started one recently`.

## Testing

- New unit tests for `hasRecentActiveTask` (status/window/trigger-type/source-id scoping) in `task-store.test.ts`.
- New dedup tests for the heartbeat service, task scheduler, and consolidation scheduler (skip-on-duplicate + proceed-when-prior-completed).
- `npx vitest run packages/core/src packages/web-backend/src` → **1247 passed**.
- `eslint` clean on all touched files; `@axiom/core`, `@axiom/telegram`, `@axiom/web-backend` `tsc` builds pass; `fallow:audit` gate passes.