### PR TITLE
fix(email): rebuild background task tools when email account changes

### DIFF
--- a/packages/web-backend/src/app.ts
+++ b/packages/web-backend/src/app.ts
@@ -171,9 +171,9 @@ export function createApp(options?: AppOptions): express.Express {
       getTaskRuntime: () => options.getTaskRuntime?.()?.schedules ?? null,
       getBackgroundTaskToolNames: options.getBackgroundTaskToolNames,
     }))
-    // Email tools are baked into the agent tool set at AgentCore construction,
-    // so an account change only takes effect after the same rebuild a provider
-    // switch triggers.
+    // Email tools are baked into the tool sets at build time, so an account
+    // change must trigger the same rebuild a provider switch does — this
+    // refreshes both the interactive core and the background-task tool set.
     app.use('/api/email', createEmailRouter({
       db: options.db,
       onAccountsChanged: () => options.onActiveProviderChanged?.(),

--- a/packages/web-backend/src/app.ts
+++ b/packages/web-backend/src/app.ts
@@ -172,8 +172,7 @@ export function createApp(options?: AppOptions): express.Express {
       getBackgroundTaskToolNames: options.getBackgroundTaskToolNames,
     }))
     // Email tools are baked into the tool sets at build time, so an account
-    // change must trigger the same rebuild a provider switch does — this
-    // refreshes both the interactive core and the background-task tool set.
+    // change must trigger the same rebuild a provider switch does.
     app.use('/api/email', createEmailRouter({
       db: options.db,
       onAccountsChanged: () => options.onActiveProviderChanged?.(),

--- a/packages/web-backend/src/bootstrap/runtime-composition.test.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.test.ts
@@ -74,8 +74,6 @@ describe('background task tools rebuild on email account change', () => {
   it('adds email tools to the background task tool set after an account change without a restart', async () => {
     composition = await createRuntimeComposition({ logger: silentLogger })
 
-    // No account yet: createEmailTools() returns [], so the background set has
-    // no email tools.
     expect(composition.getBackgroundTaskToolNames()).not.toContain('email_list')
 
     createEmailAccount({
@@ -89,15 +87,11 @@ describe('background task tools rebuild on email account change', () => {
       canSend: true,
     })
 
-    // Simulate the /api/email hook firing on an account change. The task runner
-    // captured the backgroundTaskTools array reference at boot, so this must
-    // update that same array in place rather than swap it out.
     composition.onActiveProviderChanged()
 
     const toolNames = composition.getBackgroundTaskToolNames()
     expect(toolNames).toContain('email_list')
     expect(toolNames).toContain('email_send')
-    // Task tools must survive the in-place rebuild.
     expect(toolNames).toContain('create_task')
   })
 })

--- a/packages/web-backend/src/bootstrap/runtime-composition.test.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.test.ts
@@ -2,7 +2,10 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { loadRuntimeSettings } from './runtime-composition.js'
+import { createEmailAccount } from '@axiom/core'
+import { createRuntimeComposition, loadRuntimeSettings } from './runtime-composition.js'
+
+const silentLogger = { log: () => {}, warn: () => {}, error: () => {} }
 
 let tempDataDir: string
 let previousDataDir: string | undefined
@@ -43,5 +46,58 @@ describe('runtime composition settings', () => {
 
     writeSettings({ tasks: {} })
     expect(loadRuntimeSettings().taskSettings.defaultProvider).toBe('')
+  })
+})
+
+describe('background task tools rebuild on email account change', () => {
+  let composition: Awaited<ReturnType<typeof createRuntimeComposition>> | null = null
+
+  beforeEach(() => {
+    previousDataDir = process.env.DATA_DIR
+    tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'axiom-runtime-bg-tools-'))
+    process.env.DATA_DIR = tempDataDir
+  })
+
+  afterEach(async () => {
+    if (composition) {
+      await composition.stopBackgroundServices()
+      composition = null
+    }
+    if (previousDataDir === undefined) {
+      delete process.env.DATA_DIR
+    } else {
+      process.env.DATA_DIR = previousDataDir
+    }
+    fs.rmSync(tempDataDir, { recursive: true, force: true })
+  })
+
+  it('adds email tools to the background task tool set after an account change without a restart', async () => {
+    composition = await createRuntimeComposition({ logger: silentLogger })
+
+    // No account yet: createEmailTools() returns [], so the background set has
+    // no email tools.
+    expect(composition.getBackgroundTaskToolNames()).not.toContain('email_list')
+
+    createEmailAccount({
+      name: 'Test',
+      imapHost: 'imap.example.com',
+      imapPort: 993,
+      imapUser: 'user@example.com',
+      smtpHost: 'smtp.example.com',
+      smtpPort: 465,
+      smtpUser: 'user@example.com',
+      canSend: true,
+    })
+
+    // Simulate the /api/email hook firing on an account change. The task runner
+    // captured the backgroundTaskTools array reference at boot, so this must
+    // update that same array in place rather than swap it out.
+    composition.onActiveProviderChanged()
+
+    const toolNames = composition.getBackgroundTaskToolNames()
+    expect(toolNames).toContain('email_list')
+    expect(toolNames).toContain('email_send')
+    // Task tools must survive the in-place rebuild.
+    expect(toolNames).toContain('create_task')
   })
 })

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -665,9 +665,10 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
     })
   }
 
-  // Background task tools are built as a mutable array so that
-  // create_task / list_tasks can be pushed in after taskRuntime is
-  // available (they need taskRuntime.tasks — resolved below).
+  // Background task tools live in a mutable array whose reference is handed to
+  // the task runner below and repopulated in place by rebuildBackgroundTaskTools
+  // (create_task / list_tasks are added once taskRuntime exists; email tools are
+  // refreshed on provider/account changes).
   const backgroundSttEnabled = (() => { try { return loadSttSettings().enabled } catch { return false } })()
   // createBaseAgentTools builds the shared tool set (yolo, web, chat-history,
   // search-memories, agent-skills, transcribe-audio). Both the interactive
@@ -850,21 +851,34 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
     getParentSessionId: () => agentCore?.getCurrentInteractiveSessionId() ?? null,
   }
 
-  // Now that taskRuntime exists, push create_task / list_tasks into the
-  // background-task tool set. The task runner holds a reference to the
-  // backgroundTaskTools array, so all subsequently started tasks
-  // (heartbeat, cronjob, user-spawned) will see these tools.
   // Background tasks never have an active interactive session, so
   // getParentSessionId always returns null here.
   const backgroundTaskToolsOptions = {
     ...taskToolsOptions,
     getParentSessionId: () => null as string | null,
   }
-  backgroundTaskTools.push(
-    createTaskTool(backgroundTaskToolsOptions),
-    createResumeTaskTool(backgroundTaskToolsOptions),
-    listTasksTool({ taskRuntime: taskRuntime.tasks }),
-  )
+
+  // Rebuild the background-task tool set in place. The task runner, heartbeat,
+  // and cronjob paths capture the `backgroundTaskTools` array reference once
+  // and never re-read it, so the rebuild MUST mutate that same array —
+  // reassigning the reference would leave every background path pointing at
+  // the stale set. Called at boot and again on every provider/email-account
+  // change so background tasks pick up email tools without a process restart
+  // (createEmailTools() returns [] until an account exists).
+  function rebuildBackgroundTaskTools(): void {
+    backgroundTaskTools.length = 0
+    backgroundTaskTools.push(
+      ...createBaseAgentTools({
+        db,
+        builtinToolsConfig: () => loadRuntimeSettings().builtinToolsConfig,
+        sttEnabled: backgroundSttEnabled,
+      }),
+      createTaskTool(backgroundTaskToolsOptions),
+      createResumeTaskTool(backgroundTaskToolsOptions),
+      listTasksTool({ taskRuntime: taskRuntime.tasks }),
+    )
+  }
+  rebuildBackgroundTaskTools()
 
   // Wrap the schedule boundary so deleting a cronjob also evicts its
   // cached reminder session id. Without this, a cronjob deleted mid-
@@ -1291,6 +1305,10 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
       })
     },
     onActiveProviderChanged: () => {
+      // Also refresh the background-task tool set: it is built from a separate
+      // static array that initOrUpdateAgentCore does not touch, so without this
+      // an email-account change would only reach the interactive core.
+      rebuildBackgroundTaskTools()
       initOrUpdateAgentCore().catch((err) => {
         logger.error('[axiom] Error initializing agent core after provider change:', err)
       })

--- a/packages/web-backend/src/bootstrap/runtime-composition.ts
+++ b/packages/web-backend/src/bootstrap/runtime-composition.ts
@@ -665,10 +665,8 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
     })
   }
 
-  // Background task tools live in a mutable array whose reference is handed to
-  // the task runner below and repopulated in place by rebuildBackgroundTaskTools
-  // (create_task / list_tasks are added once taskRuntime exists; email tools are
-  // refreshed on provider/account changes).
+  // Background task tools live in a mutable array that is repopulated in place
+  // by rebuildBackgroundTaskTools (see there).
   const backgroundSttEnabled = (() => { try { return loadSttSettings().enabled } catch { return false } })()
   // createBaseAgentTools builds the shared tool set (yolo, web, chat-history,
   // search-memories, agent-skills, transcribe-audio). Both the interactive
@@ -858,13 +856,9 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
     getParentSessionId: () => null as string | null,
   }
 
-  // Rebuild the background-task tool set in place. The task runner, heartbeat,
-  // and cronjob paths capture the `backgroundTaskTools` array reference once
-  // and never re-read it, so the rebuild MUST mutate that same array —
-  // reassigning the reference would leave every background path pointing at
-  // the stale set. Called at boot and again on every provider/email-account
-  // change so background tasks pick up email tools without a process restart
-  // (createEmailTools() returns [] until an account exists).
+  // Task runner, heartbeat and cronjob paths capture the `backgroundTaskTools`
+  // array reference once, so this MUST mutate that array in place — reassigning
+  // it would leave every background path on the stale tool set.
   function rebuildBackgroundTaskTools(): void {
     backgroundTaskTools.length = 0
     backgroundTaskTools.push(
@@ -1305,9 +1299,7 @@ export async function createRuntimeComposition(options: RuntimeCompositionOption
       })
     },
     onActiveProviderChanged: () => {
-      // Also refresh the background-task tool set: it is built from a separate
-      // static array that initOrUpdateAgentCore does not touch, so without this
-      // an email-account change would only reach the interactive core.
+      // initOrUpdateAgentCore only rebuilds the interactive core.
       rebuildBackgroundTaskTools()
       initOrUpdateAgentCore().catch((err) => {
         logger.error('[axiom] Error initializing agent core after provider change:', err)


### PR DESCRIPTION
## Problem

Adding, editing, or deleting an email account only makes the email tools
available to the **interactive** agent. Background tasks (`create_task`,
cronjobs), user-spawned tasks, and the **heartbeat** do not see the email
tools until the whole process is restarted.

## Cause

Email tools are produced by `createEmailTools()`, which returns `[]` while no
account is configured (`packages/core/src/email-tools.ts:976`). So any tool set
that embeds them must be rebuilt when an account is added.

- The interactive path is covered: `/api/email` fires `onAccountsChanged` →
  `onActiveProviderChanged()` (`packages/web-backend/src/app.ts:177-181`), which
  calls `initOrUpdateAgentCore()` (`runtime-composition.ts:1174`) and constructs
  a fresh `AgentCore`, whose base tools are rebuilt via `createBaseAgentTools()`
  inside `agent-runtime.ts`. This was introduced in c6e81a6.
- Background tasks are **not** covered: they use a separate `backgroundTaskTools`
  array built exactly once at boot
  (`runtime-composition.ts:676`, `createBaseAgentTools({...})`, extended with
  `create_task`/`resume_task`/`list_tasks` via `.push` at ~`:863`). The task
  runner holds that array by reference (`runtime-composition.ts:690` →
  `task-runner.ts`), and the heartbeat runs through the same path
  (`agent-heartbeat.ts`). `onActiveProviderChanged` never touched this array, so
  email tools appeared in tasks/heartbeat only after a restart.

The existing c6e81a6 fix therefore only ever covered the interactive core.

## Change

Rebuild `backgroundTaskTools` **in place** on every provider/email-account
change. Because the task runner, heartbeat, and cronjob paths capture the array
reference once and never re-read it, the rebuild must mutate that same array
(`backgroundTaskTools.length = 0` + re-`push`) — swapping the reference would
leave every background path pointing at the stale set.

- Added `rebuildBackgroundTaskTools()` in `runtime-composition.ts`. It clears the
  array and refills it with `createBaseAgentTools({...})` (identical options to
  the original boot-time build) plus the same three task tools that were
  previously `.push`ed. It is called once at boot (replacing the old `.push`) and
  again from `onActiveProviderChanged`.
- Updated the now-inaccurate comment in `app.ts` that claimed only the AgentCore
  construction rebuild mattered.

Scope is intentionally minimal — no restructuring beyond the bugfix. Purely
internal wiring; the email tools themselves are unchanged, so no user-facing
docs need updating (this makes already-documented tools actually reach
background tasks without a restart).

## Testing

New regression test in
`packages/web-backend/src/bootstrap/runtime-composition.test.ts`:
boots the composition with no account (asserts `email_list` absent), creates an
account, fires `onActiveProviderChanged()`, and asserts the background tool set
now contains `email_list` / `email_send` while `create_task` survives the
in-place rebuild. Verified it **fails** on the pre-fix code and passes with the
fix.

Repo checks (all green):
- `npm run lint` → clean
- `npm run baseline:unit` → 63 files, 1272 tests passed
- `npm run baseline:api` → 18 files, 231 tests passed (was 230; +1 new test)
- `npm run verify:critical-flows` → smoke (29 passed, 30 skipped) + 2 files, 35 tests passed