### PR TITLE
fix(core): write-path discipline for multi-persona agent_id (RC1-RC3)

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -51,6 +51,7 @@ The on-disk shape is a **superset** of [`SettingsContract`](https://github.com/)
 | `tasks`                            | object                                                            | see below      | nested                                  | Task & cronjob defaults.                                                                                          |
 | `tts`                              | object                                                            | see below      | nested                                  | Voice output config.                                                                                              |
 | `stt`                              | object                                                            | see below      | nested                                  | Voice input config.                                                                                               |
+| `multiPersona`                     | object                                                            | see below      | nested                                  | Multi-persona / multi-bot support (opt-in, default off).                                                          |
 | `tokenPriceTable`                  | `Record<string, { input: number; output: number }>`               | seed prices    | not validated by API                    | Per-model USD/1M-token costs used by [Token Usage](../web-ui/token-usage). Merged on top of `DEFAULT_PRICE_TABLE`. |
 | `builtinTools`                     | object                                                            | see below      | not validated by API                    | Enable/disable built-in `web_search` and `web_fetch` tools, choose the search provider.                           |
 | `braveSearchApiKey`                | `string`                                                          | `""`           | not validated by API                    | **Legacy** — read at boot, migrated into `builtinTools.webSearch.braveSearchApiKey` if present.                   |
@@ -186,6 +187,14 @@ A flat `tasks.statusUpdateIntervalMinutes` may exist on disk from older installs
 | `stt.rewrite.enabled`        | `boolean`                                                        | `false`          | bool                                |
 | `stt.rewrite.providerId`     | `string` (`provider::model` composite)                           | `""`             | string                              |
 
+### `multiPersona`
+
+Opt-in switch for multi-persona / multi-bot support ([issue #32](https://github.com/meteyou/axiom/issues/32)). Additive and **off by default** — while disabled the application behaves exactly as a single-agent install (all state stays under the implicit `main` agent, and the per-agent `/data/agents/<id>/` layout is bypassed). The supporting `agent_id` columns are created unconditionally by the schema migration, so toggling this flag never triggers a DDL change.
+
+| Key                     | Type      | Default | Validation |
+|-------------------------|-----------|---------|------------|
+| `multiPersona.enabled`  | `boolean` | `false` | bool       |
+
 ### `tokenPriceTable`
 
 ```json
@@ -296,7 +305,7 @@ This is the literal file written by `ensureConfigTemplates()`:
 }
 ```
 
-Note: `tts`, `stt`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel. Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`).
+Note: `tts`, `stt`, `multiPersona`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel (or, for `multiPersona`, edited into `settings.json` directly). Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`).
 
 ---
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -51,7 +51,7 @@ The on-disk shape is a **superset** of [`SettingsContract`](https://github.com/)
 | `tasks`                            | object                                                            | see below      | nested                                  | Task & cronjob defaults.                                                                                          |
 | `tts`                              | object                                                            | see below      | nested                                  | Voice output config.                                                                                              |
 | `stt`                              | object                                                            | see below      | nested                                  | Voice input config.                                                                                               |
-| `multiPersona`                     | object                                                            | see below      | nested                                  | Multi-persona / multi-bot support (opt-in, default off).                                                          |
+| `multiPersona`                     | object                                                            | see below      | not validated by API                    | Multi-persona / multi-bot support (opt-in, default off, scaffolding only).                                        |
 | `tokenPriceTable`                  | `Record<string, { input: number; output: number }>`               | seed prices    | not validated by API                    | Per-model USD/1M-token costs used by [Token Usage](../web-ui/token-usage). Merged on top of `DEFAULT_PRICE_TABLE`. |
 | `builtinTools`                     | object                                                            | see below      | not validated by API                    | Enable/disable built-in `web_search` and `web_fetch` tools, choose the search provider.                           |
 | `braveSearchApiKey`                | `string`                                                          | `""`           | not validated by API                    | **Legacy** — read at boot, migrated into `builtinTools.webSearch.braveSearchApiKey` if present.                   |
@@ -189,11 +189,13 @@ A flat `tasks.statusUpdateIntervalMinutes` may exist on disk from older installs
 
 ### `multiPersona`
 
-Opt-in switch for multi-persona / multi-bot support ([issue #32](https://github.com/meteyou/axiom/issues/32)). Additive and **off by default** — while disabled the application behaves exactly as a single-agent install (all state stays under the implicit `main` agent, and the per-agent `/data/agents/<id>/` layout is bypassed). The supporting `agent_id` columns are created unconditionally by the schema migration, so toggling this flag never triggers a DDL change.
+Opt-in switch for multi-persona / multi-bot support ([issue #32](https://github.com/meteyou/axiom/issues/32)). Additive and **off by default** — while disabled the application behaves exactly as a single-agent install: all state stays under the implicit `main` agent. The supporting `agent_id` columns are created unconditionally by the schema migration, so toggling this flag never triggers a DDL change.
 
-| Key                     | Type      | Default | Validation |
-|-------------------------|-----------|---------|------------|
-| `multiPersona.enabled`  | `boolean` | `false` | bool       |
+Scaffolding only — no runtime code branches on the flag yet. There is no Settings UI panel for this key, `PUT /api/settings` neither validates nor persists it, and it is not part of the `GET /api/settings` response. Set it by hand in `settings.json` (stop the container first).
+
+| Key                     | Type      | Default | Validation           |
+|-------------------------|-----------|---------|----------------------|
+| `multiPersona.enabled`  | `boolean` | `false` | not validated by API |
 
 ### `tokenPriceTable`
 
@@ -305,7 +307,7 @@ This is the literal file written by `ensureConfigTemplates()`:
 }
 ```
 
-Note: `tts`, `stt`, `multiPersona`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel (or, for `multiPersona`, edited into `settings.json` directly). Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`).
+Note: `tts`, `stt`, `healthMonitor`, and `healthMonitorIntervalMinutes` are **not** in the template — they are added the first time the user saves the relevant Settings panel. Until then, the runtime falls back to the defaults documented above (and surfaced by `mapSettingsResponse`). [`multiPersona`](#multipersona) is absent from the template too, but no Settings panel writes it and `mapSettingsResponse` does not surface it — only the `SettingsContract` default applies.
 
 ---
 

--- a/packages/core/src/contracts/index.ts
+++ b/packages/core/src/contracts/index.ts
@@ -36,6 +36,7 @@ export type {
   UploadsSettingsContract,
   SttRewriteSettingsContract,
   SttSettingsContract,
+  MultiPersonaSettingsContract,
   SettingsContract,
   SettingsUpdateContract,
   SettingsStorageContract,

--- a/packages/core/src/contracts/settings.test.ts
+++ b/packages/core/src/contracts/settings.test.ts
@@ -69,6 +69,22 @@ describe('settings contracts', () => {
     })
   })
 
+  describe('multi-persona toggle', () => {
+    it('defaults multiPersona.enabled to false', () => {
+      expect(DEFAULT_SETTINGS_CONTRACT.multiPersona.enabled).toBe(false)
+    })
+
+    it('defaults to disabled when the section is absent', () => {
+      const normalized = normalizeSettingsContract({ language: 'de' })
+      expect(normalized.multiPersona.enabled).toBe(false)
+    })
+
+    it('preserves an explicit enabled flag', () => {
+      const normalized = normalizeSettingsContract({ multiPersona: { enabled: true } })
+      expect(normalized.multiPersona.enabled).toBe(true)
+    })
+  })
+
   describe('thinking level', () => {
     it('defaults both thinking levels to "off"', () => {
       expect(DEFAULT_SETTINGS_CONTRACT.thinkingLevel).toBe('off')

--- a/packages/core/src/contracts/settings.ts
+++ b/packages/core/src/contracts/settings.ts
@@ -164,6 +164,20 @@ export interface TelegramSettingsContract {
   sendVoiceReply: boolean
 }
 
+/**
+ * Multi-persona / multi-bot support (issue #32).
+ *
+ * When `enabled` is `false` (the default) the application behaves exactly as a
+ * single-agent install: the per-agent `/data/agents/<id>/` layout is bypassed,
+ * all state stays under the implicit `'main'` agent, and no persona-scoped read
+ * paths are taken. This flag is the opt-in switch for the additive multi-persona
+ * feature; toggling it never triggers schema migrations (the `agent_id` columns
+ * exist unconditionally).
+ */
+export interface MultiPersonaSettingsContract {
+  enabled: boolean
+}
+
 export interface SettingsContract {
   sessionTimeoutMinutes: number
   sessionSummaryProviderId: string
@@ -184,6 +198,7 @@ export interface SettingsContract {
   tasks: TasksSettingsContract
   tts: TtsSettingsContract
   stt: SttSettingsContract
+  multiPersona: MultiPersonaSettingsContract
 }
 
 export type SettingsUpdateContract = DeepPartial<SettingsContract>
@@ -203,6 +218,7 @@ export interface SettingsStorageContract {
   tasks?: Partial<TasksSettingsContract>
   tts?: Partial<TtsSettingsContract>
   stt?: Partial<SttSettingsContract>
+  multiPersona?: Partial<MultiPersonaSettingsContract>
 }
 
 export interface TelegramSettingsStorageContract {
@@ -319,6 +335,9 @@ export const DEFAULT_SETTINGS_CONTRACT: SettingsContract = {
       enabled: false,
       providerId: '',
     },
+  },
+  multiPersona: {
+    enabled: false,
   },
 }
 
@@ -483,6 +502,9 @@ export function normalizeSettingsContract(input: DeepPartial<SettingsContract> |
         enabled: source.stt?.rewrite?.enabled ?? DEFAULT_SETTINGS_CONTRACT.stt.rewrite.enabled,
         providerId: source.stt?.rewrite?.providerId ?? DEFAULT_SETTINGS_CONTRACT.stt.rewrite.providerId,
       },
+    },
+    multiPersona: {
+      enabled: source.multiPersona?.enabled ?? DEFAULT_SETTINGS_CONTRACT.multiPersona.enabled,
     },
   }
 }

--- a/packages/core/src/contracts/settings.ts
+++ b/packages/core/src/contracts/settings.ts
@@ -167,12 +167,10 @@ export interface TelegramSettingsContract {
 /**
  * Multi-persona / multi-bot support (issue #32).
  *
- * When `enabled` is `false` (the default) the application behaves exactly as a
- * single-agent install: the per-agent `/data/agents/<id>/` layout is bypassed,
- * all state stays under the implicit `'main'` agent, and no persona-scoped read
- * paths are taken. This flag is the opt-in switch for the additive multi-persona
- * feature; toggling it never triggers schema migrations (the `agent_id` columns
- * exist unconditionally).
+ * Scaffolding: no runtime code branches on this flag yet. While it is `false`
+ * (the default) all state stays under the implicit `'main'` agent. Toggling it
+ * never triggers a schema migration — the `agent_id` columns exist
+ * unconditionally.
  */
 export interface MultiPersonaSettingsContract {
   enabled: boolean

--- a/packages/core/src/database.test.ts
+++ b/packages/core/src/database.test.ts
@@ -226,6 +226,62 @@ describe('database', () => {
     execSpy.mockRestore()
   })
 
+  it('adds agent_id columns for multi-persona scoping on a fresh database', () => {
+    const db = initDatabase(tmpDbPath())
+
+    for (const table of ['sessions', 'memories', 'chat_messages']) {
+      const col = (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string, notnull: number, dflt_value: string | null }[])
+        .find(c => c.name === 'agent_id')
+      expect(col, `${table}.agent_id missing`).toBeDefined()
+      expect(col!.notnull, `${table}.agent_id should be NOT NULL`).toBe(1)
+      expect(col!.dflt_value).toBe("'main'")
+    }
+
+    const taskCol = (db.prepare('PRAGMA table_info(tasks)').all() as { name: string, notnull: number }[])
+      .find(c => c.name === 'agent_id')
+    expect(taskCol, 'tasks.agent_id missing').toBeDefined()
+    expect(taskCol!.notnull, 'tasks.agent_id must stay nullable').toBe(0)
+
+    db.close()
+  })
+
+  it('backfills existing rows to the main agent and defaults new rows to main', () => {
+    const dbPath = tmpDbPath()
+    createLegacyDatabase(dbPath)
+
+    const db = initDatabase(dbPath)
+
+    const migratedSession = db.prepare('SELECT agent_id FROM sessions').get() as { agent_id: string }
+    expect(migratedSession.agent_id).toBe('main')
+    const migratedMessages = db.prepare('SELECT DISTINCT agent_id FROM chat_messages').all() as { agent_id: string }[]
+    expect(migratedMessages).toEqual([{ agent_id: 'main' }])
+
+    db.prepare('INSERT INTO sessions (id, source) VALUES (?, ?)').run('fresh-agent-session', 'web')
+    const fresh = db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get('fresh-agent-session') as { agent_id: string }
+    expect(fresh.agent_id).toBe('main')
+
+    db.close()
+  })
+
+  it('is idempotent across repeated initialization and never re-adds agent_id', () => {
+    const dbPath = tmpDbPath()
+
+    let db = initDatabase(dbPath)
+    db.prepare('INSERT INTO tasks (id, name, prompt, status, trigger_type) VALUES (?, ?, ?, ?, ?)')
+      .run('task-1', 'n', 'p', 'running', 'user')
+    const beforeAgentId = db.prepare('SELECT agent_id FROM tasks WHERE id = ?').get('task-1') as { agent_id: string | null }
+    expect(beforeAgentId.agent_id).toBeNull()
+    db.close()
+
+    db = initDatabase(dbPath)
+    const agentIdColumns = (db.prepare('PRAGMA table_info(tasks)').all() as { name: string }[])
+      .filter(c => c.name === 'agent_id')
+    expect(agentIdColumns).toHaveLength(1)
+    const afterAgentId = db.prepare('SELECT agent_id FROM tasks WHERE id = ?').get('task-1') as { agent_id: string | null }
+    expect(afterAgentId.agent_id).toBeNull()
+    db.close()
+  })
+
   it('backfills session token counters from existing token_usage rows', () => {
     const dbPath = tmpDbPath()
     const legacyDb = new BetterSqlite3(dbPath)

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -586,6 +586,8 @@ export function initDatabase(dbPath?: string): Database {
     CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
   `)
 
+  addMultiPersonaAgentIdColumns(db)
+
   // Migration (PRD #11 Task 2): Legacy prefix-based session IDs -> UUIDs + type backfill
   // + orphan recovery. Idempotent: only acts on rows whose session_id is not already
   // in UUID form. Wrapped in a single transaction for atomicity.
@@ -606,6 +608,35 @@ export function initDatabase(dbPath?: string): Database {
   }
 
   return db
+}
+
+/**
+ * Multi-persona / multi-bot scaffolding (issue #32).
+ *
+ * Adds an `agent_id` column to every table that holds per-agent state. Runs
+ * unconditionally, independent of the `multiPersona.enabled` setting: gating the
+ * DDL behind the runtime flag would require an ALTER TABLE the moment a user
+ * flips the flag on, which is fragile for a live SQLite database. Keeping the
+ * column always present makes flipping the flag a pure code concern and makes a
+ * rollback a code-only revert (the inert column can stay).
+ *
+ * The scoped tables backfill existing rows to 'main' via the column default —
+ * exactly the agent id the single-agent read paths assume. `tasks.agent_id` is
+ * nullable because tasks predate personas and have no implicit owner.
+ */
+function addMultiPersonaAgentIdColumns(db: Database): void {
+  const scopedTables = ['sessions', 'memories', 'chat_messages'] as const
+  for (const table of scopedTables) {
+    const cols = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]
+    if (!cols.find(c => c.name === 'agent_id')) {
+      db.exec(`ALTER TABLE ${table} ADD COLUMN agent_id TEXT NOT NULL DEFAULT 'main'`)
+    }
+  }
+
+  const taskCols = db.prepare('PRAGMA table_info(tasks)').all() as { name: string }[]
+  if (!taskCols.find(c => c.name === 'agent_id')) {
+    db.exec('ALTER TABLE tasks ADD COLUMN agent_id TEXT DEFAULT NULL')
+  }
 }
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i

--- a/packages/core/src/fact-extraction.test.ts
+++ b/packages/core/src/fact-extraction.test.ts
@@ -102,6 +102,17 @@ describe('fact-extraction', () => {
     expect(isDuplicateFact(db, 1, 'Project uses PostgreSQL at port 5433')).toBe(false)
   })
 
+  it('isDuplicateFact scopes deduplication within an agent bucket (RC1)', () => {
+    // A fact owned by persona 'bob' must not suppress the same fact for
+    // persona 'main' (or any other agent) — their memories are independent.
+    createMemory(db, 1, 'session-a', 'The project uses PostgreSQL on port 5433', 'extracted_fact', 'bob')
+
+    expect(isDuplicateFact(db, 1, 'Project uses PostgreSQL at port 5433', 'bob')).toBe(true)
+    expect(isDuplicateFact(db, 1, 'Project uses PostgreSQL at port 5433', 'main')).toBe(false)
+    // Default agent id is 'main', so an unscoped call sees only main's bucket.
+    expect(isDuplicateFact(db, 1, 'Project uses PostgreSQL at port 5433')).toBe(false)
+  })
+
   it('extractAndStoreFacts calls the LLM, wraps the transcript, deduplicates, and stores new facts', async () => {
     createMemory(db, 1, 'session-old', 'Deployment is done via Docker Compose with 3 services', 'extracted_fact')
     mockCompleteSimple.mockResolvedValueOnce(makeResponse([
@@ -134,6 +145,71 @@ describe('fact-extraction', () => {
 
     expect(storedFacts).toContain('The project uses PostgreSQL on port 5433')
     expect(storedFacts).toContain('User prefers dark mode in all applications')
+  })
+
+  it('stores extracted facts under the session\'s agent id (RC1)', async () => {
+    mockCompleteSimple.mockResolvedValueOnce(makeResponse(
+      '- Bob prefers concise answers',
+    ))
+
+    const result = await extractAndStoreFacts(
+      db,
+      1,
+      'session-bob',
+      'User: keep it short.\nAssistant: Got it.',
+      makeModel(),
+      'test-key',
+      undefined,
+      'bob',
+    )
+
+    expect(result).toEqual({ extracted: 1, stored: 1, duplicates: 0 })
+
+    const row = db.prepare(
+      "SELECT agent_id FROM memories WHERE content = 'Bob prefers concise answers'",
+    ).get() as { agent_id: string }
+    expect(row.agent_id).toBe('bob')
+  })
+
+  it('lets the same fact coexist across agents but dedupes within one (RC1)', async () => {
+    // main already holds the fact.
+    createMemory(db, 1, 'session-main', 'User prefers dark mode', 'extracted_fact', 'main')
+
+    mockCompleteSimple.mockResolvedValueOnce(makeResponse('- User prefers dark mode'))
+
+    // bob extracts the same fact — it must be stored (different bucket).
+    const bobResult = await extractAndStoreFacts(
+      db, 1, 'session-bob', 'User: dark mode please.\nAssistant: ok', makeModel(), 'test-key', undefined, 'bob',
+    )
+    expect(bobResult).toEqual({ extracted: 1, stored: 1, duplicates: 0 })
+
+    // A second bob extraction of the same fact is a duplicate within bob.
+    mockCompleteSimple.mockResolvedValueOnce(makeResponse('- User prefers dark mode'))
+    const bobAgain = await extractAndStoreFacts(
+      db, 1, 'session-bob2', 'User: still dark mode.\nAssistant: ok', makeModel(), 'test-key', undefined, 'bob',
+    )
+    expect(bobAgain).toEqual({ extracted: 1, stored: 0, duplicates: 1 })
+
+    const counts = db.prepare(
+      "SELECT agent_id, COUNT(*) AS n FROM memories WHERE content = 'User prefers dark mode' GROUP BY agent_id ORDER BY agent_id",
+    ).all() as { agent_id: string; n: number }[]
+    expect(counts).toEqual([
+      { agent_id: 'bob', n: 1 },
+      { agent_id: 'main', n: 1 },
+    ])
+  })
+
+  it('defaults extracted facts to the main agent when no agent id is given (RC1)', async () => {
+    mockCompleteSimple.mockResolvedValueOnce(makeResponse('- User lives in Berlin'))
+
+    await extractAndStoreFacts(
+      db, 1, 'session-default', 'User: I live in Berlin.\nAssistant: noted', makeModel(), 'test-key',
+    )
+
+    const row = db.prepare(
+      "SELECT agent_id FROM memories WHERE content = 'User lives in Berlin'",
+    ).get() as { agent_id: string }
+    expect(row.agent_id).toBe('main')
   })
 
   it('returns zero counts when the LLM says NO_FACTS', async () => {

--- a/packages/core/src/fact-extraction.ts
+++ b/packages/core/src/fact-extraction.ts
@@ -127,8 +127,18 @@ export function parseFactLines(response: string): string[] {
 /**
  * Check whether a fact already exists for the same user.
  * Uses FTS5 candidate search followed by normalized word-overlap matching.
+ *
+ * Duplicate detection is scoped to a single `agentId` bucket: an identical
+ * fact held by one persona must not suppress the same fact for another, since
+ * their memories are otherwise independent. With multi-persona off there is
+ * only the 'main' bucket, so behaviour is unchanged.
  */
-export function isDuplicateFact(db: Database, userId: number | null, newFact: string): boolean {
+export function isDuplicateFact(
+  db: Database,
+  userId: number | null,
+  newFact: string,
+  agentId: string = 'main',
+): boolean {
   const normalizedFact = normalizeWhitespace(newFact)
   if (!normalizedFact) return false
 
@@ -140,14 +150,14 @@ export function isDuplicateFact(db: Database, userId: number | null, newFact: st
   const ftsQuery = buildFtsOrQuery(queryTerms)
   const userClause = userId === null ? 'm.user_id IS NULL' : 'm.user_id = ?'
   const params = userId === null
-    ? [ftsQuery, DUPLICATE_SEARCH_LIMIT]
-    : [ftsQuery, userId, DUPLICATE_SEARCH_LIMIT]
+    ? [ftsQuery, agentId, DUPLICATE_SEARCH_LIMIT]
+    : [ftsQuery, userId, agentId, DUPLICATE_SEARCH_LIMIT]
 
   const candidates = db.prepare(`
     SELECT m.content
     FROM memories_fts
     INNER JOIN memories m ON m.id = memories_fts.rowid
-    WHERE memories_fts MATCH ? AND ${userClause}
+    WHERE memories_fts MATCH ? AND ${userClause} AND m.agent_id = ?
     ORDER BY bm25(memories_fts) ASC, m.timestamp DESC, m.id DESC
     LIMIT ?
   `).all(...params) as CandidateRow[]
@@ -164,8 +174,14 @@ export function isDuplicateFact(db: Database, userId: number | null, newFact: st
 /**
  * Store a single extracted fact in the memories table.
  */
-export function storeFact(db: Database, userId: number | null, sessionId: string, content: string): number {
-  return createMemory(db, userId, sessionId, normalizeWhitespace(content), 'extracted_fact')
+export function storeFact(
+  db: Database,
+  userId: number | null,
+  sessionId: string,
+  content: string,
+  agentId: string = 'main',
+): number {
+  return createMemory(db, userId, sessionId, normalizeWhitespace(content), 'extracted_fact', agentId)
 }
 
 /**
@@ -184,6 +200,11 @@ export async function extractAndStoreFacts(
    * require temperature=1). When omitted, temperature defaults to 0.
    */
   provider?: Pick<ProviderConfig, 'providerType' | 'models'>,
+  /**
+   * The persona whose session produced this transcript. Facts are stored and
+   * deduplicated within this agent's bucket. Defaults to 'main'.
+   */
+  agentId: string = 'main',
 ): Promise<{ extracted: number; stored: number; duplicates: number }> {
   const userMessage = `Analyze the following session transcript and extract atomic facts worth remembering:\n\n<transcript>\n${conversationHistory}\n</transcript>`
 
@@ -211,12 +232,12 @@ export async function extractAndStoreFacts(
   let duplicates = 0
 
   for (const fact of facts) {
-    if (isDuplicateFact(db, userId, fact)) {
+    if (isDuplicateFact(db, userId, fact, agentId)) {
       duplicates += 1
       continue
     }
 
-    storeFact(db, userId, sessionId, fact)
+    storeFact(db, userId, sessionId, fact, agentId)
     stored += 1
   }
 

--- a/packages/core/src/memories-store.test.ts
+++ b/packages/core/src/memories-store.test.ts
@@ -39,6 +39,16 @@ describe('memories-store', () => {
     expect(memory?.timestamp).toMatch(/^\d{4}-\d{2}-\d{2} /)
   })
 
+  it('defaults agent_id to main and honours an explicit agent id', () => {
+    const mainId = createMemory(db, 1, 'session-a', 'Runs on the default agent', 'session')
+    const bobId = createMemory(db, 1, 'session-b', 'Runs on bob', 'session', 'bob')
+
+    const mainRow = db.prepare('SELECT agent_id FROM memories WHERE id = ?').get(mainId) as { agent_id: string }
+    const bobRow = db.prepare('SELECT agent_id FROM memories WHERE id = ?').get(bobId) as { agent_id: string }
+    expect(mainRow.agent_id).toBe('main')
+    expect(bobRow.agent_id).toBe('bob')
+  })
+
   it('searches memories with FTS5 and orders by BM25 relevance', () => {
     createMemory(db, 1, 'session-a', 'postgres quickstart guide', 'session')
     createMemory(db, 1, 'session-b', 'postgres postgres port is 5432', 'session')

--- a/packages/core/src/memories-store.ts
+++ b/packages/core/src/memories-store.ts
@@ -201,10 +201,16 @@ export function createMemory(
   sessionId: string | null,
   content: string,
   source: string = 'session',
+  /**
+   * The persona that owns this memory. Defaults to 'main' — matching the #93
+   * column default — so single-agent installs write exactly what they did
+   * before this column existed.
+   */
+  agentId: string = 'main',
 ): number {
   const result = db.prepare(
-    'INSERT INTO memories (user_id, session_id, content, source) VALUES (?, ?, ?, ?)'
-  ).run(userId, sessionId, content, source)
+    'INSERT INTO memories (user_id, session_id, content, source, agent_id) VALUES (?, ?, ?, ?, ?)'
+  ).run(userId, sessionId, content, source, agentId)
 
   return Number(result.lastInsertRowid)
 }

--- a/packages/core/src/session-manager.test.ts
+++ b/packages/core/src/session-manager.test.ts
@@ -117,6 +117,36 @@ describe('SessionManager', () => {
     })
   })
 
+  describe('agent labelling (RC3)', () => {
+    function agentIdOf(db: Database, sessionId: string): string {
+      return (db.prepare('SELECT agent_id FROM sessions WHERE id = ?').get(sessionId) as { agent_id: string }).agent_id
+    }
+
+    it('createSession persists an explicit agentId', async () => {
+      const manager = new SessionManager({ db, memoryDir })
+      await manager.init()
+      const session = manager.createSession({ type: 'task', source: 'system', agentId: 'bob' })
+
+      expect(agentIdOf(db, session.id)).toBe('bob')
+    })
+
+    it('createSession defaults to main when agentId is omitted', async () => {
+      const manager = new SessionManager({ db, memoryDir })
+      await manager.init()
+      const session = manager.createSession({ type: 'task', source: 'system' })
+
+      expect(agentIdOf(db, session.id)).toBe('main')
+    })
+
+    it('interactive sessions are labelled main', async () => {
+      const manager = new SessionManager({ db, memoryDir })
+      await manager.init()
+      const session = manager.getOrCreateSession('user1', 'web')
+
+      expect(agentIdOf(db, session.id)).toBe('main')
+    })
+  })
+
   describe('message recording', () => {
     it('increments message count', async () => {
       const manager = new SessionManager({ db, memoryDir })

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -24,6 +24,11 @@ export interface CreateSessionOptions {
   source: string
   userId?: string
   parentSessionId?: string
+  /**
+   * The persona that owns this session. Defaults to 'main' when omitted,
+   * matching the #93 column default, so single-agent installs are unchanged.
+   */
+  agentId?: string
 }
 
 export interface SessionInfo {
@@ -445,9 +450,12 @@ export class SessionManager {
 
       // Insert into SQLite (type is hardcoded to 'interactive'; see method
       // docstring for rationale).
+      // Interactive sessions belong to 'main' — written explicitly rather than
+      // left to the column default so the ownership is unambiguous until a
+      // persona-aware caller supplies a different id.
       this.db.prepare(
-        `INSERT INTO sessions (id, user_id, source, type, parent_session_id, started_at, last_activity, session_user, message_count, summary_written)
-         VALUES (?, ?, ?, 'interactive', NULL, datetime(? / 1000, 'unixepoch'), datetime(? / 1000, 'unixepoch'), ?, 0, 0)`
+        `INSERT INTO sessions (id, user_id, source, type, parent_session_id, started_at, last_activity, session_user, message_count, summary_written, agent_id)
+         VALUES (?, ?, ?, 'interactive', NULL, datetime(? / 1000, 'unixepoch'), datetime(? / 1000, 'unixepoch'), ?, 0, 0, 'main')`
       ).run(session.id, null, source, session.startedAt, session.lastActivity, userId)
 
       // Log session start to tool_calls for activity log visibility
@@ -485,8 +493,8 @@ export class SessionManager {
     }
 
     this.db.prepare(
-      `INSERT INTO sessions (id, user_id, source, type, parent_session_id, started_at, last_activity, session_user, message_count, summary_written)
-       VALUES (?, NULL, ?, ?, ?, datetime(? / 1000, 'unixepoch'), datetime(? / 1000, 'unixepoch'), ?, 0, 0)`
+      `INSERT INTO sessions (id, user_id, source, type, parent_session_id, started_at, last_activity, session_user, message_count, summary_written, agent_id)
+       VALUES (?, NULL, ?, ?, ?, datetime(? / 1000, 'unixepoch'), datetime(? / 1000, 'unixepoch'), ?, 0, 0, ?)`
     ).run(
       id,
       options.source,
@@ -495,6 +503,7 @@ export class SessionManager {
       now,
       now,
       options.userId ?? null,
+      options.agentId ?? 'main',
     )
 
     return session

--- a/packages/core/src/task-notification.test.ts
+++ b/packages/core/src/task-notification.test.ts
@@ -39,6 +39,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     startedAt: '2026-03-29 10:00:01',
     completedAt: '2026-03-29 10:15:00',
     sessionId: 'task-task-123',
+    agentId: null,
     ...overrides,
   }
 }
@@ -133,6 +134,49 @@ describe('persistTaskResultMessage', () => {
     expect(metadata.durationMinutes).toBe(15)
     expect(metadata.promptTokens).toBe(5000)
     expect(metadata.completionTokens).toBe(3000)
+  })
+
+  it('labels the row with the task\'s agent_id (RC2)', () => {
+    const db = createTestDb()
+    const task = makeTask({ agentId: 'bob' })
+
+    persistTaskResultMessage(db, 1, task, 15)
+
+    const row = db.prepare(
+      'SELECT agent_id FROM chat_messages WHERE user_id = 1'
+    ).get() as { agent_id: string }
+    expect(row.agent_id).toBe('bob')
+  })
+
+  it('coalesces a null agentId to main (RC2)', () => {
+    const db = createTestDb()
+    const task = makeTask({ agentId: null })
+
+    persistTaskResultMessage(db, 1, task, 15)
+
+    const row = db.prepare(
+      'SELECT agent_id FROM chat_messages WHERE user_id = 1'
+    ).get() as { agent_id: string }
+    expect(row.agent_id).toBe('main')
+  })
+
+  it('keeps chat_messages.agent_id consistent with its session (invariant)', () => {
+    const db = createTestDb()
+    // A task session owned by 'bob' plus a task result written into it must
+    // never leave a row whose agent_id disagrees with its session's.
+    db.prepare(
+      "INSERT INTO sessions (id, user_id, source, type, parent_session_id, started_at, message_count, summary_written, agent_id) VALUES ('task-sess-bob', 1, 'system', 'task', NULL, datetime('now'), 0, 0, 'bob')"
+    ).run()
+    const task = makeTask({ sessionId: 'task-sess-bob', agentId: 'bob' })
+
+    persistTaskResultMessage(db, 1, task, 15)
+
+    const mismatch = db.prepare(
+      `SELECT count(*) AS n FROM chat_messages c
+       JOIN sessions s ON s.id = c.session_id
+       WHERE c.agent_id != s.agent_id`
+    ).get() as { n: number }
+    expect(mismatch.n).toBe(0)
   })
 })
 

--- a/packages/core/src/task-notification.ts
+++ b/packages/core/src/task-notification.ts
@@ -137,8 +137,8 @@ export function persistTaskResultMessage(
   }
 
   db.prepare(
-    'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
-  ).run(resolvedSessionId, userId, 'system', content, metadata)
+    'INSERT INTO chat_messages (session_id, user_id, role, content, metadata, agent_id) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(resolvedSessionId, userId, 'system', content, metadata, task.agentId ?? 'main')
 }
 
 export type TelegramDeliveryMode = 'auto' | 'always'
@@ -239,8 +239,8 @@ export function persistTaskStatusUpdateMessage(
   }
 
   db.prepare(
-    'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
-  ).run(resolvedSessionId, userId, 'system', content, metadata)
+    'INSERT INTO chat_messages (session_id, user_id, role, content, metadata, agent_id) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(resolvedSessionId, userId, 'system', content, metadata, task.agentId ?? 'main')
 }
 
 export interface TaskStatusUpdateEvent {

--- a/packages/core/src/task-runner.ts
+++ b/packages/core/src/task-runner.ts
@@ -397,6 +397,7 @@ export class TaskRunner {
       type: sessionType,
       source: 'system',
       parentSessionId: parentSessionId ?? undefined,
+      agentId: task.agentId ?? 'main',
     })
     const sessionId = session.id
 
@@ -762,9 +763,12 @@ export class TaskRunner {
               model: assistantMsg.model,
             })
             try {
+              // Label the row with the task's owning persona so it matches its
+              // (task) session's agent_id; coalesces to 'main' for legacy tasks.
+              const agentId = this.store.getById(runningTask.taskId)?.agentId ?? 'main'
               this.db.prepare(
-                'INSERT INTO chat_messages (session_id, user_id, role, content, metadata) VALUES (?, ?, ?, ?, ?)'
-              ).run(sessionId, null, 'assistant', content, metadata)
+                'INSERT INTO chat_messages (session_id, user_id, role, content, metadata, agent_id) VALUES (?, ?, ?, ?, ?, ?)'
+              ).run(sessionId, null, 'assistant', content, metadata, agentId)
             } catch {
               // Ignore persistence errors — non-critical
             }
@@ -896,11 +900,13 @@ export class TaskRunner {
       })
 
       // Track token usage from detection — register a child session of the task
-      const taskSessionId = this.store.getById(runningTask.taskId)?.sessionId ?? null
+      const detectionTask = this.store.getById(runningTask.taskId)
+      const taskSessionId = detectionTask?.sessionId ?? null
       const sessionId = this.options.sessionManager.createSession({
         type: 'loop_detection',
         source: 'system',
         parentSessionId: taskSessionId ?? undefined,
+        agentId: detectionTask?.agentId ?? 'main',
       }).id
       detectionAgent.subscribe((event: AgentEvent) => {
         if (event.type === 'message_end') {

--- a/packages/core/src/task-store.test.ts
+++ b/packages/core/src/task-store.test.ts
@@ -80,6 +80,28 @@ describe('TaskStore', () => {
       expect(task.isDefaultModel).toBeNull()
     })
 
+    it('defaults agentId to null (tasks predate personas)', () => {
+      const task = store.create({
+        name: 'Ownerless Task',
+        prompt: 'test',
+        triggerType: 'agent',
+      })
+
+      expect(task.agentId).toBeNull()
+    })
+
+    it('persists an explicit agentId', () => {
+      const task = store.create({
+        name: 'Bob Task',
+        prompt: 'test',
+        triggerType: 'agent',
+        agentId: 'bob',
+      })
+
+      expect(task.agentId).toBe('bob')
+      expect(store.getById(task.id)?.agentId).toBe('bob')
+    })
+
     it('persists isDefaultModel=true for tasks using the default provider', () => {
       const task = store.create({
         name: 'Default Task',

--- a/packages/core/src/task-store.ts
+++ b/packages/core/src/task-store.ts
@@ -33,6 +33,12 @@ export interface Task {
   startedAt: string | null
   completedAt: string | null
   sessionId: string | null
+  /**
+   * The persona that owns this task. Nullable because tasks predate the
+   * multi-persona schema (#93): legacy rows and tasks created without an
+   * explicit owner have no persona, and consumers coalesce to 'main'.
+   */
+  agentId: string | null
 }
 
 export interface CreateTaskInput {
@@ -50,6 +56,7 @@ export interface CreateTaskInput {
   isDefaultModel?: boolean
   maxDurationMinutes?: number
   sessionId?: string
+  agentId?: string
 }
 
 export interface UpdateTaskInput {
@@ -152,6 +159,7 @@ interface TaskRow {
   started_at: string | null
   completed_at: string | null
   session_id: string | null
+  agent_id: string | null
 }
 
 function rowToTask(row: TaskRow): Task {
@@ -180,6 +188,7 @@ function rowToTask(row: TaskRow): Task {
     startedAt: row.started_at,
     completedAt: row.completed_at,
     sessionId: row.session_id,
+    agentId: row.agent_id,
   }
 }
 
@@ -236,8 +245,8 @@ export class TaskStore {
     const now = new Date().toISOString().replace('T', ' ').slice(0, 19)
 
     this.db.prepare(`
-      INSERT INTO tasks (id, name, prompt, status, trigger_type, trigger_source_id, provider, model, is_default_model, max_duration_minutes, session_id, created_at)
-      VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO tasks (id, name, prompt, status, trigger_type, trigger_source_id, provider, model, is_default_model, max_duration_minutes, session_id, agent_id, created_at)
+      VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       input.name,
@@ -249,6 +258,7 @@ export class TaskStore {
       input.isDefaultModel === undefined ? null : (input.isDefaultModel ? 1 : 0),
       input.maxDurationMinutes ?? null,
       input.sessionId ?? null,
+      input.agentId ?? null,
       now,
     )
 

--- a/packages/web-backend/src/fact-extraction-session-end.test.ts
+++ b/packages/web-backend/src/fact-extraction-session-end.test.ts
@@ -7,11 +7,11 @@ import {
   triggerFactExtractionForSessionEnd,
 } from './fact-extraction-session-end.js'
 
-function insertSession(db: Database, input: { id: string; userId: number; messageCount: number }): void {
+function insertSession(db: Database, input: { id: string; userId: number; messageCount: number; agentId?: string }): void {
   db.prepare(
-    `INSERT INTO sessions (id, user_id, source, started_at, ended_at, message_count, summary_written)
-     VALUES (?, ?, 'web', datetime('now', '-5 minutes'), datetime('now'), ?, 1)`
-  ).run(input.id, input.userId, input.messageCount)
+    `INSERT INTO sessions (id, user_id, source, started_at, ended_at, message_count, summary_written, agent_id)
+     VALUES (?, ?, 'web', datetime('now', '-5 minutes'), datetime('now'), ?, 1, ?)`
+  ).run(input.id, input.userId, input.messageCount, input.agentId ?? 'main')
 }
 
 function makeProvider(id: string, name: string): ProviderConfig {
@@ -203,12 +203,54 @@ describe('fact-extraction session-end trigger', () => {
         expect.objectContaining({ id: 'gpt-4o-mini' }),
         'key',
         expect.objectContaining({ providerType: 'openai' }),
+        'main',
       )
       expect(error).toHaveBeenCalled()
     })
 
     expect(log).not.toHaveBeenCalled()
     expect(String(error.mock.calls[0][0])).toContain('[fact-extraction] Failed for session session-2:')
+
+    db.close()
+  })
+
+  it('threads the session\'s owning agent id into extraction (RC1)', async () => {
+    const db = initDatabase(':memory:')
+    db.prepare('INSERT INTO users (id, username, password_hash, role) VALUES (1, ?, ?, ?)').run('alice', 'hash', 'user')
+    insertSession(db, { id: 'session-bob', userId: 1, messageCount: 4, agentId: 'bob' })
+
+    const extractAndStoreFacts = vi.fn().mockResolvedValue({ extracted: 0, stored: 0, duplicates: 0 })
+    const buildConversationHistory = vi.fn(() => 'User: remember that I use dark mode')
+
+    triggerFactExtractionForSessionEnd({
+      db,
+      agentCore: {
+        getSessionManager: () => ({ buildConversationHistory }),
+      },
+      userId: '1',
+      sessionId: 'session-bob',
+      deps: {
+        loadSettings: () => ({ factExtraction: { enabled: true, providerId: '', minSessionMessages: 3 } }),
+        getActiveProvider: () => makeProvider('active', 'Active'),
+        buildModel: vi.fn(() => makeModel('gpt-4o-mini')),
+        getApiKeyForProvider: vi.fn().mockResolvedValue('key'),
+        extractAndStoreFacts,
+        console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(extractAndStoreFacts).toHaveBeenCalledWith(
+        db,
+        1,
+        'session-bob',
+        'User: remember that I use dark mode',
+        expect.objectContaining({ id: 'gpt-4o-mini' }),
+        'key',
+        expect.objectContaining({ providerType: 'openai' }),
+        'bob',
+      )
+    })
 
     db.close()
   })

--- a/packages/web-backend/src/fact-extraction-session-end.ts
+++ b/packages/web-backend/src/fact-extraction-session-end.ts
@@ -26,6 +26,7 @@ interface SessionRow {
   user_id: number | null
   session_user: string | null
   message_count: number
+  agent_id: string | null
 }
 
 interface FactExtractionDeps {
@@ -130,7 +131,7 @@ export function triggerFactExtractionForSessionEnd(options: TriggerFactExtractio
   }
 
   const sessionRow = db.prepare(
-    'SELECT user_id, session_user, message_count FROM sessions WHERE id = ?'
+    'SELECT user_id, session_user, message_count, agent_id FROM sessions WHERE id = ?'
   ).get(sessionId) as SessionRow | undefined
 
   if (!sessionRow || sessionRow.message_count < settings.minSessionMessages) {
@@ -144,6 +145,11 @@ export function triggerFactExtractionForSessionEnd(options: TriggerFactExtractio
     deps.console.warn(`[fact-extraction] Skipping session ${sessionId}: no numeric user ID available`)
     return false
   }
+
+  // Facts inherit the session's owning persona so they land in that agent's
+  // memory bucket. Legacy sessions predate the column default and coalesce to
+  // 'main', matching single-agent behaviour.
+  const agentId = sessionRow.agent_id ?? 'main'
 
   const conversationHistory = agentCore.getSessionManager().buildConversationHistory(sessionId)
 
@@ -167,6 +173,7 @@ export function triggerFactExtractionForSessionEnd(options: TriggerFactExtractio
         executionContext.model,
         executionContext.apiKey,
         executionContext.provider,
+        agentId,
       )
 
       deps.console.log(`[fact-extraction] Session ${sessionId}: ${result.stored} new facts`)


### PR DESCRIPTION
> **Draft, opened per the offer in #32.** This implements **step 4** of the revised PR ordering agreed there (write-path discipline). If @meteyou would rather own this implementation himself, this PR can be closed without ceremony — no hard feelings.

## ⚠️ This PR stacks on #93 — read first

This branch is based on **#93's head** (`feat/issue-32-multi-persona-schema`), **not** on `main`. #93 introduces the `agent_id` columns (`addMultiPersonaAgentIdColumns()` in `packages/core/src/database.ts`); this PR fills the write paths that populate them. **#93 must merge first.** Because the branch stacks on #93 and not on `main`, **the diff below includes #93's commits** — the write-path-discipline changes are the four `fix(core): …` commits on top of #93's two commits. Rebase onto `main` once #93 lands and the diff collapses to just those four.

## What this fixes

#93 added the columns but nothing writes them explicitly, so every agent-scoped row falls through to the SQL default `'main'`. In a single-agent install that is correct; in a multi-persona deployment it silently mislabels rows. This PR makes every agent-owned write pass `agent_id` explicitly.

Threading is done along the entity that already owns the row (task → session → message; session → fact). No ambient state, no reading of the feature flag in the write path — the flag decides *who* creates non-`main` sessions, not *whether* the column is written. Everything defaults to `?? 'main'`, matching the #93 column default.

### RC1 — fact extraction (`fact-extraction.ts`, `memories-store.ts`, `fact-extraction-session-end.ts`)
- **Failure mode:** extracted facts were stored under `'main'` regardless of the persona whose session produced them, and cross-agent dedup meant persona A's fact suppressed persona B's identical fact.
- **Fix:** `agentId` threaded `extractAndStoreFacts → storeFact → createMemory`; every `memories` INSERT passes it (default `'main'`). `isDuplicateFact` now filters `m.agent_id = ?`, so dedup is scoped **within** an agent bucket. The session-end hook `SELECT`s `sessions.agent_id` and passes it down.

### RC2 — task result / status messages (`task-notification.ts`)
- **Failure mode:** `persistTaskResultMessage` / `persistTaskStatusUpdateMessage` wrote `chat_messages` without `agent_id`, mislabelling task notifications `'main'`.
- **Fix:** both INSERTs bind `task.agentId ?? 'main'`.

### RC3 — sessions labelled with their owning agent (`session-manager.ts`, `task-runner.ts`)
- **Failure mode:** task and interactive sessions inserted no `agent_id`, so a persona-owned task's session was labelled `'main'`.
- **Fix:** `CreateSessionOptions.agentId` added and bound in `createSession()`; `getOrCreateSession()` writes `'main'` explicitly. The task runner passes `task.agentId ?? 'main'` for task and loop-detection sessions, and the task-viewer assistant-message write is labelled with the task's agent so it matches its session.

### Prerequisite — `Task.agentId` (`task-store.ts`)
The DB column exists (nullable, via #93) but the domain object had no field. Added `Task.agentId`, `CreateTaskInput.agentId`, `TaskRow.agent_id`, `rowToTask` mapping, and the INSERT binding (`input.agentId ?? null`). Nullable because tasks predate personas. `initTasksTable`'s `CREATE TABLE` is intentionally left unchanged — the column is owned by `addMultiPersonaAgentIdColumns()`, which runs after the tasks table is created on a fresh DB (I checked the call order in `database.ts`), so no divergence and no fresh-DB gap.

## Zero behaviour change when `multiPersona.enabled` is false

Every write resolves to `'main'` via `?? 'main'`, which is exactly what the #93 column default already produced. Single-agent installs are bit-for-bit identical. The only behaviour change is *when the flag is on*: dedup is now per-agent (intended — otherwise one persona suppresses another's facts), covered by a test asserting both.

## Scope

Strictly RC1–RC3 (write paths) + the `Task.agentId` prerequisite. **Not** included and deferred by design: RC4 (read-path scoping of `read_chat_history` / `search_memories` — step 5), RC5 (per-persona memory file roots — step 5), RC6 (telegram pool fallback — independent). Interactive-chat / telegram / migration `chat_messages` writes remain on the `'main'` default and are enumerated in `FOLLOWUPS.md` in the branch; they were already unlabelled at #93's head and belong with RC4/RC6.

## Verification gates

- **Tests** — `npx vitest run` on all touched files: **green**, incl. new regression tests. Full suite: 1331 passed; the only 6 failures are pre-existing `EXDEV: cross-device link not permitted` errors in `memory.test.ts` / `config.test.ts` (a sandbox `/data`→`/tmp` `fs.renameSync` artifact), **confirmed to fail identically on the base commit `ba2ea883` with my changes stashed** — unrelated to this PR.
- **Typecheck** — production `tsc --noEmit` (excluding `*.test.ts`, which the repo compiles only via vitest/esbuild) on `@axiom/core` and `@axiom/web-backend`: **0 errors**.
- **Lint** — `eslint` on all 13 changed files: **clean**.
- **Static invariant** — `grep -rn "INSERT INTO (chat_messages|sessions|memories)" packages/ --include=*.ts | grep -v test | grep -v agent_id`: the agent-owned write paths this PR is responsible for no longer appear. The remaining matches are all pre-existing at #93's head — FTS shadow-table maintenance, one-time migrations, and main-only interactive/telegram writes deferred to RC4/RC6 — documented in `FOLLOWUPS.md`.

### New regression tests
- RC1: a fact from an `agent_id='bob'` session is stored as `'bob'`; same fact text coexists across two agents but dedupes within one; default `'main'`.
- RC2: `persistTaskResultMessage` for `agentId='bob'` writes `agent_id='bob'`; `agentId=null` → `'main'`.
- RC3: `createSession({ agentId: 'bob' })` persists `'bob'`; omitting it yields `'main'`; interactive sessions are `'main'`.
- Cross-table invariant: after a task session + task result message, `SELECT count(*) FROM chat_messages c JOIN sessions s ON s.id=c.session_id WHERE c.agent_id != s.agent_id` is `0`.
- Session-end hook: threads the owning session's `agent_id` into `extractAndStoreFacts`.

Refs #32, #93.
