### PR TITLE
feat(core): add multi-persona schema scaffolding and settings toggle

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -51,6 +51,7 @@ The on-disk shape is a **superset** of [`SettingsContract`](https://github.com/)
 | `tasks`                            | object                                                            | see below      | nested                                  | Task & cronjob defaults.                                                                                          |
 | `tts`                              | object                                                            | see below      | nested                                  | Voice output config.                                                                                              |
 | `stt`                              | object                                                            | see below      | nested                                  | Voice input config.                                                                                               |
+| `multiPersona`                     | object                                                            | see below      | nested                                  | Multi-persona / multi-bot support (opt-in, default off).                                                          |
 | `tokenPriceTable`                  | `Record<string, { input: number; output: number }>`               | seed prices    | not validated by API                    | Per-model USD/1M-token costs used by [Token Usage](../web-ui/token-usage). Merged on top of `DEFAULT_PRICE_TABLE`. |
 | `builtinTools`                     | object                                                            | see below      | not validated by API                    | Enable/disable built-in `web_search` and `web_fetch` tools, choose the search provider.                           |
 | `braveSearchApiKey`                | `string`                                                          | `""`           | not validated by API                    | **Legacy** — read at boot, migrated into `builtinTools.webSearch.braveSearchApiKey` if present.                   |
@@ -186,6 +187,14 @@ A flat `tasks.statusUpdateIntervalMinutes` may exist on disk from older installs
 | `stt.rewrite.enabled`        | `boolean`                                                        | `false`          | bool                                |
 | `stt.rewrite.providerId`     | `string` (`provider::model` composite)                           | `""`             | string                              |
 
+### `multiPersona`
+
+Opt-in switch for multi-persona / multi-bot support ([issue #32](https://github.com/meteyou/axiom/issues/32)). Additive and **off by default** — while disabled the application behaves exactly as a single-agent install (all state stays under the implicit `main` agent, and the per-agent `/data/agents/<id>/` layout is bypassed). The supporting `agent_id` columns are created unconditionally by the schema migration, so toggling this flag never triggers a DDL change.
+
+| Key                     | Type      | Default | Validation |
+|-------------------------|-----------|---------|------------|
+| `multiPersona.enabled`  | `boolean` | `false` | bool       |
+
 ### `tokenPriceTable`
 
 ```json
@@ -296,7 +305,7 @@ This is the literal file written by `ensureConfigTemplates()`:
 }
 ```
 
-Note: `tts`, `stt`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel. Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`).
+Note: `tts`, `stt`, `multiPersona`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel (or, for `multiPersona`, edited into `settings.json` directly). Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`).
 
 ---
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -51,7 +51,7 @@ The on-disk shape is a **superset** of [`SettingsContract`](https://github.com/)
 | `tasks`                            | object                                                            | see below      | nested                                  | Task & cronjob defaults.                                                                                          |
 | `tts`                              | object                                                            | see below      | nested                                  | Voice output config.                                                                                              |
 | `stt`                              | object                                                            | see below      | nested                                  | Voice input config.                                                                                               |
-| `multiPersona`                     | object                                                            | see below      | nested                                  | Multi-persona / multi-bot support (opt-in, default off).                                                          |
+| `multiPersona`                     | object                                                            | see below      | not validated by API                    | Multi-persona / multi-bot support (opt-in, default off, scaffolding only).                                        |
 | `tokenPriceTable`                  | `Record<string, { input: number; output: number }>`               | seed prices    | not validated by API                    | Per-model USD/1M-token costs used by [Token Usage](../web-ui/token-usage). Merged on top of `DEFAULT_PRICE_TABLE`. |
 | `builtinTools`                     | object                                                            | see below      | not validated by API                    | Enable/disable built-in `web_search` and `web_fetch` tools, choose the search provider.                           |
 | `braveSearchApiKey`                | `string`                                                          | `""`           | not validated by API                    | **Legacy** — read at boot, migrated into `builtinTools.webSearch.braveSearchApiKey` if present.                   |
@@ -189,11 +189,13 @@ A flat `tasks.statusUpdateIntervalMinutes` may exist on disk from older installs
 
 ### `multiPersona`
 
-Opt-in switch for multi-persona / multi-bot support ([issue #32](https://github.com/meteyou/axiom/issues/32)). Additive and **off by default** — while disabled the application behaves exactly as a single-agent install (all state stays under the implicit `main` agent, and the per-agent `/data/agents/<id>/` layout is bypassed). The supporting `agent_id` columns are created unconditionally by the schema migration, so toggling this flag never triggers a DDL change.
+Opt-in switch for multi-persona / multi-bot support ([issue #32](https://github.com/meteyou/axiom/issues/32)). Additive and **off by default** — while disabled the application behaves exactly as a single-agent install: all state stays under the implicit `main` agent. The supporting `agent_id` columns are created unconditionally by the schema migration, so toggling this flag never triggers a DDL change.
 
-| Key                     | Type      | Default | Validation |
-|-------------------------|-----------|---------|------------|
-| `multiPersona.enabled`  | `boolean` | `false` | bool       |
+Scaffolding only — no runtime code branches on the flag yet. There is no Settings UI panel for this key, `PUT /api/settings` neither validates nor persists it, and it is not part of the `GET /api/settings` response. Set it by hand in `settings.json` (stop the container first).
+
+| Key                     | Type      | Default | Validation           |
+|-------------------------|-----------|---------|----------------------|
+| `multiPersona.enabled`  | `boolean` | `false` | not validated by API |
 
 ### `tokenPriceTable`
 
@@ -305,7 +307,7 @@ This is the literal file written by `ensureConfigTemplates()`:
 }
 ```
 
-Note: `tts`, `stt`, `multiPersona`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel (or, for `multiPersona`, edited into `settings.json` directly). Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`).
+Note: `tts`, `stt`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel. Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`). [`multiPersona`](#multipersona) is absent from the template too, but no Settings panel writes it and `mapSettingsResponse` does not surface it — only the `SettingsContract` default applies.
 
 ---
 

--- a/packages/core/src/contracts/index.ts
+++ b/packages/core/src/contracts/index.ts
@@ -36,6 +36,7 @@ export type {
   UploadsSettingsContract,
   SttRewriteSettingsContract,
   SttSettingsContract,
+  MultiPersonaSettingsContract,
   SettingsContract,
   SettingsUpdateContract,
   SettingsStorageContract,

--- a/packages/core/src/contracts/settings.test.ts
+++ b/packages/core/src/contracts/settings.test.ts
@@ -69,6 +69,22 @@ describe('settings contracts', () => {
     })
   })
 
+  describe('multi-persona toggle', () => {
+    it('defaults multiPersona.enabled to false', () => {
+      expect(DEFAULT_SETTINGS_CONTRACT.multiPersona.enabled).toBe(false)
+    })
+
+    it('defaults to disabled when the section is absent', () => {
+      const normalized = normalizeSettingsContract({ language: 'de' })
+      expect(normalized.multiPersona.enabled).toBe(false)
+    })
+
+    it('preserves an explicit enabled flag', () => {
+      const normalized = normalizeSettingsContract({ multiPersona: { enabled: true } })
+      expect(normalized.multiPersona.enabled).toBe(true)
+    })
+  })
+
   describe('thinking level', () => {
     it('defaults both thinking levels to "off"', () => {
       expect(DEFAULT_SETTINGS_CONTRACT.thinkingLevel).toBe('off')

--- a/packages/core/src/contracts/settings.ts
+++ b/packages/core/src/contracts/settings.ts
@@ -164,6 +164,20 @@ export interface TelegramSettingsContract {
   sendVoiceReply: boolean
 }
 
+/**
+ * Multi-persona / multi-bot support (issue #32).
+ *
+ * When `enabled` is `false` (the default) the application behaves exactly as a
+ * single-agent install: the per-agent `/data/agents/<id>/` layout is bypassed,
+ * all state stays under the implicit `'main'` agent, and no persona-scoped read
+ * paths are taken. This flag is the opt-in switch for the additive multi-persona
+ * feature; toggling it never triggers schema migrations (the `agent_id` columns
+ * exist unconditionally).
+ */
+export interface MultiPersonaSettingsContract {
+  enabled: boolean
+}
+
 export interface SettingsContract {
   sessionTimeoutMinutes: number
   sessionSummaryProviderId: string
@@ -184,6 +198,7 @@ export interface SettingsContract {
   tasks: TasksSettingsContract
   tts: TtsSettingsContract
   stt: SttSettingsContract
+  multiPersona: MultiPersonaSettingsContract
 }
 
 export type SettingsUpdateContract = DeepPartial<SettingsContract>
@@ -203,6 +218,7 @@ export interface SettingsStorageContract {
   tasks?: Partial<TasksSettingsContract>
   tts?: Partial<TtsSettingsContract>
   stt?: Partial<SttSettingsContract>
+  multiPersona?: Partial<MultiPersonaSettingsContract>
 }
 
 export interface TelegramSettingsStorageContract {
@@ -319,6 +335,9 @@ export const DEFAULT_SETTINGS_CONTRACT: SettingsContract = {
       enabled: false,
       providerId: '',
     },
+  },
+  multiPersona: {
+    enabled: false,
   },
 }
 
@@ -483,6 +502,9 @@ export function normalizeSettingsContract(input: DeepPartial<SettingsContract> |
         enabled: source.stt?.rewrite?.enabled ?? DEFAULT_SETTINGS_CONTRACT.stt.rewrite.enabled,
         providerId: source.stt?.rewrite?.providerId ?? DEFAULT_SETTINGS_CONTRACT.stt.rewrite.providerId,
       },
+    },
+    multiPersona: {
+      enabled: source.multiPersona?.enabled ?? DEFAULT_SETTINGS_CONTRACT.multiPersona.enabled,
     },
   }
 }

--- a/packages/core/src/contracts/settings.ts
+++ b/packages/core/src/contracts/settings.ts
@@ -167,12 +167,10 @@ export interface TelegramSettingsContract {
 /**
  * Multi-persona / multi-bot support (issue #32).
  *
- * When `enabled` is `false` (the default) the application behaves exactly as a
- * single-agent install: the per-agent `/data/agents/<id>/` layout is bypassed,
- * all state stays under the implicit `'main'` agent, and no persona-scoped read
- * paths are taken. This flag is the opt-in switch for the additive multi-persona
- * feature; toggling it never triggers schema migrations (the `agent_id` columns
- * exist unconditionally).
+ * Scaffolding: no runtime code branches on this flag yet. While it is `false`
+ * (the default) all state stays under the implicit `'main'` agent. Toggling it
+ * never triggers a schema migration — the `agent_id` columns exist
+ * unconditionally.
  */
 export interface MultiPersonaSettingsContract {
   enabled: boolean

--- a/packages/core/src/database.test.ts
+++ b/packages/core/src/database.test.ts
@@ -226,6 +226,62 @@ describe('database', () => {
     execSpy.mockRestore()
   })
 
+  it('adds agent_id columns for multi-persona scoping on a fresh database', () => {
+    const db = initDatabase(tmpDbPath())
+
+    for (const table of ['sessions', 'memories', 'chat_messages']) {
+      const col = (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string, notnull: number, dflt_value: string | null }[])
+        .find(c => c.name === 'agent_id')
+      expect(col, `${table}.agent_id missing`).toBeDefined()
+      expect(col!.notnull, `${table}.agent_id should be NOT NULL`).toBe(1)
+      expect(col!.dflt_value).toBe("'main'")
+    }
+
+    const taskCol = (db.prepare('PRAGMA table_info(tasks)').all() as { name: string, notnull: number }[])
+      .find(c => c.name === 'agent_id')
+    expect(taskCol, 'tasks.agent_id missing').toBeDefined()
+    expect(taskCol!.notnull, 'tasks.agent_id must stay nullable').toBe(0)
+
+    db.close()
+  })
+
+  it('backfills existing rows to the main agent and defaults new rows to main', () => {
+    const dbPath = tmpDbPath()
+    createLegacyDatabase(dbPath)
+
+    const db = initDatabase(dbPath)
+
+    const migratedSession = db.prepare('SELECT agent_id FROM sessions').get() as { agent_id: string }
+    expect(migratedSession.agent_id).toBe('main')
+    const migratedMessages = db.prepare('SELECT DISTINCT agent_id FROM chat_messages').all() as { agent_id: string }[]
+    expect(migratedMessages).toEqual([{ agent_id: 'main' }])
+
+    db.prepare('INSERT INTO sessions (id, source) VALUES (?, ?)').run('fresh-agent-session', 'web')
+    const fresh = db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get('fresh-agent-session') as { agent_id: string }
+    expect(fresh.agent_id).toBe('main')
+
+    db.close()
+  })
+
+  it('is idempotent across repeated initialization and never re-adds agent_id', () => {
+    const dbPath = tmpDbPath()
+
+    let db = initDatabase(dbPath)
+    db.prepare('INSERT INTO tasks (id, name, prompt, status, trigger_type) VALUES (?, ?, ?, ?, ?)')
+      .run('task-1', 'n', 'p', 'running', 'user')
+    const beforeAgentId = db.prepare('SELECT agent_id FROM tasks WHERE id = ?').get('task-1') as { agent_id: string | null }
+    expect(beforeAgentId.agent_id).toBeNull()
+    db.close()
+
+    db = initDatabase(dbPath)
+    const agentIdColumns = (db.prepare('PRAGMA table_info(tasks)').all() as { name: string }[])
+      .filter(c => c.name === 'agent_id')
+    expect(agentIdColumns).toHaveLength(1)
+    const afterAgentId = db.prepare('SELECT agent_id FROM tasks WHERE id = ?').get('task-1') as { agent_id: string | null }
+    expect(afterAgentId.agent_id).toBeNull()
+    db.close()
+  })
+
   it('backfills session token counters from existing token_usage rows', () => {
     const dbPath = tmpDbPath()
     const legacyDb = new BetterSqlite3(dbPath)

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -586,6 +586,8 @@ export function initDatabase(dbPath?: string): Database {
     CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
   `)
 
+  addMultiPersonaAgentIdColumns(db)
+
   // Migration (PRD #11 Task 2): Legacy prefix-based session IDs -> UUIDs + type backfill
   // + orphan recovery. Idempotent: only acts on rows whose session_id is not already
   // in UUID form. Wrapped in a single transaction for atomicity.
@@ -606,6 +608,35 @@ export function initDatabase(dbPath?: string): Database {
   }
 
   return db
+}
+
+/**
+ * Multi-persona / multi-bot scaffolding (issue #32).
+ *
+ * Adds an `agent_id` column to every table that holds per-agent state. Runs
+ * unconditionally, independent of the `multiPersona.enabled` setting: gating the
+ * DDL behind the runtime flag would require an ALTER TABLE the moment a user
+ * flips the flag on, which is fragile for a live SQLite database. Keeping the
+ * column always present makes flipping the flag a pure code concern and makes a
+ * rollback a code-only revert (the inert column can stay).
+ *
+ * The scoped tables backfill existing rows to 'main' via the column default —
+ * exactly the agent id the single-agent read paths assume. `tasks.agent_id` is
+ * nullable because tasks predate personas and have no implicit owner.
+ */
+function addMultiPersonaAgentIdColumns(db: Database): void {
+  const scopedTables = ['sessions', 'memories', 'chat_messages'] as const
+  for (const table of scopedTables) {
+    const cols = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]
+    if (!cols.find(c => c.name === 'agent_id')) {
+      db.exec(`ALTER TABLE ${table} ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'main'`)
+    }
+  }
+
+  const taskCols = db.prepare('PRAGMA table_info(tasks)').all() as { name: string }[]
+  if (!taskCols.find(c => c.name === 'agent_id')) {
+    db.exec('ALTER TABLE tasks ADD COLUMN agent_id TEXT DEFAULT NULL')
+  }
 }
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i


### PR DESCRIPTION
## Problem

Issue #32 proposes multi-persona / multi-bot support behind a feature flag. This is the first, deliberately narrow PR from the agreed staging plan: **schema + settings toggle only**, with zero behavior change when the flag is off.

The contract for this baseline was pinned with @Kruppes on the six technical points in #32 (his confirmation on 2026-04-21). This PR implements exactly point 6 of that recap — nothing more.

## Change

- **Migration (unconditional):** add an `agent_id` column to the tables that hold per-agent state.
  - `sessions`, `memories`, `chat_messages` → `agent_id TEXT NOT NULL DEFAULT 'main'`
  - `tasks` → `agent_id TEXT DEFAULT NULL` (nullable — tasks predate personas and carry no implicit owner)
  - Existing rows backfill to `'main'` via the column default. The migration is idempotent (guarded by `PRAGMA table_info`) and runs independently of the flag, so toggling the flag never triggers DDL on a live SQLite DB.
- **Settings toggle:** add `multiPersona.enabled` (default `false`) to the settings contract, `DEFAULT_SETTINGS_CONTRACT`, and `normalizeSettingsContract`, plus a barrel export for `MultiPersonaSettingsContract`.
- **Docs:** document the new key in `docs/reference/settings.md`.

**Explicitly out of scope** (future PRs, per the staging plan in #32): persona loader, Telegram bot pool, session/memory scoping read paths, `ask_agent` tool, runtime isolation, personas API + UI. No read path scopes by `agent_id` yet.

## Zero behavior change when disabled

With `multiPersona.enabled = false` (the default), the app behaves exactly as a single-agent install: every existing/new row lives under the implicit `'main'` agent, no persona-scoped read path exists, and the `/data/agents/<id>/` layout is untouched. The added columns are inert — a rollback is a code-only revert.

## Testing

- `packages/core` build (`tsc`) and `eslint` on all changed files: clean.
- New tests in `database.test.ts`: `agent_id` present with correct nullability/defaults on a fresh DB; legacy rows backfill to `'main'` and new rows default to `'main'`; migration is idempotent across repeated init.
- New tests in `settings.test.ts`: default is `false`, absent section normalizes to `false`, explicit `true` is preserved.
- Full `packages/core` suite: 1047 tests pass. Backend settings suite: 10 tests pass.

## Notes for review

This PR is intentionally conservative and additive so it stays easy to adapt if @Kruppes returns with feedback on the reference implementation ([Kruppes/openagent](https://github.com/Kruppes/openagent), branch `feature/multi-persona-phase6-ui`). The reporter confirmed all six contract points in #32 but has been quiet for ~3 months despite pings; this baseline changes nothing observable when the flag is off, so it can land safely and be revised later.

Refs #32